### PR TITLE
cuszi_24 2D (-a 2, -s cr) & Clean compilation warnings

### DIFF
--- a/cmake/cusz.cmake
+++ b/cmake/cusz.cmake
@@ -127,9 +127,25 @@ target_link_libraries(pszcomp_cu PUBLIC pszcompile_settings pszkernel_cu
 add_library(psztestframe_cu src/pipeline/testframe.cc)
 target_link_libraries(psztestframe_cu PUBLIC pszcomp_cu pszmem pszutils_seq)
 
+add_library(lc src/lc/comp-tcms.cu src/lc/decomp-tcms.cu 
+            src/lc/comp-bitr.cu src/lc/decomp-bitr.cu
+            src/lc/comp-rtr.cu src/lc/decomp-rtr.cu)
+target_compile_options(lc
+  PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      -O3
+      -arch=sm_89
+      -arch=sm_80
+      -fmad=false>
+    $<$<COMPILE_LANGUAGE:CXX>:
+      -O3
+      -march=native
+      -mno-fma>)
+target_link_libraries(lc PUBLIC pszcompile_settings CUDA::cudart)
+
 add_library(cusz src/cusz_lib.cc)
 target_link_libraries(cusz PUBLIC pszcomp_cu pszhf_cu pszspv_cu pszstat_seq
-                                  pszutils_seq pszmem)
+                                  pszutils_seq pszmem lc)
 
 
 add_executable(cusz-bin src/cli_psz.cc)
@@ -160,6 +176,7 @@ install(TARGETS pszhfbook_seq EXPORT CUSZTargets LIBRARY DESTINATION ${CMAKE_INS
 install(TARGETS pszhf_cu EXPORT CUSZTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(TARGETS pszcomp_cu EXPORT CUSZTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(TARGETS psztestframe_cu EXPORT CUSZTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS lc EXPORT CUSZTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(TARGETS cusz EXPORT CUSZTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(TARGETS cusz-bin EXPORT CUSZTargets)
 if(PSZ_RESEARCH_HUFFBK_CUDA)

--- a/include/compressor.hh
+++ b/include/compressor.hh
@@ -57,13 +57,25 @@ class Compressor {
   // external codec that has standalone internals
   Codec* codec;
 
-  float time_pred, time_hist, time_sp;
+  float time_pred, time_hist, time_sp, time_tcms, time_bitr, time_rtr;
 
   size_t len;
   int splen;
+  int compressed_len_rre1;
 
   BYTE* comp_hf_out{nullptr};
   size_t comp_hf_outlen{0};
+
+  BYTE* comp_tcms_out{nullptr};
+  size_t comp_tcms_outlen{0};
+
+  BYTE* comp_bitr_out{nullptr};
+  size_t comp_bitr_outlen{0};
+
+  BYTE* comp_rtr_out{nullptr};
+  size_t comp_rtr_outlen{0};
+
+  T* device_anchor{nullptr};
 
   // configs
   float outlier_density{0.2};
@@ -87,14 +99,16 @@ class Compressor {
   Compressor* compress_encode(pszctx*, uninit_stream_t);
   Compressor* compress_merge(pszctx*, void*);
   Compressor* compress_update_header(pszctx*, uninit_stream_t);
+  Compressor* compress_tcms(pszctx*, uninit_stream_t);
   Compressor* compress_wrapup(BYTE** out, szt* outlen);
   Compressor* compress_collect_kerneltime();
 
-  Compressor* decompress(pszheader*, BYTE*, T*, uninit_stream_t);
+  Compressor* decompress(pszheader*, BYTE*, T*, T*, uninit_stream_t);
   Compressor* decompress_scatter(pszheader*, BYTE*, T*, uninit_stream_t);
   Compressor* decompress_decode(pszheader*, BYTE*, uninit_stream_t);
-  Compressor* decompress_predict(pszheader*, BYTE*, T*, T*, uninit_stream_t);
-  Compressor* decompress_collect_kerneltime();
+  Compressor* decompress_tcms(pszheader*, BYTE*, uninit_stream_t);
+  Compressor* decompress_predict(pszheader*, BYTE*, T*, T*, T*, uninit_stream_t);
+  Compressor* decompress_collect_kerneltime(pszheader*);
 
   Compressor* clear_buffer();
   Compressor* dump(std::vector<pszmem_dump>, char const*);

--- a/include/context.h
+++ b/include/context.h
@@ -67,8 +67,9 @@ struct psz_context {
   psz_mode mode{Rel};
   double eb{0.0};
   double rel_eb{0.0};
-  int dict_size{1024}, radius{512};
-  int quant_bytewidth{2}, huff_bytewidth{4};
+  int dict_size{256}, radius{128};
+  int quant_bytewidth{1}, huff_bytewidth{4};
+  bool use_huffman{true};
 
   // spv gather-scatter config, tmp. unused
   float nz_density{0.2};

--- a/include/cusz.h
+++ b/include/cusz.h
@@ -49,7 +49,7 @@ pszerror psz_decompress_init(pszcompressor* comp, pszheader* header);
 
 pszerror psz_decompress(
     pszcompressor* comp, pszout compressed, size_t const comp_len,
-    void* decompressed, pszlen const decomp_len, void* record, void* stream);
+    void* decompressed, void* outlier_tmp, pszlen const decomp_len, void* record, void* stream);
 
 #endif
 

--- a/include/cusz/type.h
+++ b/include/cusz/type.h
@@ -206,14 +206,17 @@ struct INTERPOLATION_PARAMS {
     double beta{4.0};
     
     //
-    bool interpolators[3];
+    //bool interpolators[3];
+
+    bool use_md[6];
+    bool use_natural[6];
     
     //
-    bool reverse[3];
-    uint8_t auto_tuning{2};
+    bool reverse[6];
+    uint8_t auto_tuning{3};
 
     //
-    INTERPOLATION_PARAMS() : interpolators{false, false, false}, reverse{false, false, false} {};
+    INTERPOLATION_PARAMS() : use_md{true, true, false, false, false, false}, use_natural{false, false, false, false, false, false}, reverse{false, false, false, false, false, false} {};
 };
 
 

--- a/include/header.h
+++ b/include/header.h
@@ -26,8 +26,8 @@ extern "C" {
 
 typedef struct alignas(128) psz_header {
   static const int HEADER = 0;
-  static const int ANCHOR = 1;
-  static const int VLE = 2;
+  static const int VLE = 1;
+  static const int ANCHOR = 2;
   static const int SPFMT = 3;
   static const int END = 4;
 
@@ -36,6 +36,7 @@ typedef struct alignas(128) psz_header {
   uint32_t byte_vle : 4;           // 4, 8
   uint32_t nz_density_factor : 8;  // TODO configurate it
   uint32_t codecs_in_use : 2;
+  bool with_huffman{true};
   uint32_t vle_pardeg;
   uint32_t x, y, z, w;
   psz_dtype dtype;
@@ -43,7 +44,7 @@ typedef struct alignas(128) psz_header {
   uint32_t radius : 16;
   int splen;
 
-  uint32_t entry[END + 1];
+  uint32_t entry[END + 2];
 
   psz_predtype pred_type;
 

--- a/include/kernel/spline.hh
+++ b/include/kernel/spline.hh
@@ -24,7 +24,7 @@ int spline_construct(
 
 template <typename T, typename E, typename FP = T>
 int spline_reconstruct(
-    pszmem_cxx<T>* anchor, pszmem_cxx<E>* errctrl, pszmem_cxx<T>* xdata,
+    pszmem_cxx<T>* anchor, pszmem_cxx<E>* errctrl, pszmem_cxx<T>* xdata, T* outlier_tmp,
     double eb, uint32_t radius, INTERPOLATION_PARAMS intp_param, float* time, void* stream);
 
 #endif /* AA9BE6AD_ECA4_4267_A97F_B12C25A2B0C1 */

--- a/include/lc/components/component_template/d_[name_of_component].h
+++ b/include/lc/components/component_template/d_[name_of_component].h
@@ -1,0 +1,25 @@
+static __device__ inline bool d_[name_of_component](int& csize, byte in [CS], byte out [CS], byte temp [CS])  // GPU encoder
+{
+  // transforms the first csize bytes of the 'in' array and writes the result to the 'out' array
+  // the transformation must be lossless
+  // returns false if the encoded data does not fit in the out array
+  // updates csize if the encoded data has a different size than the input data
+
+  // must be thread-block-local code
+  // is allowed to change the contents of all three arrays
+  // must not allocate any __shared__ memory (use the temp array instead, e.g., long long* buf = (long long*)&temp;)
+  // the three arrays are guaranteed to start at an 8-byte aligned address
+}
+
+
+static __device__ inline void d_i[name_of_component](int& csize, byte in [CS], byte out [CS], byte temp [CS])  // GPU decoder
+{
+  // transforms the first csize bytes of the 'in' array and writes the result to the 'out' array
+  // the transformation must be lossless
+  // updates csize if the decoded data has a different size than the input data
+
+  // must be thread-block-local code
+  // is allowed to change the contents of all three arrays
+  // must not allocate any __shared__ memory (use the temp array instead, e.g., int* buf = (int*)&temp;)
+  // the three arrays are guaranteed to start at an 8-byte aligned address
+}

--- a/include/lc/components/component_template/h_[name_of_component].h
+++ b/include/lc/components/component_template/h_[name_of_component].h
@@ -1,0 +1,24 @@
+static inline bool h_[name_of_component](int& csize, byte in [CS], byte out [CS])  // CPU encoder
+{
+  // transforms the first csize bytes of the 'in' array and writes the result to the 'out' array
+  // the transformation must be lossless
+  // returns false if the encoded data does not fit in the out array
+  // updates csize if the encoded data has a different size than the input data
+
+  // must be serial code (e.g., cannot use OpenMP)
+  // is allowed to change the contents of both arrays
+  // the two arrays are guaranteed to start at an 8-byte aligned address
+}
+
+
+static inline void h_i[name_of_component](int& csize, byte in [CS], byte out [CS])  // CPU decoder
+{
+  // transforms the first csize bytes of the 'in' array and writes the result to the 'out' array
+  // the transformation must be lossless
+  // updates csize if the decoded data has a different size than the input data
+
+  // must be serial code (e.g., cannot use OpenMP)
+  // is allowed to change the contents of both arrays
+  // the two arrays are guaranteed to start at an 8-byte aligned address
+}
+

--- a/include/lc/components/d_BIT_1.h
+++ b/include/lc/components/d_BIT_1.h
@@ -1,0 +1,86 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static __device__ inline bool d_BIT_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int extra = csize % (8 * 8 / 8);
+  const int size = csize - extra;
+  const int tid = threadIdx.x;
+
+  for (int pos = tid * 8; pos < size; pos += 8 * TPB) {
+    unsigned long long t, x;
+    x = *((unsigned long long*)&in[pos]);
+    t = (x ^ (x >> 7)) & 0x00AA00AA00AA00AAULL;
+    x = x ^ t ^ (t << 7);
+    t = (x ^ (x >> 14)) & 0x0000CCCC0000CCCCULL;
+    x = x ^ t ^ (t << 14);
+    t = (x ^ (x >> 28)) & 0x00000000F0F0F0F0ULL;
+    x = x ^ t ^ (t << 28);
+    for (int i = 0; i < 8; i++) {
+      out[pos / 8 + i * (size / 8)] = x >> (i * 8);
+    }
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  return true;
+}
+
+
+static __device__ inline void d_iBIT_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int extra = csize % (8 * 8 / 8);
+  const int size = csize - extra;
+  const int tid = threadIdx.x;
+
+  for (int pos = tid * 8; pos < size; pos += 8 * TPB) {
+    unsigned long long t, x = 0;
+    for (int i = 0; i < 8; i++) x |= (unsigned long long)in[pos / 8 + i * (size / 8)] << (i * 8);
+    t = (x ^ (x >> 7)) & 0x00AA00AA00AA00AAULL;
+    x = x ^ t ^ (t << 7);
+    t = (x ^ (x >> 14)) & 0x0000CCCC0000CCCCULL;
+    x = x ^ t ^ (t << 14);
+    t = (x ^ (x >> 28)) & 0x00000000F0F0F0F0ULL;
+    x = x ^ t ^ (t << 28);
+    *((unsigned long long*)&out[pos]) = x;
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+}

--- a/include/lc/components/d_BIT_2.h
+++ b/include/lc/components/d_BIT_2.h
@@ -1,0 +1,124 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#define swp(x, y, s, m) t = ((x) ^ ((y) >> (s))) & (m);  (x) ^= t;  (y) ^= t << (s);
+
+static __device__ inline bool d_BIT_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int extra = csize % (16 * 16 / 8);
+  const int size = (csize - extra) / 2;
+  const int tid = threadIdx.x;
+  unsigned long long* const in_l = (unsigned long long*)in;
+  unsigned short* const out_s = (unsigned short*)out;
+
+  for (int pos = 16 * tid; pos < size; pos += 16 * TPB) {
+    unsigned long long t, *a = &in_l[pos / 4];  // process 4 shorts in 1 long long
+
+    for (int i = 0; i < 2; i++) {
+      swp(a[i], a[i + 2], 8, 0x00FF00FF00FF00FFULL);
+    }
+
+    for (int j = 0; j < 4; j += 2) {
+      swp(a[j], a[j + 1], 4, 0x0F0F0F0F0F0F0F0FULL);
+    }
+
+    for (int j = 0; j < 4; j++) {
+      const unsigned long long m = 0x33333333CCCCCCCCULL;
+      const unsigned long long vnm = a[j] & ~m;
+      a[j] = (a[j] & m) | (vnm >> 34) | (vnm << 34);
+    }
+
+    for (int j = 0; j < 4; j++) {
+      const unsigned long long m = 0x5555AAAA5555AAAAULL;
+      const unsigned long long m1 = 0xFFFF0000FFFF0000ULL;
+      const unsigned long long vnm = a[j] & ~m;
+      const unsigned long long res = (a[j] & m) | ((vnm & m1) >> 17) | ((vnm & ~m1) << 17);
+      out_s[pos / 16 + (j * 4) * (size / 16)] = res;
+      out_s[pos / 16 + (j * 4 + 1) * (size / 16)] = res >> 16;
+      out_s[pos / 16 + (j * 4 + 2) * (size / 16)] = res >> 32;
+      out_s[pos / 16 + (j * 4 + 3) * (size / 16)] = res >> 48;
+    }
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  return true;
+}
+
+
+static __device__ inline void d_iBIT_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int extra = csize % (16 * 16 / 8);
+  const int size = (csize - extra) / 2;
+  const int tid = threadIdx.x;
+  unsigned short* const in_s = (unsigned short*)in;
+  unsigned long long* const out_l = (unsigned long long*)out;
+
+  for (int pos = 16 * tid; pos < size; pos += 16 * TPB) {
+    unsigned long long t, *a = &out_l[pos / 4];  // process 4 shorts in 1 long long
+
+    for (int i = 0; i < 4; i++) {
+      a[i] = in_s[pos / 16 + (i * 4) * (size / 16)] | ((unsigned long long)in_s[pos / 16 + (i * 4 + 1) * (size / 16)] << 16) | ((unsigned long long)in_s[pos / 16 + (i * 4 + 2) * (size / 16)] << 32) | ((unsigned long long)in_s[pos / 16 + (i * 4 + 3) * (size / 16)] << 48);
+    }
+
+    for (int i = 0; i < 2; i++) {
+      swp(a[i], a[i + 2], 8, 0x00FF00FF00FF00FFULL);
+    }
+
+    for (int j = 0; j < 4; j += 2) {
+      swp(a[j], a[j + 1], 4, 0x0F0F0F0F0F0F0F0FULL);
+    }
+
+    for (int j = 0; j < 4; j++) {
+      const unsigned long long m = 0x33333333CCCCCCCCULL;
+      const unsigned long long vnm = a[j] & ~m;
+      a[j] = (a[j] & m) | (vnm >> 34) | (vnm << 34);
+    }
+
+    for (int j = 0; j < 4; j++) {
+      const unsigned long long m = 0x5555AAAA5555AAAAULL;
+      const unsigned long long m1 = 0xFFFF0000FFFF0000ULL;
+      const unsigned long long vnm = a[j] & ~m;
+      a[j] = (a[j] & m) | ((vnm & m1) >> 17) | ((vnm & ~m1) << 17);
+    }
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+}

--- a/include/lc/components/d_BIT_4.h
+++ b/include/lc/components/d_BIT_4.h
@@ -1,0 +1,144 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static __device__ inline bool d_BIT_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int SWS = 32;  // sub-warp size
+  int* const in_w = (int*)in;
+  int* const out_w = (int*)out;
+  const int tid = threadIdx.x;
+  const int sublane = tid % SWS;
+  const int extra = csize % (32 * 32 / 8);
+  const int size = (csize - extra) / 4;
+  assert(WS % SWS == 0);
+
+  // works for warpsize of 64 on AMD because shfl does not include sync
+
+  for (int i = tid; i < size; i += TPB) {
+    unsigned int a = in_w[i];
+
+    unsigned int q = __shfl_xor_sync(~0, a, 16);
+    a = ((sublane & 16) == 0) ? __byte_perm(a, q, (3 << 12) | (2 << 8) | (7 << 4) | 6) : __byte_perm(a, q, (5 << 12) | (4 << 8) | (1 << 4) | 0);
+
+    q = __shfl_xor_sync(~0, a, 8);
+    a = ((sublane & 8) == 0) ? __byte_perm(a, q, (3 << 12) | (7 << 8) | (1 << 4) | 5) : __byte_perm(a, q, (6 << 12) | (2 << 8) | (4 << 4) | 0);
+
+    q = __shfl_xor_sync(~0, a, 4);
+    unsigned int mask = 0x0F0F0F0F;
+    if ((sublane & 4) == 0) {
+      a = (a & ~mask) | ((q >> 4) & mask);
+    } else {
+      a = ((q << 4) & ~mask) | (a & mask);
+    }
+
+    q = __shfl_xor_sync(~0, a, 2);
+    mask = 0x33333333;
+    if ((sublane & 2) == 0) {
+      a = (a & ~mask) | ((q >> 2) & mask);
+    } else {
+      a = ((q << 2) & ~mask) | (a & mask);
+    }
+
+    q = __shfl_xor_sync(~0, a, 1);
+    mask = 0x55555555;
+    if ((sublane & 1) == 0) {
+      a = (a & ~mask) | ((q >> 1) & mask);
+    } else {
+      a = ((q << 1) & ~mask) | (a & mask);
+    }
+
+    out_w[i / 32 + sublane * (size / 32)] = a;
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  return true;
+}
+
+
+static __device__ inline void d_iBIT_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int SWS = 32;  // sub-warp size
+  int* const in_w = (int*)in;
+  int* const out_w = (int*)out;
+  const int tid = threadIdx.x;
+  const int sublane = tid % SWS;
+  const int extra = csize % (32 * 32 / 8);
+  const int size = (csize - extra) / 4;
+  assert(WS % SWS == 0);
+
+  for (int i = tid; i < size; i += TPB) {
+    unsigned int a = in_w[i / 32 + sublane * (size / 32)];
+
+    unsigned int q = __shfl_xor_sync(~0, a, 16);
+    a = ((sublane & 16) == 0) ? __byte_perm(a, q, (3 << 12) | (2 << 8) | (7 << 4) | 6) : __byte_perm(a, q, (5 << 12) | (4 << 8) | (1 << 4) | 0);
+
+    q = __shfl_xor_sync(~0, a, 8);
+    a = ((sublane & 8) == 0) ? __byte_perm(a, q, (3 << 12) | (7 << 8) | (1 << 4) | 5) : __byte_perm(a, q, (6 << 12) | (2 << 8) | (4 << 4) | 0);
+
+    q = __shfl_xor_sync(~0, a, 4);
+    unsigned int mask = 0x0F0F0F0F;
+    if ((sublane & 4) == 0) {
+      a = (a & ~mask) | ((q >> 4) & mask);
+    } else {
+      a = (a & mask) | ((q << 4) & ~mask);
+    }
+
+    q = __shfl_xor_sync(~0, a, 2);
+    mask = 0x33333333;
+    if ((sublane & 2) == 0) {
+      a = (a & ~mask) | ((q >> 2) & mask);
+    } else {
+      a = (a & mask) | ((q << 2) & ~mask);
+    }
+
+    q = __shfl_xor_sync(~0, a, 1);
+    mask = 0x55555555;
+    if ((sublane & 1) == 0) {
+      a = (a & ~mask) | ((q >> 1) & mask);
+    } else {
+      a = (a & mask) | ((q << 1) & ~mask);
+    }
+
+    out_w[i] = a;
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+}

--- a/include/lc/components/d_BIT_8.h
+++ b/include/lc/components/d_BIT_8.h
@@ -1,0 +1,211 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static __device__ inline bool d_BIT_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int SWS = 32;  // sub-warp size
+  long long* const in_l = (long long*)in;
+  long long* const out_l = (long long*)out;
+  const int tid = threadIdx.x;
+  const int subwarp = tid / SWS;
+  const int sublane = tid % SWS;
+  const int extra = csize % (64 * 64 / 8);
+  const int size = (csize - extra) / 8;
+  assert(WS % SWS == 0);
+
+  // works for warpsize of 64 on AMD because shfl does not include sync
+
+  for (int i = subwarp * 64 + sublane; i < size; i += TPB * 2) {
+    unsigned long long a0 = in_l[i];
+    unsigned long long a1 = in_l[i + 32];
+
+    unsigned long long b0 = a1;
+    unsigned long long b1 = a0;
+    unsigned long long mask = 0x00000000FFFFFFFFULL;
+    a0 = (a0 & ~mask) | (b0 >> 32);
+    a1 = (a1 & mask) | (b1 << 32);
+
+    b0 = __shfl_xor_sync(~0, a0, 16);
+    b1 = __shfl_xor_sync(~0, a1, 16);
+    mask = 0x0000FFFF0000FFFFULL;
+    if ((sublane & 16) == 0) {
+      a0 = (a0 & ~mask) | ((b0 >> 16) & mask);
+      a1 = (a1 & ~mask) | ((b1 >> 16) & mask);
+    } else {
+      a0 = (a0 & mask) | ((b0 << 16) & ~mask);
+      a1 = (a1 & mask) | ((b1 << 16) & ~mask);
+    }
+
+    b0 = __shfl_xor_sync(~0, a0, 8);
+    b1 = __shfl_xor_sync(~0, a1, 8);
+    mask = 0x00FF00FF00FF00FFULL;
+    if ((sublane & 8) == 0) {
+      a0 = (a0 & ~mask) | ((b0 >> 8) & mask);
+      a1 = (a1 & ~mask) | ((b1 >> 8) & mask);
+    } else {
+      a0 = (a0 & mask) | ((b0 << 8) & ~mask);
+      a1 = (a1 & mask) | ((b1 << 8) & ~mask);
+    }
+
+    b0 = __shfl_xor_sync(~0, a0, 4);
+    b1 = __shfl_xor_sync(~0, a1, 4);
+    mask = 0x0F0F0F0F0F0F0F0FULL;
+    if ((sublane & 4) == 0) {
+      a0 = (a0 & ~mask) | ((b0 >> 4) & mask);
+      a1 = (a1 & ~mask) | ((b1 >> 4) & mask);
+    } else {
+      a0 = (a0 & mask) | ((b0 << 4) & ~mask);
+      a1 = (a1 & mask) | ((b1 << 4) & ~mask);
+    }
+
+    b0 = __shfl_xor_sync(~0, a0, 2);
+    b1 = __shfl_xor_sync(~0, a1, 2);
+    mask = 0x3333333333333333ULL;
+    if ((sublane & 2) == 0) {
+      a0 = (a0 & ~mask) | ((b0 >> 2) & mask);
+      a1 = (a1 & ~mask) | ((b1 >> 2) & mask);
+    } else {
+      a0 = (a0 & mask) | ((b0 << 2) & ~mask);
+      a1 = (a1 & mask) | ((b1 << 2) & ~mask);
+    }
+
+    b0 = __shfl_xor_sync(~0, a0, 1);
+    b1 = __shfl_xor_sync(~0, a1, 1);
+    mask = 0x5555555555555555ULL;
+    if ((sublane & 1) == 0) {
+      a0 = (a0 & ~mask) | ((b0 >> 1) & mask);
+      a1 = (a1 & ~mask) | ((b1 >> 1) & mask);
+    } else {
+      a0 = (a0 & mask) | ((b0 << 1) & ~mask);
+      a1 = (a1 & mask) | ((b1 << 1) & ~mask);
+    }
+
+    out_l[i / 64 + sublane * (size / 64)] = a0;
+    out_l[i / 64 + (sublane + 32) * (size / 64)] = a1;
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  return true;
+}
+
+
+static __device__ inline void d_iBIT_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int SWS = 32;  // sub-warp size
+  long long* const in_l = (long long*)in;
+  long long* const out_l = (long long*)out;
+  const int tid = threadIdx.x;
+  const int subwarp = tid / SWS;
+  const int sublane = tid % SWS;
+  const int extra = csize % (64 * 64 / 8);
+  const int size = (csize - extra) / 8;
+
+  for (int i = subwarp * 64 + sublane; i < size; i += TPB * 2) {
+    unsigned long long a0 = in_l[i / 64 + sublane * (size / 64)];
+    unsigned long long a1 = in_l[i / 64 + (sublane + 32) * (size / 64)];
+
+    unsigned long long b0 = a1;
+    unsigned long long b1 = a0;
+    unsigned long long mask = 0x00000000FFFFFFFFULL;
+    a0 = (a0 & ~mask) | (b0 >> 32);
+    a1 = (a1 & mask) | (b1 << 32);
+
+    b0 = __shfl_xor_sync(~0, a0, 16);
+    b1 = __shfl_xor_sync(~0, a1, 16);
+    mask = 0x0000FFFF0000FFFFULL;
+    if ((sublane & 16) == 0) {
+      a0 = (a0 & ~mask) | ((b0 >> 16) & mask);
+      a1 = (a1 & ~mask) | ((b1 >> 16) & mask);
+    } else {
+      a0 = (a0 & mask) | ((b0 << 16) & ~mask);
+      a1 = (a1 & mask) | ((b1 << 16) & ~mask);
+    }
+
+    b0 = __shfl_xor_sync(~0, a0, 8);
+    b1 = __shfl_xor_sync(~0, a1, 8);
+    mask = 0x00FF00FF00FF00FFULL;
+    if ((sublane & 8) == 0) {
+      a0 = (a0 & ~mask) | ((b0 >> 8) & mask);
+      a1 = (a1 & ~mask) | ((b1 >> 8) & mask);
+    } else {
+      a0 = (a0 & mask) | ((b0 << 8) & ~mask);
+      a1 = (a1 & mask) | ((b1 << 8) & ~mask);
+    }
+
+    b0 = __shfl_xor_sync(~0, a0, 4);
+    b1 = __shfl_xor_sync(~0, a1, 4);
+    mask = 0x0F0F0F0F0F0F0F0FULL;
+    if ((sublane & 4) == 0) {
+      a0 = (a0 & ~mask) | ((b0 >> 4) & mask);
+      a1 = (a1 & ~mask) | ((b1 >> 4) & mask);
+    } else {
+      a0 = (a0 & mask) | ((b0 << 4) & ~mask);
+      a1 = (a1 & mask) | ((b1 << 4) & ~mask);
+    }
+
+    b0 = __shfl_xor_sync(~0, a0, 2);
+    b1 = __shfl_xor_sync(~0, a1, 2);
+    mask = 0x3333333333333333ULL;
+    if ((sublane & 2) == 0) {
+      a0 = (a0 & ~mask) | ((b0 >> 2) & mask);
+      a1 = (a1 & ~mask) | ((b1 >> 2) & mask);
+    } else {
+      a0 = (a0 & mask) | ((b0 << 2) & ~mask);
+      a1 = (a1 & mask) | ((b1 << 2) & ~mask);
+    }
+
+    b0 = __shfl_xor_sync(~0, a0, 1);
+    b1 = __shfl_xor_sync(~0, a1, 1);
+    mask = 0x5555555555555555ULL;
+    if ((sublane & 1) == 0) {
+      a0 = (a0 & ~mask) | ((b0 >> 1) & mask);
+      a1 = (a1 & ~mask) | ((b1 >> 1) & mask);
+    } else {
+      a0 = (a0 & mask) | ((b0 << 1) & ~mask);
+      a1 = (a1 & mask) | ((b1 << 1) & ~mask);
+    }
+
+    out_l[i] = a0;
+    out_l[i + 32] = a1;
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+}

--- a/include/lc/components/d_CLOG_1.h
+++ b/include/lc/components/d_CLOG_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_CLOG.h"
+
+
+static __device__ inline bool d_CLOG_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_CLOG<byte>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iCLOG_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iCLOG<byte>(csize, in, out, temp);
+}

--- a/include/lc/components/d_CLOG_2.h
+++ b/include/lc/components/d_CLOG_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_CLOG.h"
+
+
+static __device__ inline bool d_CLOG_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_CLOG<unsigned short>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iCLOG_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iCLOG<unsigned short>(csize, in, out, temp);
+}

--- a/include/lc/components/d_CLOG_4.h
+++ b/include/lc/components/d_CLOG_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_CLOG.h"
+
+
+static __device__ inline bool d_CLOG_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_CLOG<unsigned int>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iCLOG_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iCLOG<unsigned int>(csize, in, out, temp);
+}

--- a/include/lc/components/d_CLOG_8.h
+++ b/include/lc/components/d_CLOG_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_CLOG.h"
+
+
+static __device__ inline bool d_CLOG_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_CLOG<unsigned long long>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iCLOG_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iCLOG<unsigned long long>(csize, in, out, temp);
+}

--- a/include/lc/components/d_DBEFS_4.h
+++ b/include/lc/components/d_DBEFS_4.h
@@ -1,0 +1,78 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static __device__ inline bool d_DBEFS_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  using type = unsigned int;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+  const int tid = threadIdx.x;
+
+  // convert from IEEE 754 to EFS
+  for (int i = tid; i < size; i += TPB) {
+    const type val = bufin[i];
+    bufout[i] = ((val << 1) | (val >> 31)) - 0x7f00'0000;
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  return true;
+}
+
+
+static __device__ inline void d_iDBEFS_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  using type = unsigned int;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+  const int tid = threadIdx.x;
+
+  // convert from EFS to IEEE 754
+  for (int i = tid; i < size; i += TPB) {
+    const type val = bufin[i] + 0x7f00'0000;
+    bufout[i] = (val << 31) | (val >> 1);
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+}

--- a/include/lc/components/d_DBEFS_8.h
+++ b/include/lc/components/d_DBEFS_8.h
@@ -1,0 +1,78 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static __device__ inline bool d_DBEFS_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  using type = unsigned long long;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+  const int tid = threadIdx.x;
+
+  // convert from IEEE 754 to EFS
+  for (int i = tid; i < size; i += TPB) {
+    const type val = bufin[i];
+    bufout[i] = ((val << 1) | (val >> 63)) - 0x7fe0'0000'0000'0000;
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  return true;
+}
+
+
+static __device__ inline void d_iDBEFS_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  using type = unsigned long long;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+  const int tid = threadIdx.x;
+
+  // convert from EFS to IEEE 754
+  for (int i = tid; i < size; i += TPB) {
+    const type val = bufin[i] + 0x7fe0'0000'0000'0000;
+    bufout[i] = (val << 63) | (val >> 1);
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+}

--- a/include/lc/components/d_DBESF_4.h
+++ b/include/lc/components/d_DBESF_4.h
@@ -1,0 +1,84 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static __device__ inline bool d_DBESF_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  using type = unsigned int;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+  const int tid = threadIdx.x;
+
+  // convert from IEEE 754 to ESF
+  for (int i = tid; i < size; i += TPB) {
+    const type val = bufin[i];
+    const type f = ((1 << 23) - 1) & val;
+    const type e = val >> 23;  // extracts S and E, S shifted out later
+    const type v = (e << 1) | (val >> 31);
+    bufout[i] = ((v << 23) | f) - 0x7f00'0000;
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  return true;
+}
+
+
+static __device__ inline void d_iDBESF_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  using type = unsigned int;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+  const int tid = threadIdx.x;
+
+  // convert from ESF to IEEE 754
+  for (int i = tid; i < size; i += TPB) {
+    const type val = bufin[i] + 0x7f00'0000;
+    const type s = val >> 23;  // extracts E and S, E shifted out later
+    const type f = ((1 << 23) - 1) & val;
+    const type v = (s << 8) | (val >> 24);
+    bufout[i] = (v << 23) | f;
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+}

--- a/include/lc/components/d_DBESF_8.h
+++ b/include/lc/components/d_DBESF_8.h
@@ -1,0 +1,84 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static __device__ inline bool d_DBESF_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  using type = unsigned long long;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+  const int tid = threadIdx.x;
+
+  // convert from IEEE 754 to ESF
+  for (int i = tid; i < size; i += TPB) {
+    const type val = bufin[i];
+    const type f = ((1ULL << 52) - 1) & val;
+    const type e = val >> 52;  // extracts S and E, S shifted out later
+    const type v = (e << 1) | (val >> 63);
+    bufout[i] = ((v << 52) | f) - 0x7fe0'0000'0000'0000;
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  return true;
+}
+
+
+static __device__ inline void d_iDBESF_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  using type = unsigned long long;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+  const int tid = threadIdx.x;
+
+  // convert from ESF to IEEE 754
+  for (int i = tid; i < size; i += TPB) {
+    const type val = bufin[i] + 0x7fe0'0000'0000'0000;
+    const type s = val >> 52;  // extracts E and S, E shifted out later
+    const type f = ((1ULL << 52) - 1) & val;
+    const type v = (s << 11) | (val >> 53);
+    bufout[i] = (v << 52) | f;
+  }
+
+  // copy leftover bytes
+  if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+}

--- a/include/lc/components/d_DIFFMS_1.h
+++ b/include/lc/components/d_DIFFMS_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_DIFFMS.h"
+
+
+static __device__ inline bool d_DIFFMS_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_DIFFMS<byte>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iDIFFMS_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iDIFFMS<byte>(csize, in, out, temp);
+}

--- a/include/lc/components/d_DIFFMS_2.h
+++ b/include/lc/components/d_DIFFMS_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_DIFFMS.h"
+
+
+static __device__ inline bool d_DIFFMS_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_DIFFMS<unsigned short>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iDIFFMS_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iDIFFMS<unsigned short>(csize, in, out, temp);
+}

--- a/include/lc/components/d_DIFFMS_4.h
+++ b/include/lc/components/d_DIFFMS_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_DIFFMS.h"
+
+
+static __device__ inline bool d_DIFFMS_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_DIFFMS<unsigned int>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iDIFFMS_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iDIFFMS<unsigned int>(csize, in, out, temp);
+}

--- a/include/lc/components/d_DIFFMS_8.h
+++ b/include/lc/components/d_DIFFMS_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_DIFFMS.h"
+
+
+static __device__ inline bool d_DIFFMS_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_DIFFMS<unsigned long long>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iDIFFMS_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iDIFFMS<unsigned long long>(csize, in, out, temp);
+}

--- a/include/lc/components/d_DIFF_1.h
+++ b/include/lc/components/d_DIFF_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_DIFF.h"
+
+
+static __device__ inline bool d_DIFF_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_DIFF<byte>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iDIFF_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iDIFF<byte>(csize, in, out, temp);
+}

--- a/include/lc/components/d_DIFF_2.h
+++ b/include/lc/components/d_DIFF_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_DIFF.h"
+
+
+static __device__ inline bool d_DIFF_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_DIFF<unsigned short>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iDIFF_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iDIFF<unsigned short>(csize, in, out, temp);
+}

--- a/include/lc/components/d_DIFF_4.h
+++ b/include/lc/components/d_DIFF_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_DIFF.h"
+
+
+static __device__ inline bool d_DIFF_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_DIFF<unsigned int>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iDIFF_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iDIFF<unsigned int>(csize, in, out, temp);
+}

--- a/include/lc/components/d_DIFF_8.h
+++ b/include/lc/components/d_DIFF_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_DIFF.h"
+
+
+static __device__ inline bool d_DIFF_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_DIFF<unsigned long long>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iDIFF_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iDIFF<unsigned long long>(csize, in, out, temp);
+}

--- a/include/lc/components/d_HCLOG_1.h
+++ b/include/lc/components/d_HCLOG_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_HCLOG.h"
+
+
+static __device__ inline bool d_HCLOG_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_HCLOG<byte>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iHCLOG_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iHCLOG<byte>(csize, in, out, temp);
+}

--- a/include/lc/components/d_HCLOG_2.h
+++ b/include/lc/components/d_HCLOG_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_HCLOG.h"
+
+
+static __device__ inline bool d_HCLOG_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_HCLOG<unsigned short>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iHCLOG_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iHCLOG<unsigned short>(csize, in, out, temp);
+}

--- a/include/lc/components/d_HCLOG_4.h
+++ b/include/lc/components/d_HCLOG_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_HCLOG.h"
+
+
+static __device__ inline bool d_HCLOG_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_HCLOG<unsigned int>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iHCLOG_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iHCLOG<unsigned int>(csize, in, out, temp);
+}

--- a/include/lc/components/d_HCLOG_8.h
+++ b/include/lc/components/d_HCLOG_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_HCLOG.h"
+
+
+static __device__ inline bool d_HCLOG_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_HCLOG<unsigned long long>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iHCLOG_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iHCLOG<unsigned long long>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RLE_1.h
+++ b/include/lc/components/d_RLE_1.h
@@ -1,0 +1,53 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+
+#include "include/d_RLE.h"
+
+
+static __device__ inline bool d_RLE_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RLE<byte>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRLE_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRLE<byte>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RLE_2.h
+++ b/include/lc/components/d_RLE_2.h
@@ -1,0 +1,53 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+
+#include "include/d_RLE.h"
+
+
+static __device__ inline bool d_RLE_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RLE<unsigned short>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRLE_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRLE<unsigned short>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RLE_4.h
+++ b/include/lc/components/d_RLE_4.h
@@ -1,0 +1,53 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+
+#include "include/d_RLE.h"
+
+
+static __device__ inline bool d_RLE_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RLE<unsigned int>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRLE_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRLE<unsigned int>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RLE_8.h
+++ b/include/lc/components/d_RLE_8.h
@@ -1,0 +1,53 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+
+#include "include/d_RLE.h"
+
+
+static __device__ inline bool d_RLE_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RLE<unsigned long long>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRLE_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRLE<unsigned long long>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RRE_1.h
+++ b/include/lc/components/d_RRE_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_RRE.h"
+
+
+static __device__ inline bool d_RRE_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RRE<byte>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRRE_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRRE<byte>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RRE_2.h
+++ b/include/lc/components/d_RRE_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_RRE.h"
+
+
+static __device__ inline bool d_RRE_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RRE<unsigned short>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRRE_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRRE<unsigned short>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RRE_4.h
+++ b/include/lc/components/d_RRE_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_RRE.h"
+
+
+static __device__ inline bool d_RRE_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RRE<unsigned int>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRRE_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRRE<unsigned int>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RRE_8.h
+++ b/include/lc/components/d_RRE_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_RRE.h"
+
+
+static __device__ inline bool d_RRE_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RRE<unsigned long long>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRRE_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRRE<unsigned long long>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RZE_1.h
+++ b/include/lc/components/d_RZE_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_RZE.h"
+
+
+static __device__ inline bool d_RZE_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RZE<byte>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRZE_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRZE<byte>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RZE_2.h
+++ b/include/lc/components/d_RZE_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_RZE.h"
+
+
+static __device__ inline bool d_RZE_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RZE<unsigned short>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRZE_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRZE<unsigned short>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RZE_4.h
+++ b/include/lc/components/d_RZE_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_RZE.h"
+
+
+static __device__ inline bool d_RZE_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RZE<unsigned int>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRZE_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRZE<unsigned int>(csize, in, out, temp);
+}

--- a/include/lc/components/d_RZE_8.h
+++ b/include/lc/components/d_RZE_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_RZE.h"
+
+
+static __device__ inline bool d_RZE_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_RZE<unsigned long long>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iRZE_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iRZE<unsigned long long>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TCMS_1.h
+++ b/include/lc/components/d_TCMS_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TCMS.h"
+
+
+static __device__ inline bool d_TCMS_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TCMS<byte>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTCMS_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTCMS<byte>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TCMS_2.h
+++ b/include/lc/components/d_TCMS_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TCMS.h"
+
+
+static __device__ inline bool d_TCMS_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TCMS<unsigned short>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTCMS_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTCMS<unsigned short>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TCMS_4.h
+++ b/include/lc/components/d_TCMS_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TCMS.h"
+
+
+static __device__ inline bool d_TCMS_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TCMS<unsigned int>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTCMS_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTCMS<unsigned int>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TCMS_8.h
+++ b/include/lc/components/d_TCMS_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TCMS.h"
+
+
+static __device__ inline bool d_TCMS_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TCMS<unsigned long long>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTCMS_8(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTCMS<unsigned long long>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TUPL12_1.h
+++ b/include/lc/components/d_TUPL12_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TUPL.h"
+
+
+static __device__ inline bool d_TUPL12_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TUPL<byte, 12>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTUPL12_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTUPL<byte, 12>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TUPL2_1.h
+++ b/include/lc/components/d_TUPL2_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TUPL.h"
+
+
+static __device__ inline bool d_TUPL2_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TUPL<byte, 2>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTUPL2_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTUPL<byte, 2>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TUPL2_2.h
+++ b/include/lc/components/d_TUPL2_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TUPL.h"
+
+
+static __device__ inline bool d_TUPL2_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TUPL<short, 2>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTUPL2_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTUPL<short, 2>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TUPL2_4.h
+++ b/include/lc/components/d_TUPL2_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TUPL.h"
+
+
+static __device__ inline bool d_TUPL2_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TUPL<int, 2>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTUPL2_4(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTUPL<int, 2>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TUPL3_1.h
+++ b/include/lc/components/d_TUPL3_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TUPL.h"
+
+
+static __device__ inline bool d_TUPL3_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TUPL<byte, 3>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTUPL3_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTUPL<byte, 3>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TUPL3_2.h
+++ b/include/lc/components/d_TUPL3_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TUPL.h"
+
+
+static __device__ inline bool d_TUPL3_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TUPL<short, 3>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTUPL3_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTUPL<short, 3>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TUPL4_1.h
+++ b/include/lc/components/d_TUPL4_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TUPL.h"
+
+
+static __device__ inline bool d_TUPL4_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TUPL<byte, 4>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTUPL4_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTUPL<byte, 4>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TUPL4_2.h
+++ b/include/lc/components/d_TUPL4_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TUPL.h"
+
+
+static __device__ inline bool d_TUPL4_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TUPL<short, 4>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTUPL4_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTUPL<short, 4>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TUPL6_1.h
+++ b/include/lc/components/d_TUPL6_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TUPL.h"
+
+
+static __device__ inline bool d_TUPL6_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TUPL<byte, 6>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTUPL6_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTUPL<byte, 6>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TUPL6_2.h
+++ b/include/lc/components/d_TUPL6_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TUPL.h"
+
+
+static __device__ inline bool d_TUPL6_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TUPL<short, 6>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTUPL6_2(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTUPL<short, 6>(csize, in, out, temp);
+}

--- a/include/lc/components/d_TUPL8_1.h
+++ b/include/lc/components/d_TUPL8_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/d_TUPL.h"
+
+
+static __device__ inline bool d_TUPL8_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  return d_TUPL<byte, 8>(csize, in, out, temp);
+}
+
+
+static __device__ inline void d_iTUPL8_1(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  d_iTUPL<byte, 8>(csize, in, out, temp);
+}

--- a/include/lc/components/h_BIT_1.h
+++ b/include/lc/components/h_BIT_1.h
@@ -1,0 +1,88 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static inline bool h_BIT_1(int& csize, byte in [CS], byte out [CS])
+{
+  const int extra = csize % (8 * 8 / 8);
+  const int size = csize - extra;
+
+  for (int pos = 0; pos < size; pos += 8) {
+    unsigned long long t, x;
+    x = *((unsigned long long*)&in[pos]);
+    t = (x ^ (x >> 7)) & 0x00AA00AA00AA00AAULL;
+    x = x ^ t ^ (t << 7);
+    t = (x ^ (x >> 14)) & 0x0000CCCC0000CCCCULL;
+    x = x ^ t ^ (t << 14);
+    t = (x ^ (x >> 28)) & 0x00000000F0F0F0F0ULL;
+    x = x ^ t ^ (t << 28);
+    for (int i = 0; i < 8; i++) {
+      out[pos / 8 + i * (size / 8)] = x >> (i * 8);
+    }
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+  return true;
+}
+
+
+static inline void h_iBIT_1(int& csize, byte in [CS], byte out [CS])
+{
+  const int extra = csize % (8 * 8 / 8);
+  const int size = csize - extra;
+
+  for (int pos = 0; pos < size; pos += 8) {
+    unsigned long long t, x = 0;
+    for (int i = 0; i < 8; i++) x |= (unsigned long long)in[pos / 8 + i * (size / 8)] << (i * 8);
+    t = (x ^ (x >> 7)) & 0x00AA00AA00AA00AAULL;
+    x = x ^ t ^ (t << 7);
+    t = (x ^ (x >> 14)) & 0x0000CCCC0000CCCCULL;
+    x = x ^ t ^ (t << 14);
+    t = (x ^ (x >> 28)) & 0x00000000F0F0F0F0ULL;
+    x = x ^ t ^ (t << 28);
+    *((unsigned long long*)&out[pos]) = x;
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+}

--- a/include/lc/components/h_BIT_2.h
+++ b/include/lc/components/h_BIT_2.h
@@ -1,0 +1,126 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#define swp(x, y, s, m) t = ((x) ^ ((y) >> (s))) & (m);  (x) ^= t;  (y) ^= t << (s);
+
+static inline bool h_BIT_2(int& csize, byte in [CS], byte out [CS])
+{
+  const int extra = csize % (16 * 16 / 8);
+  const int size = (csize - extra) / 2;
+  unsigned long long* const in_l = (unsigned long long*)in;
+  unsigned short* const out_s = (unsigned short*)out;
+
+  for (int pos = 0; pos < size; pos += 16) {
+    unsigned long long t, *a = &in_l[pos / 4];  // process 4 shorts in 1 long long
+
+    for (int i = 0; i < 2; i++) {
+      swp(a[i], a[i + 2], 8, 0x00FF00FF00FF00FFULL);
+    }
+
+    for (int j = 0; j < 4; j += 2) {
+      swp(a[j], a[j + 1], 4, 0x0F0F0F0F0F0F0F0FULL);
+    }
+
+    for (int j = 0; j < 4; j++) {
+      const unsigned long long m = 0x33333333CCCCCCCCULL;
+      const unsigned long long vnm = a[j] & ~m;
+      a[j] = (a[j] & m) | (vnm >> 34) | (vnm << 34);
+    }
+
+    for (int j = 0; j < 4; j++) {
+      const unsigned long long m = 0x5555AAAA5555AAAAULL;
+      const unsigned long long m1 = 0xFFFF0000FFFF0000ULL;
+      const unsigned long long vnm = a[j] & ~m;
+      const unsigned long long res = (a[j] & m) | ((vnm & m1) >> 17) | ((vnm & ~m1) << 17);
+      out_s[pos / 16 + (j * 4) * (size / 16)] = res;
+      out_s[pos / 16 + (j * 4 + 1) * (size / 16)] = res >> 16;
+      out_s[pos / 16 + (j * 4 + 2) * (size / 16)] = res >> 32;
+      out_s[pos / 16 + (j * 4 + 3) * (size / 16)] = res >> 48;
+    }
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+  return true;
+}
+
+
+static inline void h_iBIT_2(int& csize, byte in [CS], byte out [CS])
+{
+  const int extra = csize % (16 * 16 / 8);
+  const int size = (csize - extra) / 2;
+  unsigned short* const in_s = (unsigned short*)in;
+  unsigned long long* const out_l = (unsigned long long*)out;
+
+  for (int pos = 0; pos < size; pos += 16) {
+    unsigned long long t, *a = &out_l[pos / 4];  // process 4 shorts in 1 long long
+
+    for (int i = 0; i < 4; i++) {
+      a[i] = in_s[pos / 16 + (i * 4) * (size / 16)] | ((unsigned long long)in_s[pos / 16 + (i * 4 + 1) * (size / 16)] << 16) | ((unsigned long long)in_s[pos / 16 + (i * 4 + 2) * (size / 16)] << 32) | ((unsigned long long)in_s[pos / 16 + (i * 4 + 3) * (size / 16)] << 48);
+    }
+
+    for (int i = 0; i < 2; i++) {
+      swp(a[i], a[i + 2], 8, 0x00FF00FF00FF00FFULL);
+    }
+
+    for (int j = 0; j < 4; j += 2) {
+      swp(a[j], a[j + 1], 4, 0x0F0F0F0F0F0F0F0FULL);
+    }
+
+    for (int j = 0; j < 4; j++) {
+      const unsigned long long m = 0x33333333CCCCCCCCULL;
+      const unsigned long long vnm = a[j] & ~m;
+      a[j] = (a[j] & m) | (vnm >> 34) | (vnm << 34);
+    }
+
+    for (int j = 0; j < 4; j++) {
+      const unsigned long long m = 0x5555AAAA5555AAAAULL;
+      const unsigned long long m1 = 0xFFFF0000FFFF0000ULL;
+      const unsigned long long vnm = a[j] & ~m;
+      a[j] = (a[j] & m) | ((vnm & m1) >> 17) | ((vnm & ~m1) << 17);
+    }
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+}

--- a/include/lc/components/h_BIT_4.h
+++ b/include/lc/components/h_BIT_4.h
@@ -1,0 +1,134 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#define swp(x, y, s, m) t = ((x) ^ ((y) >> (s))) & (m);  (x) ^= t;  (y) ^= t << (s);
+
+static inline bool h_BIT_4(int& csize, byte in [CS], byte out [CS])
+{
+  const int extra = csize % (32 * 32 / 8);
+  const int size = (csize - extra) / 4;
+  unsigned long long* const in_l = (unsigned long long*)in;
+  unsigned int* const out_w = (unsigned int*)out;
+
+  for (int pos = 0; pos < size; pos += 32) {
+    unsigned long long t, *a = &in_l[pos / 2];  // process 2 ints in 1 long long
+
+    for (int i = 0; i < 8; i++) {
+      swp(a[i], a[i + 8], 16, 0x0000FFFF0000FFFFULL);
+    }
+
+    for (int j = 0; j < 16; j += 8) {
+      for (int i = 0; i < 4; i++) {
+        swp(a[j + i], a[j + i + 4], 8, 0x00FF00FF00FF00FFULL);
+      }
+    }
+
+    for (int j = 0; j < 16; j += 4) {
+      for (int i = 0; i < 2; i++) {
+        swp(a[j + i], a[j + i + 2], 4, 0x0F0F0F0F0F0F0F0FULL);
+      }
+    }
+
+    for (int j = 0; j < 16; j += 2) {
+      swp(a[j], a[j + 1], 2, 0x3333333333333333ULL);
+    }
+
+    for (int j = 0; j < 16; j++) {
+      const unsigned long long m = 0x55555555AAAAAAAAULL;
+      const unsigned long long vnm = a[j] & ~m;
+      const unsigned long long res = (a[j] & m) | (vnm >> 33) | (vnm << 33);
+      out_w[pos / 32 + (j * 2) * (size / 32)] = res;
+      out_w[pos / 32 + (j * 2 + 1) * (size / 32)] = res >> 32;
+    }
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+  return true;
+}
+
+
+static inline void h_iBIT_4(int& csize, byte in [CS], byte out [CS])
+{
+  const int extra = csize % (32 * 32 / 8);
+  const int size = (csize - extra) / 4;
+  unsigned int* const in_w = (unsigned int*)in;
+  unsigned long long* const out_l = (unsigned long long*)out;
+
+  for (int pos = 0; pos < size; pos += 32) {
+    unsigned long long t, *a = &out_l[pos / 2];  // process 2 ints in 1 long long
+
+    for (int i = 0; i < 8; i++) {
+      const unsigned long long s1 = in_w[pos / 32 + (i * 2) * (size / 32)] | ((unsigned long long)in_w[pos / 32 + (i * 2 + 1) * (size / 32)] << 32);
+      const unsigned long long s2 = in_w[pos / 32 + (i * 2 + 16) * (size / 32)] | ((unsigned long long)in_w[pos / 32 + (i * 2 + 1 + 16) * (size / 32)] << 32);
+      const unsigned long long t = (s1 ^ (s2 >> 16)) & 0x0000FFFF0000FFFFULL;
+      a[i] = s1 ^ t;
+      a[i + 8] = s2 ^ (t << 16);
+    }
+
+    for (int j = 0; j < 16; j += 8) {
+      for (int i = 0; i < 4; i++) {
+        swp(a[j + i], a[j + i + 4], 8, 0x00FF00FF00FF00FFULL);
+      }
+    }
+
+    for (int j = 0; j < 16; j += 4) {
+      for (int i = 0; i < 2; i++) {
+        swp(a[j + i], a[j + i + 2], 4, 0x0F0F0F0F0F0F0F0FULL);
+      }
+    }
+
+    for (int j = 0; j < 16; j += 2) {
+      swp(a[j], a[j + 1], 2, 0x3333333333333333ULL);
+    }
+
+    for (int j = 0; j < 16; j++) {
+      const unsigned long long m = 0x55555555AAAAAAAAULL;
+      const unsigned long long vnm = a[j] & ~m;
+      a[j] = (a[j] & m) | (vnm >> 33) | (vnm << 33);
+    }
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+}

--- a/include/lc/components/h_BIT_8.h
+++ b/include/lc/components/h_BIT_8.h
@@ -1,0 +1,146 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#define swp(x, y, s, m) t = ((x) ^ ((y) >> (s))) & (m);  (x) ^= t;  (y) ^= t << (s);
+
+static inline bool h_BIT_8(int& csize, byte in [CS], byte out [CS])
+{
+  const int extra = csize % (64 * 64 / 8);
+  const int size = (csize - extra) / 8;
+  unsigned long long* const in_l = (unsigned long long*)in;
+  unsigned long long* const out_l = (unsigned long long*)out;
+
+  for (int pos = 0; pos < size; pos += 64) {
+    unsigned long long t, *a = &in_l[pos];
+
+    for (int i = 0; i < 32; i++) {
+      swp(a[i], a[i + 32], 32, 0x00000000FFFFFFFFULL);
+    }
+
+    for (int j = 0; j < 64; j += 32) {
+      for (int i = 0; i < 16; i++) {
+        swp(a[j + i], a[j + i + 16], 16, 0x0000FFFF0000FFFFULL);
+      }
+    }
+
+    for (int j = 0; j < 64; j += 16) {
+      for (int i = 0; i < 8; i++) {
+        swp(a[j + i], a[j + i + 8], 8, 0x00FF00FF00FF00FFULL);
+      }
+    }
+
+    for (int j = 0; j < 64; j += 8) {
+      for (int i = 0; i < 4; i++) {
+        swp(a[j + i], a[j + i + 4], 4, 0x0F0F0F0F0F0F0F0FULL);
+      }
+    }
+
+    for (int j = 0; j < 64; j += 4) {
+      for (int i = 0; i < 2; i++) {
+        swp(a[j + i], a[j + i + 2], 2, 0x3333333333333333ULL);
+      }
+    }
+
+    for (int j = 0; j < 64; j += 2) {
+      t = (a[j] ^ (a[j + 1] >> 1)) & 0x5555555555555555ULL;
+      out_l[pos / 64 + j * (size / 64)] = a[j] ^ t;
+      out_l[pos / 64 + (j + 1) * (size / 64)] = a[j + 1] ^ (t << 1);
+    }
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+  return true;
+}
+
+
+static inline void h_iBIT_8(int& csize, byte in [CS], byte out [CS])
+{
+  const int extra = csize % (64 * 64 / 8);
+  const int size = (csize - extra) / 8;
+  unsigned long long* const in_l = (unsigned long long*)in;
+  unsigned long long* const out_l = (unsigned long long*)out;
+
+  for (int pos = 0; pos < size; pos += 64) {
+    unsigned long long t, *a = &out_l[pos];
+
+    for (int i = 0; i < 32; i++) {
+      const long long ai = in_l[pos / 64 + i * (size / 64)];
+      const long long ai32 = in_l[pos / 64 + (i + 32) * (size / 64)];
+      t = (ai ^ (ai32 >> 32)) & 0x00000000FFFFFFFFULL;
+      a[i] = ai ^ t;
+      a[i + 32] = ai32 ^ (t << 32);
+    }
+
+    for (int j = 0; j < 64; j += 32) {
+      for (int i = 0; i < 16; i++) {
+        swp(a[j + i], a[j + i + 16], 16, 0x0000FFFF0000FFFFULL);
+      }
+    }
+
+    for (int j = 0; j < 64; j += 16) {
+      for (int i = 0; i < 8; i++) {
+        swp(a[j + i], a[j + i + 8], 8, 0x00FF00FF00FF00FFULL);
+      }
+    }
+
+    for (int j = 0; j < 64; j += 8) {
+      for (int i = 0; i < 4; i++) {
+        swp(a[j + i], a[j + i + 4], 4, 0x0F0F0F0F0F0F0F0FULL);
+      }
+    }
+
+    for (int j = 0; j < 64; j += 4) {
+      for (int i = 0; i < 2; i++) {
+        swp(a[j + i], a[j + i + 2], 2, 0x3333333333333333ULL);
+      }
+    }
+
+    for (int j = 0; j < 64; j += 2) {
+      swp(a[j], a[j + 1], 1, 0x5555555555555555ULL);
+    }
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+}

--- a/include/lc/components/h_CLOG_1.h
+++ b/include/lc/components/h_CLOG_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_CLOG.h"
+
+
+static inline bool h_CLOG_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_CLOG<byte>(csize, in, out);
+}
+
+
+static inline void h_iCLOG_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iCLOG<byte>(csize, in, out);
+}

--- a/include/lc/components/h_CLOG_2.h
+++ b/include/lc/components/h_CLOG_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_CLOG.h"
+
+
+static inline bool h_CLOG_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_CLOG<unsigned short>(csize, in, out);
+}
+
+
+static inline void h_iCLOG_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iCLOG<unsigned short>(csize, in, out);
+}

--- a/include/lc/components/h_CLOG_4.h
+++ b/include/lc/components/h_CLOG_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_CLOG.h"
+
+
+static inline bool h_CLOG_4(int& csize, byte in [CS], byte out [CS])
+{
+  return h_CLOG<unsigned int>(csize, in, out);
+}
+
+
+static inline void h_iCLOG_4(int& csize, byte in [CS], byte out [CS])
+{
+  h_iCLOG<unsigned int>(csize, in, out);
+}

--- a/include/lc/components/h_CLOG_8.h
+++ b/include/lc/components/h_CLOG_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_CLOG.h"
+
+
+static inline bool h_CLOG_8(int& csize, byte in [CS], byte out [CS])
+{
+  return h_CLOG<unsigned long long>(csize, in, out);
+}
+
+
+static inline void h_iCLOG_8(int& csize, byte in [CS], byte out [CS])
+{
+  h_iCLOG<unsigned long long>(csize, in, out);
+}

--- a/include/lc/components/h_DBEFS_4.h
+++ b/include/lc/components/h_DBEFS_4.h
@@ -1,0 +1,80 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static inline bool h_DBEFS_4(int& csize, byte in [CS], byte out [CS])
+{
+  using type = unsigned int;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+
+  // convert from IEEE 754 to EFS
+  for (int i = 0; i < size; i++) {
+    const type val = bufin[i];
+    bufout[i] = ((val << 1) | (val >> 31)) - 0x7f00'0000;
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+  return true;
+}
+
+
+static inline void h_iDBEFS_4(int& csize, byte in [CS], byte out [CS])
+{
+  using type = unsigned int;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+
+  // convert from EFS to IEEE 754
+  for (int i = 0; i < size; i++) {
+    const type val = bufin[i] + 0x7f00'0000;
+    bufout[i] = (val << 31) | (val >> 1);
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+}

--- a/include/lc/components/h_DBEFS_8.h
+++ b/include/lc/components/h_DBEFS_8.h
@@ -1,0 +1,80 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static inline bool h_DBEFS_8(int& csize, byte in [CS], byte out [CS])
+{
+  using type = unsigned long long;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+
+  // convert from IEEE 754 to EFS
+  for (int i = 0; i < size; i++) {
+    const type val = bufin[i];
+    bufout[i] = ((val << 1) | (val >> 63)) - 0x7fe0'0000'0000'0000;
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+  return true;
+}
+
+
+static inline void h_iDBEFS_8(int& csize, byte in [CS], byte out [CS])
+{
+  using type = unsigned long long;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+
+  // convert from EFS to IEEE 754
+  for (int i = 0; i < size; i++) {
+    const type val = bufin[i] + 0x7fe0'0000'0000'0000;
+    bufout[i] = (val << 63) | (val >> 1);
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+}

--- a/include/lc/components/h_DBESF_4.h
+++ b/include/lc/components/h_DBESF_4.h
@@ -1,0 +1,86 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static inline bool h_DBESF_4(int& csize, byte in [CS], byte out [CS])
+{
+  using type = unsigned int;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+
+  // convert from IEEE 754 to ESF
+  for (int i = 0; i < size; i++) {
+    const type val = bufin[i];
+    const type f = ((1 << 23) - 1) & val;
+    const type e = val >> 23;  // extracts S and E, S shifted out later
+    const type v = (e << 1) | (val >> 31);
+    bufout[i] = ((v << 23) | f) - 0x7f00'0000;
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+  return true;
+}
+
+
+static inline void h_iDBESF_4(int& csize, byte in [CS], byte out [CS])
+{
+  using type = unsigned int;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+
+  // convert from ESF to IEEE 754
+  for (int i = 0; i < size; i++) {
+    const type val = bufin[i] + 0x7f00'0000;
+    const type s = val >> 23;  // extracts E and S, E shifted out later
+    const type f = ((1 << 23) - 1) & val;
+    const type v = (s << 8) | (val >> 24);
+    bufout[i] = (v << 23) | f;
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+}

--- a/include/lc/components/h_DBESF_8.h
+++ b/include/lc/components/h_DBESF_8.h
@@ -1,0 +1,86 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+static inline bool h_DBESF_8(int& csize, byte in [CS], byte out [CS])
+{
+  using type = unsigned long long;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+
+  // convert from IEEE 754 to ESF
+  for (int i = 0; i < size; i++) {
+    const type val = bufin[i];
+    const type f = ((1ULL << 52) - 1) & val;
+    const type e = val >> 52;  // extracts S and E, S shifted out later
+    const type v = (e << 1) | (val >> 63);
+    bufout[i] = ((v << 52) | f) - 0x7fe0'0000'0000'0000;
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+  return true;
+}
+
+
+static inline void h_iDBESF_8(int& csize, byte in [CS], byte out [CS])
+{
+  using type = unsigned long long;
+  const int size = csize / sizeof(type);
+  const int extra = csize % sizeof(type);
+  type* const bufin = (type*)in;
+  type* const bufout = (type*)out;
+
+  // convert from ESF to IEEE 754
+  for (int i = 0; i < size; i++) {
+    const type val = bufin[i] + 0x7fe0'0000'0000'0000;
+    const type s = val >> 52;  // extracts E and S, E shifted out later
+    const type f = ((1ULL << 52) - 1) & val;
+    const type v = (s << 11) | (val >> 53);
+    bufout[i] = (v << 52) | f;
+  }
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) {
+    out[csize - extra + i] = in[csize - extra + i];
+  }
+}

--- a/include/lc/components/h_DIFFMS_1.h
+++ b/include/lc/components/h_DIFFMS_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_DIFFMS.h"
+
+
+static inline bool h_DIFFMS_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_DIFFMS<byte>(csize, in, out);
+}
+
+
+static inline void h_iDIFFMS_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iDIFFMS<byte>(csize, in, out);
+}

--- a/include/lc/components/h_DIFFMS_2.h
+++ b/include/lc/components/h_DIFFMS_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_DIFFMS.h"
+
+
+static inline bool h_DIFFMS_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_DIFFMS<unsigned short>(csize, in, out);
+}
+
+
+static inline void h_iDIFFMS_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iDIFFMS<unsigned short>(csize, in, out);
+}

--- a/include/lc/components/h_DIFFMS_4.h
+++ b/include/lc/components/h_DIFFMS_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_DIFFMS.h"
+
+
+static inline bool h_DIFFMS_4(int& csize, byte in [CS], byte out [CS])
+{
+  return h_DIFFMS<unsigned int>(csize, in, out);
+}
+
+
+static inline void h_iDIFFMS_4(int& csize, byte in [CS], byte out [CS])
+{
+  h_iDIFFMS<unsigned int>(csize, in, out);
+}

--- a/include/lc/components/h_DIFFMS_8.h
+++ b/include/lc/components/h_DIFFMS_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_DIFFMS.h"
+
+
+static inline bool h_DIFFMS_8(int& csize, byte in [CS], byte out [CS])
+{
+  return h_DIFFMS<unsigned long long>(csize, in, out);
+}
+
+
+static inline void h_iDIFFMS_8(int& csize, byte in [CS], byte out [CS])
+{
+  h_iDIFFMS<unsigned long long>(csize, in, out);
+}

--- a/include/lc/components/h_DIFF_1.h
+++ b/include/lc/components/h_DIFF_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_DIFF.h"
+
+
+static inline bool h_DIFF_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_DIFF<byte>(csize, in, out);
+}
+
+
+static inline void h_iDIFF_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iDIFF<byte>(csize, in, out);
+}

--- a/include/lc/components/h_DIFF_2.h
+++ b/include/lc/components/h_DIFF_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_DIFF.h"
+
+
+static inline bool h_DIFF_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_DIFF<unsigned short>(csize, in, out);
+}
+
+
+static inline void h_iDIFF_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iDIFF<unsigned short>(csize, in, out);
+}

--- a/include/lc/components/h_DIFF_4.h
+++ b/include/lc/components/h_DIFF_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_DIFF.h"
+
+
+static inline bool h_DIFF_4(int& csize, byte in [CS], byte out [CS])
+{
+  return h_DIFF<unsigned int>(csize, in, out);
+}
+
+
+static inline void h_iDIFF_4(int& csize, byte in [CS], byte out [CS])
+{
+  h_iDIFF<unsigned int>(csize, in, out);
+}

--- a/include/lc/components/h_DIFF_8.h
+++ b/include/lc/components/h_DIFF_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_DIFF.h"
+
+
+static inline bool h_DIFF_8(int& csize, byte in [CS], byte out [CS])
+{
+  return h_DIFF<unsigned long long>(csize, in, out);
+}
+
+
+static inline void h_iDIFF_8(int& csize, byte in [CS], byte out [CS])
+{
+  h_iDIFF<unsigned long long>(csize, in, out);
+}

--- a/include/lc/components/h_HCLOG_1.h
+++ b/include/lc/components/h_HCLOG_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_HCLOG.h"
+
+
+static inline bool h_HCLOG_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_HCLOG<byte>(csize, in, out);
+}
+
+
+static inline void h_iHCLOG_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iHCLOG<byte>(csize, in, out);
+}

--- a/include/lc/components/h_HCLOG_2.h
+++ b/include/lc/components/h_HCLOG_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_HCLOG.h"
+
+
+static inline bool h_HCLOG_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_HCLOG<unsigned short>(csize, in, out);
+}
+
+
+static inline void h_iHCLOG_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iHCLOG<unsigned short>(csize, in, out);
+}

--- a/include/lc/components/h_HCLOG_4.h
+++ b/include/lc/components/h_HCLOG_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_HCLOG.h"
+
+
+static inline bool h_HCLOG_4(int& csize, byte in [CS], byte out [CS])
+{
+  return h_HCLOG<unsigned int>(csize, in, out);
+}
+
+
+static inline void h_iHCLOG_4(int& csize, byte in [CS], byte out [CS])
+{
+  h_iHCLOG<unsigned int>(csize, in, out);
+}

--- a/include/lc/components/h_HCLOG_8.h
+++ b/include/lc/components/h_HCLOG_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_HCLOG.h"
+
+
+static inline bool h_HCLOG_8(int& csize, byte in [CS], byte out [CS])
+{
+  return h_HCLOG<unsigned long long>(csize, in, out);
+}
+
+
+static inline void h_iHCLOG_8(int& csize, byte in [CS], byte out [CS])
+{
+  h_iHCLOG<unsigned long long>(csize, in, out);
+}

--- a/include/lc/components/h_RLE_1.h
+++ b/include/lc/components/h_RLE_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_RLE.h"
+
+
+static inline bool h_RLE_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RLE<byte>(csize, in, out);
+}
+
+
+static inline void h_iRLE_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRLE<byte>(csize, in, out);
+}

--- a/include/lc/components/h_RLE_2.h
+++ b/include/lc/components/h_RLE_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_RLE.h"
+
+
+static inline bool h_RLE_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RLE<unsigned short>(csize, in, out);
+}
+
+
+static inline void h_iRLE_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRLE<unsigned short>(csize, in, out);
+}

--- a/include/lc/components/h_RLE_4.h
+++ b/include/lc/components/h_RLE_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_RLE.h"
+
+
+static inline bool h_RLE_4(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RLE<unsigned int>(csize, in, out);
+}
+
+
+static inline void h_iRLE_4(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRLE<unsigned int>(csize, in, out);
+}

--- a/include/lc/components/h_RLE_8.h
+++ b/include/lc/components/h_RLE_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_RLE.h"
+
+
+static inline bool h_RLE_8(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RLE<unsigned long long>(csize, in, out);
+}
+
+
+static inline void h_iRLE_8(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRLE<unsigned long long>(csize, in, out);
+}

--- a/include/lc/components/h_RRE_1.h
+++ b/include/lc/components/h_RRE_1.h
@@ -1,0 +1,53 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+
+#include "include/h_RRE.h"
+
+
+static inline bool h_RRE_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RRE<byte>(csize, in, out);
+}
+
+
+static inline void h_iRRE_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRRE<byte>(csize, in, out);
+}

--- a/include/lc/components/h_RRE_2.h
+++ b/include/lc/components/h_RRE_2.h
@@ -1,0 +1,53 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+
+#include "include/h_RRE.h"
+
+
+static inline bool h_RRE_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RRE<unsigned short>(csize, in, out);
+}
+
+
+static inline void h_iRRE_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRRE<unsigned short>(csize, in, out);
+}

--- a/include/lc/components/h_RRE_4.h
+++ b/include/lc/components/h_RRE_4.h
@@ -1,0 +1,53 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+
+#include "include/h_RRE.h"
+
+
+static inline bool h_RRE_4(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RRE<unsigned int>(csize, in, out);
+}
+
+
+static inline void h_iRRE_4(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRRE<unsigned int>(csize, in, out);
+}

--- a/include/lc/components/h_RRE_8.h
+++ b/include/lc/components/h_RRE_8.h
@@ -1,0 +1,53 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+
+#include "include/h_RRE.h"
+
+
+static inline bool h_RRE_8(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RRE<unsigned long long>(csize, in, out);
+}
+
+
+static inline void h_iRRE_8(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRRE<unsigned long long>(csize, in, out);
+}

--- a/include/lc/components/h_RZE_1.h
+++ b/include/lc/components/h_RZE_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_RZE.h"
+
+
+static inline bool h_RZE_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RZE<byte>(csize, in, out);
+}
+
+
+static inline void h_iRZE_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRZE<byte>(csize, in, out);
+}

--- a/include/lc/components/h_RZE_2.h
+++ b/include/lc/components/h_RZE_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_RZE.h"
+
+
+static inline bool h_RZE_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RZE<unsigned short>(csize, in, out);
+}
+
+
+static inline void h_iRZE_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRZE<unsigned short>(csize, in, out);
+}

--- a/include/lc/components/h_RZE_4.h
+++ b/include/lc/components/h_RZE_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_RZE.h"
+
+
+static inline bool h_RZE_4(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RZE<unsigned int>(csize, in, out);
+}
+
+
+static inline void h_iRZE_4(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRZE<unsigned int>(csize, in, out);
+}

--- a/include/lc/components/h_RZE_8.h
+++ b/include/lc/components/h_RZE_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_RZE.h"
+
+
+static inline bool h_RZE_8(int& csize, byte in [CS], byte out [CS])
+{
+  return h_RZE<unsigned long long>(csize, in, out);
+}
+
+
+static inline void h_iRZE_8(int& csize, byte in [CS], byte out [CS])
+{
+  h_iRZE<unsigned long long>(csize, in, out);
+}

--- a/include/lc/components/h_TCMS_1.h
+++ b/include/lc/components/h_TCMS_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TCMS.h"
+
+
+static inline bool h_TCMS_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TCMS<byte>(csize, in, out);
+}
+
+
+static inline void h_iTCMS_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTCMS<byte>(csize, in, out);
+}

--- a/include/lc/components/h_TCMS_2.h
+++ b/include/lc/components/h_TCMS_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TCMS.h"
+
+
+static inline bool h_TCMS_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TCMS<unsigned short>(csize, in, out);
+}
+
+
+static inline void h_iTCMS_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTCMS<unsigned short>(csize, in, out);
+}

--- a/include/lc/components/h_TCMS_4.h
+++ b/include/lc/components/h_TCMS_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TCMS.h"
+
+
+static inline bool h_TCMS_4(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TCMS<unsigned int>(csize, in, out);
+}
+
+
+static inline void h_iTCMS_4(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTCMS<unsigned int>(csize, in, out);
+}

--- a/include/lc/components/h_TCMS_8.h
+++ b/include/lc/components/h_TCMS_8.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TCMS.h"
+
+
+static inline bool h_TCMS_8(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TCMS<unsigned long long>(csize, in, out);
+}
+
+
+static inline void h_iTCMS_8(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTCMS<unsigned long long>(csize, in, out);
+}

--- a/include/lc/components/h_TUPL12_1.h
+++ b/include/lc/components/h_TUPL12_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TUPL.h"
+
+
+static inline bool h_TUPL12_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TUPL<byte, 12>(csize, in, out);
+}
+
+
+static inline void h_iTUPL12_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTUPL<byte, 12>(csize, in, out);
+}

--- a/include/lc/components/h_TUPL2_1.h
+++ b/include/lc/components/h_TUPL2_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TUPL.h"
+
+
+static inline bool h_TUPL2_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TUPL<byte, 2>(csize, in, out);
+}
+
+
+static inline void h_iTUPL2_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTUPL<byte, 2>(csize, in, out);
+}

--- a/include/lc/components/h_TUPL2_2.h
+++ b/include/lc/components/h_TUPL2_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TUPL.h"
+
+
+static inline bool h_TUPL2_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TUPL<short, 2>(csize, in, out);
+}
+
+
+static inline void h_iTUPL2_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTUPL<short, 2>(csize, in, out);
+}

--- a/include/lc/components/h_TUPL2_4.h
+++ b/include/lc/components/h_TUPL2_4.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TUPL.h"
+
+
+static inline bool h_TUPL2_4(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TUPL<int, 2>(csize, in, out);
+}
+
+
+static inline void h_iTUPL2_4(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTUPL<int, 2>(csize, in, out);
+}

--- a/include/lc/components/h_TUPL3_1.h
+++ b/include/lc/components/h_TUPL3_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TUPL.h"
+
+
+static inline bool h_TUPL3_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TUPL<byte, 3>(csize, in, out);
+}
+
+
+static inline void h_iTUPL3_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTUPL<byte, 3>(csize, in, out);
+}

--- a/include/lc/components/h_TUPL3_2.h
+++ b/include/lc/components/h_TUPL3_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TUPL.h"
+
+
+static inline bool h_TUPL3_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TUPL<short, 3>(csize, in, out);
+}
+
+
+static inline void h_iTUPL3_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTUPL<short, 3>(csize, in, out);
+}

--- a/include/lc/components/h_TUPL4_1.h
+++ b/include/lc/components/h_TUPL4_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TUPL.h"
+
+
+static inline bool h_TUPL4_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TUPL<byte, 4>(csize, in, out);
+}
+
+
+static inline void h_iTUPL4_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTUPL<byte, 4>(csize, in, out);
+}

--- a/include/lc/components/h_TUPL4_2.h
+++ b/include/lc/components/h_TUPL4_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TUPL.h"
+
+
+static inline bool h_TUPL4_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TUPL<short, 4>(csize, in, out);
+}
+
+
+static inline void h_iTUPL4_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTUPL<short, 4>(csize, in, out);
+}

--- a/include/lc/components/h_TUPL6_1.h
+++ b/include/lc/components/h_TUPL6_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TUPL.h"
+
+
+static inline bool h_TUPL6_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TUPL<byte, 6>(csize, in, out);
+}
+
+
+static inline void h_iTUPL6_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTUPL<byte, 6>(csize, in, out);
+}

--- a/include/lc/components/h_TUPL6_2.h
+++ b/include/lc/components/h_TUPL6_2.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TUPL.h"
+
+
+static inline bool h_TUPL6_2(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TUPL<short, 6>(csize, in, out);
+}
+
+
+static inline void h_iTUPL6_2(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTUPL<short, 6>(csize, in, out);
+}

--- a/include/lc/components/h_TUPL8_1.h
+++ b/include/lc/components/h_TUPL8_1.h
@@ -1,0 +1,52 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#include "include/h_TUPL.h"
+
+
+static inline bool h_TUPL8_1(int& csize, byte in [CS], byte out [CS])
+{
+  return h_TUPL<byte, 8>(csize, in, out);
+}
+
+
+static inline void h_iTUPL8_1(int& csize, byte in [CS], byte out [CS])
+{
+  h_iTUPL<byte, 8>(csize, in, out);
+}

--- a/include/lc/components/include/.gitignore
+++ b/include/lc/components/include/.gitignore
@@ -1,0 +1,3 @@
+CPUcomponents.h
+GPUcomponents.h
+components.h

--- a/include/lc/components/include/d_CLOG.h
+++ b/include/lc/components/include/d_CLOG.h
@@ -1,0 +1,274 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef GPU_CLOG
+#define GPU_CLOG
+
+
+template <typename T>
+static __device__ inline bool d_CLOG(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int tid = threadIdx.x;
+  const int lane = threadIdx.x % WS;
+  const int warp = threadIdx.x / WS;
+  const int warps = TPB / WS;
+
+  assert(std::is_unsigned<T>::value);
+  const int TB = sizeof(T) * 8;  // number of bits in T
+  const int SC = 32;  // subchunks [do not change]
+  const int CB = (32 - __clz((int)sizeof(T))) + 3;  // counter bits
+  assert((1 << CB) > TB);
+  assert((1 << (CB - 1)) <= TB);
+  assert(WS >= SC);
+  assert(SC == sizeof(int) * 8);
+  assert(sizeof(int) == 4);
+
+  // T casts
+  T* const in_t = (T*)in;
+  int* const out_i = (int*)out;  // int
+  const int TB_i = sizeof(int) * 8;
+  const int size = csize / sizeof(T);
+
+  byte* const ln = temp;
+  int* const bits = (int*)&temp[SC];
+  int* const total_bits = (int*)&bits[WS];
+
+  // determine bits needed for each subchunk
+  for (int i = warp; i < SC; i += warps) {
+    const int beg = i * size / SC;
+    const int end = (i + 1) * size / SC;
+
+    T max_val = 0;
+    // max of values for each thread
+    for (int j = beg + lane; j < end; j += WS) {
+      max_val = max(max_val, in_t[j]);
+    }
+
+    // warp level max
+    max_val = max(max_val, __shfl_xor_sync(~0, max_val, 1));
+    max_val = max(max_val, __shfl_xor_sync(~0, max_val, 2));
+    max_val = max(max_val, __shfl_xor_sync(~0, max_val, 4));
+    max_val = max(max_val, __shfl_xor_sync(~0, max_val, 8));
+    max_val = max(max_val, __shfl_xor_sync(~0, max_val, 16));
+#if defined(WS) && (WS == 64)
+    max_val = max(max_val, __shfl_xor_sync(~0, max_val, 32));
+#endif
+
+    // use approach yielding smaller max_val
+    if (lane == 0) {
+      // figure out number of bits needed
+      int cnt = 0;
+      if (max_val != 0) {
+        cnt = (sizeof(T) == 8) ? (64 - __clzll(max_val)) : (sizeof(unsigned int) * 8 - __clz((unsigned int)max_val));
+      }
+      bits[i] = cnt * (end - beg); // total bits of each chunk
+      ln[i] = cnt;  // logn value for each chunk
+    }
+  }
+  __syncthreads();
+
+  // warp prefix sum over bits
+  if (warp == 0) {
+    const int org = bits[lane];
+    int val = org;
+    int tmp = __shfl_up_sync(~0, val, 1);
+    if (lane >= 1) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 2);
+    if (lane >= 2) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 4);
+    if (lane >= 4) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 8);
+    if (lane >= 8) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 16);
+    if (lane >= 16) val += tmp;
+    bits[lane] = val - org;
+    if (lane == SC - 1) *total_bits = val;
+  }
+  __syncthreads();
+
+  // check if encoded data fits
+  const int extra = csize % sizeof(T);
+  const int newsize = (16 + CB * SC + *total_bits + 7) / 8;
+  if (newsize + extra >= CS) return false;
+
+  // clear out buffer
+  for (int i = tid; i < (newsize + sizeof(int) - 1) / sizeof(int); i += TPB) out_i[i] = 0;
+  __syncthreads();
+
+  // encode logn values
+  if (lane < SC) {
+    const int val = ln[lane];
+    const int loc = 16 + (CB * lane);
+    const int pos = loc / TB_i;
+    const int shift = loc % TB_i;
+    atomicOr_block(&out_i[pos], val << shift);
+    if (TB_i - CB < shift) {
+      atomicOr_block(&out_i[pos + 1], val >> (TB_i - shift));
+    }
+  }
+
+  // encode data values
+  for (int i = warp; i < SC; i += warps) {
+    const int logn = ln[i];
+    const int beg = i * size / SC;
+    const int end = (i + 1) * size / SC;
+    const int offs = 16 + CB * SC + bits[i];
+    for (int j = beg + lane; j < end; j += WS) {
+      const T val = in_t[j];
+      const int loc = offs + (j - beg) * logn;
+      if constexpr (sizeof(T) < 8) {
+        const int pos = loc / TB_i;
+        const int shift = loc % TB_i;
+        atomicOr_block(&out_i[pos], (unsigned int)val << shift);
+        if (TB_i - logn < shift) {
+          atomicOr_block(&out_i[pos + 1], (unsigned int)val >> (TB_i - shift));
+        }
+      } else {
+        long long* const out_l = (long long*)out;
+        const int pos = loc / TB;
+        const int shift = loc % TB;
+        atomicOr_block(&out_l[pos], val << shift);
+        if (TB - logn < shift) {
+          atomicOr_block(&out_l[pos + 1], val >> (TB - shift));
+        }
+      }
+    }
+  }
+  __syncthreads();
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    if (tid < extra) out[newsize + tid] = in[csize - extra + tid];
+  }
+
+  // record old csize
+  if (tid == 0) {
+    *((short*)out) = csize;
+  }
+  csize = newsize + extra;
+  return true;
+}
+
+
+template <typename T>
+static __device__ inline void d_iCLOG(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int tid = threadIdx.x;
+  const int lane = threadIdx.x % WS;
+  const int warp = threadIdx.x / WS;
+
+  assert(std::is_unsigned<T>::value);
+  const int TB = sizeof(T) * 8;  // number of bits in T
+  const int SC = 32;  // subchunks [do not change]
+  const int CB = (32 - __clz((int)sizeof(T))) + 3;  // counter bits
+  assert((1 << CB) > TB);
+  assert((1 << (CB - 1)) <= TB);
+  assert(WS >= SC);
+
+  // T casts
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  byte* const ln = (byte*)temp;
+  int* const bits = (int*)&temp[SC];
+  const int orig_csize = *((short*)in);
+  const int size = orig_csize / sizeof(T);
+
+  // decode logn values
+  const T mask = ((1 << CB) - 1);
+  if (warp == 0) {
+    T res = 0;
+    if (lane < SC) {
+      const int loc = 16 + (lane * CB);
+      const int pos = loc / TB;
+      const int shift = loc % TB;
+      res = in_t[pos] >> shift;
+      if (TB - CB < shift) {
+        res |= in_t[pos + 1] << (TB - shift);
+      }
+      res &= mask;
+      ln[lane] = res;
+    }
+
+    const int beg = lane * size / SC;
+    const int end = (lane + 1) * size / SC;
+    const int org = res * (end - beg);
+    int val = org;
+    int tmp = __shfl_up_sync(~0, val, 1);
+    if (lane >= 1) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 2);
+    if (lane >= 2) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 4);
+    if (lane >= 4) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 8);
+    if (lane >= 8) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 16);
+    if (lane >= 16) val += tmp;
+    bits[lane] = val - org;
+  }
+  __syncthreads();
+
+  // decode data values
+  for (int i = warp; i < SC; i += TPB / WS) {
+    const int logn = ln[i];
+    const int beg = i * size / SC;
+    const int end = (i + 1) * size / SC;
+    const T mask = (sizeof(T) < 8) ? ((1ULL << logn) - 1) : ((logn == 64) ? (~0ULL) : ((1ULL << logn) - 1));
+    const int offs = 16 + SC * CB + bits[i];
+    for (int j = beg + lane; j < end; j += WS) {
+      const int loc = offs + (j - beg) * logn;
+      const int pos = loc / TB;
+      const int shift = loc % TB;
+      T res = in_t[pos] >> shift;
+      if (TB - logn < shift) {
+        res |= in_t[pos + 1] << (TB - shift);
+      }
+      out_t[j] = res & mask;
+    }
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    const int extra = orig_csize % sizeof(T);
+    if (tid < extra) out[orig_csize - extra + tid] = in[csize - extra + tid];
+  }
+  csize = orig_csize;
+}
+
+
+#endif

--- a/include/lc/components/include/d_DIFF.h
+++ b/include/lc/components/include/d_DIFF.h
@@ -1,0 +1,101 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef GPU_DIFF
+#define GPU_DIFF
+
+
+template <typename T>
+static __device__ inline bool d_DIFF(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  const int tid = threadIdx.x;
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+
+  // compute difference sequence
+  for (int i = tid; i < size; i += TPB) {
+    const T prev = (i == 0) ? 0 : in_t[i - 1];
+    const T val = in_t[i];
+    out_t[i] = val - prev;
+  }
+
+  // copy leftover bytes at end
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  }
+  return true;
+}
+
+
+template <typename T>
+static __device__ inline void d_iDIFF(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  const int tid = threadIdx.x;
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  const int beg = tid * size / TPB;
+  const int end = (tid + 1) * size / TPB;
+
+  // compute local sums
+  T sum = 0;
+  for (int i = beg; i < end; i++) {
+    sum += in_t[i];
+  }
+
+  // compute prefix sum
+  sum = block_prefix_sum(sum, temp);
+
+  // compute intermediate values
+  for (int i = end - 1; i >= beg; i--) {
+    out_t[i] = sum;
+    sum -= in_t[i];
+  }
+
+  // copy leftover bytes at end
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/d_DIFFMS.h
+++ b/include/lc/components/include/d_DIFFMS.h
@@ -1,0 +1,105 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef GPU_DIFFMS
+#define GPU_DIFFMS
+
+
+template <typename T>
+static __device__ inline bool d_DIFFMS(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  const int tid = threadIdx.x;
+
+  // compute difference sequence
+  for (int i = tid; i < size; i += TPB) {
+    const T prev = (i == 0) ? 0 : in_t[i - 1];
+    const T val = in_t[i];
+    const T data = val - prev;
+    out_t[i] = (data << 1) ^ ((std::make_signed_t<T>)data) >> (sizeof(T) * 8 - 1);
+  }
+
+  // copy leftover bytes at end
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  }
+  return true;
+}
+
+
+template <typename T>
+static __device__ inline void d_iDIFFMS(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  const int tid = threadIdx.x;
+  const int beg = tid * size / TPB;
+  const int end = (tid + 1) * size / TPB;
+
+  // compute local sums
+  T sum = 0;
+  for (int i = beg; i < end; i++) {
+    const T data = in_t[i];
+    const T val = (data >> 1) ^ ((std::make_signed_t<T>)(data << (sizeof(T) * 8 - 1))) >> (sizeof(T) * 8 - 1);
+    sum += val;
+    in_t[i] = val;
+  }
+
+  // compute prefix sum
+  sum = block_prefix_sum(sum, temp);  // includes barrier
+
+  // compute intermediate values
+  for (int i = end - 1; i >= beg; i--) {
+    out_t[i] = sum;
+    sum -= in_t[i];
+  }
+
+  // copy leftover bytes at end
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/d_HCLOG.h
+++ b/include/lc/components/include/d_HCLOG.h
@@ -1,0 +1,302 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef GPU_HCLOG
+#define GPU_HCLOG
+
+
+template <typename T>
+static __device__ inline bool d_HCLOG(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int tid = threadIdx.x;
+  const int lane = threadIdx.x % WS;
+  const int warp = threadIdx.x / WS;
+  const int warps = TPB / WS;
+
+  assert(std::is_unsigned<T>::value);
+  const int TB = sizeof(T) * 8;  // number of bits in T
+  const int SC = 32;  // subchunks [do not change]
+  const int CB = (32 - __clz((int)sizeof(T))) + 3;  // counter bits
+  assert((1 << CB) > TB);
+  assert((1 << (CB - 1)) <= TB);
+  assert(WS >= SC);
+  assert(SC == sizeof(int) * 8);
+  assert(sizeof(int) == 4);
+
+  // T casts
+  T* const in_t = (T*)in;
+  int* const out_i = (int*)out;  // int
+  const int TB_i = sizeof(int) * 8;
+  const int size = csize / sizeof(T);
+
+  byte* const ln = temp;
+  int* const bits = (int*)&temp[SC];
+  int* const total_bits = (int*)&bits[WS];
+  if (tid == 0) out_i[0] = 0;  // flags = 0
+  __syncthreads();
+
+  // determine bits needed for each subchunk
+  for (int i = warp; i < SC; i += warps) {
+    const int beg = i * size / SC;
+    const int end = (i + 1) * size / SC;
+
+    T max_val1 = 0;
+    T max_val2 = 0;
+    // max of values for each thread
+    for (int j = beg + lane; j < end; j += WS) {
+      const T val1 = in_t[j];
+      const T val2 = (val1 << 1) ^ (((std::make_signed_t<T>)val1) >> (sizeof(T) * 8 - 1));  // TCMS
+      max_val1 = max(max_val1, val1);
+      max_val2 = max(max_val2, val2);
+    }
+
+    // warp level max
+    max_val1 = max(max_val1, __shfl_xor_sync(~0, max_val1, 1));
+    max_val1 = max(max_val1, __shfl_xor_sync(~0, max_val1, 2));
+    max_val1 = max(max_val1, __shfl_xor_sync(~0, max_val1, 4));
+    max_val1 = max(max_val1, __shfl_xor_sync(~0, max_val1, 8));
+    max_val1 = max(max_val1, __shfl_xor_sync(~0, max_val1, 16));
+#if defined(WS) && (WS == 64)
+    max_val1 = max(max_val1, __shfl_xor_sync(~0, max_val1, 32));
+#endif
+    max_val2 = max(max_val2, __shfl_xor_sync(~0, max_val2, 1));
+    max_val2 = max(max_val2, __shfl_xor_sync(~0, max_val2, 2));
+    max_val2 = max(max_val2, __shfl_xor_sync(~0, max_val2, 4));
+    max_val2 = max(max_val2, __shfl_xor_sync(~0, max_val2, 8));
+    max_val2 = max(max_val2, __shfl_xor_sync(~0, max_val2, 16));
+#if defined(WS) && (WS == 64)
+    max_val2 = max(max_val2, __shfl_xor_sync(~0, max_val2, 32));
+#endif
+
+    // use approach yielding smaller max_val
+    const T max_val = min(max_val1, max_val2);
+    if (lane == 0) {
+      if (max_val2 < max_val1) atomicOr_block(out_i, 1 << i);  // set flag
+
+      // figure out number of bits needed
+      int cnt = 0;
+      if (max_val != 0) {
+        cnt = (sizeof(T) == 8) ? (64 - __clzll(max_val)) : (sizeof(unsigned int) * 8 - __clz((unsigned int)max_val));
+      }
+      bits[i] = cnt * (end - beg); // total bits of each chunk
+      ln[i] = cnt;  // logn value for each chunk
+    }
+  }
+  __syncthreads();
+
+  // warp prefix sum over bits
+  if (warp == 0) {
+    const int org = bits[lane];
+    int val = org;
+    int tmp = __shfl_up_sync(~0, val, 1);
+    if (lane >= 1) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 2);
+    if (lane >= 2) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 4);
+    if (lane >= 4) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 8);
+    if (lane >= 8) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 16);
+    if (lane >= 16) val += tmp;
+    bits[lane] = val - org;
+    if (lane == SC - 1) *total_bits = val;
+  }
+  __syncthreads();
+
+  // check if encoded data fits
+  const int extra = csize % sizeof(T);
+  const int newsize = (SC + 16 + CB * SC + *total_bits + 7) / 8;
+  if (newsize + extra >= CS) return false;
+
+  // clear out buffer
+  for (int i = tid + 1; i < (newsize + sizeof(int) - 1) / sizeof(int); i += TPB) out_i[i] = 0;
+  __syncthreads();
+
+  // encode logn values
+  if (lane < SC) {
+    const int val = ln[lane];
+    const int loc = SC + 16 + (CB * lane);
+    const int pos = loc / TB_i;
+    const int shift = loc % TB_i;
+    atomicOr_block(&out_i[pos], val << shift);
+    if (TB_i - CB < shift) {
+      atomicOr_block(&out_i[pos + 1], val >> (TB_i - shift));
+    }
+  }
+
+  // encode data values
+  const int flags = out_i[0];
+  for (int i = warp; i < SC; i += warps) {
+    const int logn = ln[i];
+    const int beg = i * size / SC;
+    const int end = (i + 1) * size / SC;
+    const int offs = SC + 16 + CB * SC + bits[i];
+    const bool flag = flags & (1 << i);
+    for (int j = beg + lane; j < end; j += WS) {
+      T val = in_t[j];
+      if (flag) {
+        val = (val << 1) ^ (((std::make_signed_t<T>)val) >> (sizeof(T) * 8 - 1));  // TCMS
+      }
+      const int loc = offs + (j - beg) * logn;
+      if constexpr (sizeof(T) < 8) {
+        const int pos = loc / TB_i;
+        const int shift = loc % TB_i;
+        atomicOr_block(&out_i[pos], (unsigned int)val << shift);
+        if (TB_i - logn < shift) {
+          atomicOr_block(&out_i[pos + 1], (unsigned int)val >> (TB_i - shift));
+        }
+      } else {
+        long long* const out_l = (long long*)out;
+        const int pos = loc / TB;
+        const int shift = loc % TB;
+        atomicOr_block(&out_l[pos], val << shift);
+        if (TB - logn < shift) {
+          atomicOr_block(&out_l[pos + 1], val >> (TB - shift));
+        }
+      }
+    }
+  }
+  __syncthreads();
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    if (tid < extra) out[newsize + tid] = in[csize - extra + tid];
+  }
+
+  // record old csize
+  if (tid == 0) {
+    *((short*)&out[4]) = csize;
+  }
+  csize = newsize + extra;
+  return true;
+}
+
+
+template <typename T>
+static __device__ inline void d_iHCLOG(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int tid = threadIdx.x;
+  const int lane = threadIdx.x % WS;
+  const int warp = threadIdx.x / WS;
+
+  assert(std::is_unsigned<T>::value);
+  const int TB = sizeof(T) * 8;  // number of bits in T
+  const int SC = 32;  // subchunks [do not change]
+  const int CB = (32 - __clz((int)sizeof(T))) + 3;  // counter bits
+  assert((1 << CB) > TB);
+  assert((1 << (CB - 1)) <= TB);
+  assert(WS >= SC);
+
+  // T casts
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  byte* const ln = (byte*)temp;
+  int* const bits = (int*)&temp[SC];
+  const int orig_csize = *((short*)&in[4]);
+  const int size = orig_csize / sizeof(T);
+
+  // decode logn values
+  const int flags = *((int*)in);
+  const T mask = ((1 << CB) - 1);
+  if (warp == 0) {
+    T res = 0;
+    if (lane < SC) {
+      const int loc = SC + 16 + (lane * CB);
+      const int pos = loc / TB;
+      const int shift = loc % TB;
+      res = in_t[pos] >> shift;
+      if (TB - CB < shift) {
+        res |= in_t[pos + 1] << (TB - shift);
+      }
+      res &= mask;
+      ln[lane] = res;
+    }
+
+    const int beg = lane * size / SC;
+    const int end = (lane + 1) * size / SC;
+    const int org = res * (end - beg);
+    int val = org;
+    int tmp = __shfl_up_sync(~0, val, 1);
+    if (lane >= 1) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 2);
+    if (lane >= 2) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 4);
+    if (lane >= 4) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 8);
+    if (lane >= 8) val += tmp;
+    tmp = __shfl_up_sync(~0, val, 16);
+    if (lane >= 16) val += tmp;
+    bits[lane] = val - org;
+  }
+  __syncthreads();
+
+  // decode data values
+  for (int i = warp; i < SC; i += TPB / WS) {
+    const int logn = ln[i];
+    const int beg = i * size / SC;
+    const int end = (i + 1) * size / SC;
+    const T mask = (sizeof(T) < 8) ? ((1ULL << logn) - 1) : ((logn == 64) ? (~0ULL) : ((1ULL << logn) - 1));
+    const int offs = SC + 16 + SC * CB + bits[i];
+    const bool flag = flags & (1 << i);
+    for (int j = beg + lane; j < end; j += WS) {
+      const int loc = offs + (j - beg) * logn;
+      const int pos = loc / TB;
+      const int shift = loc % TB;
+      T res = in_t[pos] >> shift;
+      if (TB - logn < shift) {
+        res |= in_t[pos + 1] << (TB - shift);
+      }
+      T val = res & mask;
+      if (flag) {
+        val = (val >> 1) ^ ((std::make_signed_t<T>)(val << (sizeof(T) * 8 - 1))) >> (sizeof(T) * 8 - 1);  // iTCMS
+      }
+      out_t[j] = val;
+    }
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    const int extra = orig_csize % sizeof(T);
+    if (tid < extra) out[orig_csize - extra + tid] = in[csize - extra + tid];
+  }
+  csize = orig_csize;
+}
+
+
+#endif

--- a/include/lc/components/include/d_RLE.h
+++ b/include/lc/components/include/d_RLE.h
@@ -1,0 +1,224 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef GPU_RLE
+#define GPU_RLE
+
+
+template <typename T>
+static __device__ inline bool d_RLE(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  int* const s_tmp = (int*)temp;
+  const int elems = csize / (int)sizeof(T);
+  const int extra = csize % (int)sizeof(T);
+  const int tid = threadIdx.x;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+  const int beg = tid * elems / TPB;
+  const int end = (tid + 1) * elems / TPB;
+  assert(CS / (int)sizeof(T) / TPB <= (int)sizeof(int) * 8);
+
+  // count non-repeating values and perform local max scan
+  const T first = (beg == 0) ? (~in_t[0]) : in_t[beg - 1];
+  int bmp = 0;
+  int msk = 0;
+  int loc = -1;
+  int nrepeat = 0;
+  T prev = first;
+  T curr = (beg < end) ? in_t[beg] : 0;
+  for (int i = beg; i < end; i++) {
+    const T next = (i + 1 < elems) ? in_t[i + 1] : 0;
+    const int shft = 1 << (i - beg);
+    if (prev != curr) {
+      nrepeat++;
+      msk |= shft;
+    }
+    if (((prev == curr) != (curr == next)) || (i + 1 == elems)) {
+      loc = i;
+      bmp |= shft;
+    }
+    prev = curr;
+    curr = next;
+  }
+
+  // compute inclusive prefix sum and make exclusive
+  int vpos = block_prefix_sum(nrepeat, &s_tmp[WS]) - nrepeat;
+
+  // compute inclusive max scan and make exclusive (with -1)
+  const int msres = block_max_scan(loc, &s_tmp[0]);
+  int prevmax = __shfl_up_sync(~0, msres, 1);
+  if (lane == 0) prevmax = (warp == 0) ? -1 : s_tmp[warp - 1];
+
+  // output non-repeating values and determine number of counters
+  int cnt = 0;
+  int prior = prevmax;
+  prev = first;
+  for (int i = beg; i < end; i++) {
+    const T curr = in_t[i];
+    if (prev != curr) {
+      out_t[vpos++] = curr;
+    }
+    prev = curr;
+    if (bmp & (1 << (i - beg))) {
+      const int dist = i - prior;
+      prior = i;
+      cnt += (dist + 127) / 128;
+    }
+  }
+
+  // compute prefix sum
+  int cpos = block_prefix_sum(cnt, &s_tmp[WS * 2]);
+  const int tot = vpos * (int)sizeof(T) + extra + cpos + 2;
+  if (tid == TPB - 1) {
+    s_tmp[WS * 3] = vpos * (int)sizeof(T) + extra;
+    s_tmp[WS * 3 + 1] = tot;
+  }
+  if (__syncthreads_or(tot >= CS)) return false;
+
+  // copy leftover bytes
+  const int wpos = s_tmp[WS * 3];
+  if (tid < extra) {
+    out[wpos - extra + tid] = in[csize - extra + tid];
+  }
+  csize = s_tmp[WS * 3 + 1];
+
+  // write counts to output
+  cpos -= cnt;
+  prior = prevmax;
+  for (int i = beg; i < end; i++) {
+    const int shft = 1 << (i - beg);
+    if (bmp & shft) {
+      const byte mask = (msk & shft) ? 0x00 : 0x80;
+      int dist = i - prior;
+      prior = i;
+      while (dist > 0) {
+        const int rep = min(128, dist);
+        out[wpos + cpos++] = (mask | (rep - 1));
+        dist -= rep;
+      }
+    }
+  }
+
+  // store position where counts start
+  if (tid == TPB - 1) {
+    out[csize - 2] = (wpos & 0xff);
+    out[csize - 1] = ((wpos >> 8) & 0xff);
+  }
+  return true;
+}
+
+
+template <typename T>
+static __device__ inline void d_iRLE(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  const int cpos = (((int)in[csize - 1]) << 8) | in[csize - 2];
+  const int extra = cpos % (int)sizeof(T);
+  const int tid = threadIdx.x;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+  const int warps = TPB / WS;
+
+  int rpos = 0;
+  int wpos = 0;
+  int bot = cpos;
+  int top = (cpos & ~(warps - 1)) + warp;
+  if (top < cpos) top += warps;
+
+  while (bot < csize - 2) {
+    int rsum = 0;
+    int wsum = 0;
+    int pos = top - WS + lane;
+    if ((bot <= pos) && (pos < csize - 2)) {
+      const int rep = in[pos];  // int instead of byte
+      const int repeat = (rep & 0x7f) + 1;
+      wsum += repeat;
+      if ((rep & 0x80) == 0) rsum += repeat;
+    }
+    rsum += __shfl_xor_sync(~0, rsum, 1);
+    rsum += __shfl_xor_sync(~0, rsum, 2);
+    rsum += __shfl_xor_sync(~0, rsum, 4);
+    rsum += __shfl_xor_sync(~0, rsum, 8);
+    rsum += __shfl_xor_sync(~0, rsum, 16);
+#if defined(WS) && (WS == 64)
+    rsum += __shfl_xor_sync(~0, rsum, 32);
+#endif
+    wsum += __shfl_xor_sync(~0, wsum, 1);
+    wsum += __shfl_xor_sync(~0, wsum, 2);
+    wsum += __shfl_xor_sync(~0, wsum, 4);
+    wsum += __shfl_xor_sync(~0, wsum, 8);
+    wsum += __shfl_xor_sync(~0, wsum, 16);
+#if defined(WS) && (WS == 64)
+    wsum += __shfl_xor_sync(~0, wsum, 32);
+#endif
+    rpos += rsum;
+    wpos += wsum;
+
+    if (top < csize - 2) {
+      const int rep = in[top];  // int instead of byte
+      if (rep & 0x80) {
+        // write repeating values
+        const int repeat = (rep & 0x7f) + 1;
+        const T val = in_t[rpos - 1];
+        for (int j = lane; j < repeat; j += WS) {
+          out_t[wpos + j] = val;
+        }
+      } else {
+        // write non-repeating values
+        const int nrepeat = rep + 1;
+        for (int j = lane; j < nrepeat; j += WS) {
+          out_t[wpos + j] = in_t[rpos + j];
+        }
+      }
+    }
+
+    bot = top;
+    top += warps;
+  }
+
+  // copy leftover bytes
+  csize = wpos * (int)sizeof(T) + extra;
+  if (tid < extra) out[csize - extra + tid] = in[cpos - extra + tid];
+}
+
+
+#endif

--- a/include/lc/components/include/d_RRE.h
+++ b/include/lc/components/include/d_RRE.h
@@ -1,0 +1,208 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef GPU_RRE
+#define GPU_RRE
+
+
+#include "d_repetition_elimination.h"
+
+
+template <typename T>
+static __device__ inline bool d_RRE(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int tid = threadIdx.x;
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  const int extra = csize % sizeof(T);
+  const int avail = CS - 2 - extra;
+  const int bits = 8 * sizeof(T);
+  assert(CS == 16384);
+
+  // zero out end of bitmap
+  int* const temp_w = (int*)temp;
+  byte* const bitmap = (byte*)&temp_w[WS + 1];
+  if (csize < CS) {
+    for (int i = csize / bits + tid; i < CS / bits; i += TPB) {
+      bitmap[i] = 0;
+    }
+    __syncthreads();
+  }
+
+  // copy non-repeating values and generate bitmap
+  int wpos = 0;
+  if (size > 0) d_REencode((T*)in, size, (T*)out, wpos, (T*)bitmap, temp_w);
+  wpos *= sizeof(T);
+  if (wpos >= avail) return false;
+  __syncthreads();
+
+  // check if not all zeros
+  if (wpos != 0) {
+    // iteratively compress bitmaps
+    int base = 0 / sizeof(T);
+    int range = 2048 / sizeof(T);
+    int cnt = avail - wpos;
+    if (!d_REencode<byte, 2048 / sizeof(T), true>(&bitmap[base], range, &out[wpos], cnt, &bitmap[base + range], temp_w)) return false;
+    wpos += cnt;
+    __syncthreads();
+
+    base = 2048 / sizeof(T);
+    range = 256 / sizeof(T);
+    cnt = avail - wpos;
+    if (!d_REencode<byte, 256 / sizeof(T), true>(&bitmap[base], range, &out[wpos], cnt, &bitmap[base + range], temp_w)) return false;
+    wpos += cnt;
+    __syncthreads();
+
+    base = (2048 + 256) / sizeof(T);
+    range = 32 / sizeof(T);
+    if constexpr (sizeof(T) < 8) {
+      cnt = avail - wpos;
+      if (!d_REencode<byte, 32 / sizeof(T), true>(&bitmap[base], range, &out[wpos], cnt, &bitmap[base + range], temp_w)) return false;
+      wpos += cnt;
+
+      base = (2048 + 256 + 32) / sizeof(T);
+      range = 4 / sizeof(T);
+    }
+
+    // output last level of bitmap
+    if (wpos >= avail - range) return false;
+    if (tid < range) {  // 4 / sizeof(T)
+      out[wpos + tid] = bitmap[base + tid];
+    }
+    wpos += range;
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    if (tid < extra) out[wpos + tid] = in[csize - extra + tid];
+  }
+
+  // output old csize and update csize
+  const int new_size = wpos + 2 + extra;
+  if (tid == 0) {
+    out[new_size - 2] = csize;  // bottom byte
+    out[new_size - 1] = csize >> 8;  // second byte
+  }
+  csize = new_size;
+  return true;
+}
+
+
+template <typename T>
+static __device__ inline void d_iRRE(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int tid = threadIdx.x;
+  int rpos = csize;
+  csize = (int)in[--rpos] << 8;  // second byte
+  csize |= in[--rpos];  // bottom byte
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  assert(CS == 16384);
+  assert(TPB >= 256);
+
+  // copy leftover byte
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    if (tid < extra) out[csize - extra + tid] = in[rpos - extra + tid];
+    rpos -= extra;
+  }
+
+  if (rpos == 0) {
+    // all zeros
+    T* const out_t = (T*)out;
+    for (int i = tid; i < size; i += TPB) {
+      out_t[i] = 0;
+    }
+  } else {
+    int* const temp_w = (int*)temp;
+    byte* const bitmap = (byte*)&temp_w[WS];
+
+    // iteratively decompress bitmaps
+    int base, range;
+    if constexpr (sizeof(T) == 8) {
+      base = (2048 + 256) / sizeof(T);
+      range = 32 / sizeof(T);
+      // read in last level of bitmap
+      rpos -= range;
+      if (tid < range) bitmap[base + tid] = in[rpos + tid];
+    } else {
+      base = (2048 + 256 + 32) / sizeof(T);
+      range = 4 / sizeof(T);
+      // read in last level of bitmap
+      rpos -= range;
+      if (tid < range) bitmap[base + tid] = in[rpos + tid];
+
+      rpos -= __syncthreads_count((tid < range * 8) && ((in[rpos + tid / 8] >> (tid % 8)) & 1));
+      base = (2048 + 256) / sizeof(T);
+      range = 32 / sizeof(T);
+      d_REdecode<byte, 32 / sizeof(T)>(range, &in[rpos], &bitmap[base + range], &bitmap[base], temp_w);
+    }
+    __syncthreads();
+
+    rpos -= __syncthreads_count((tid < range * 8) && ((bitmap[base + tid / 8] >> (tid % 8)) & 1));
+    base = 2048 / sizeof(T);
+    range = 256 / sizeof(T);
+    d_REdecode<byte, 256 / sizeof(T)>(range, &in[rpos], &bitmap[base + range], &bitmap[base], temp_w);
+    __syncthreads();
+
+    if constexpr (sizeof(T) >= 4) {
+      rpos -= __syncthreads_count((tid < range * 8) && ((bitmap[base + tid / 8] >> (tid % 8)) & 1));
+    }
+    if constexpr (sizeof(T) == 2) {
+      int sum = __syncthreads_count((tid < range * 8) && ((bitmap[base + tid / 8] >> (tid % 8)) & 1));
+      sum += __syncthreads_count((tid + TPB < range * 8) && ((bitmap[base + (tid + TPB) / 8] >> (tid % 8)) & 1));
+      rpos -= sum;
+    }
+    if constexpr (sizeof(T) == 1) {
+      int sum = 0;
+      for (int i = 0; i < TPB * 4; i += TPB) {
+        sum += __syncthreads_count((tid + i < range * 8) && ((bitmap[base + (tid + i) / 8] >> (tid % 8)) & 1));
+      }
+      rpos -= sum;
+    }
+    base = 0 / sizeof(T);
+    range = 2048 / sizeof(T);
+    d_REdecode<byte, 2048 / sizeof(T)>(range, &in[rpos], &bitmap[base + range], &bitmap[base], temp_w);
+    __syncthreads();
+
+    // copy non-repeating values based on bitmap
+    if (size > 0) d_REdecode(size, (T*)in, (T*)bitmap, (T*)out, temp_w);
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/d_RZE.h
+++ b/include/lc/components/include/d_RZE.h
@@ -1,0 +1,209 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef GPU_RZE
+#define GPU_RZE
+
+
+#include "d_zero_elimination.h"
+#include "d_repetition_elimination.h"
+
+
+template <typename T>
+static __device__ inline bool d_RZE(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int tid = threadIdx.x;
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  const int extra = csize % sizeof(T);
+  const int avail = CS - 2 - extra;
+  const int bits = 8 * sizeof(T);
+  assert(CS == 16384);
+
+  // zero out end of bitmap
+  int* const temp_w = (int*)temp;
+  byte* const bitmap = (byte*)&temp_w[WS + 1];
+  if (csize < CS) {
+    for (int i = csize / bits + tid; i < CS / bits; i += TPB) {
+      bitmap[i] = 0;
+    }
+    __syncthreads();
+  }
+
+  // copy non-zero values and generate bitmap
+  int wpos = 0;
+  if (size > 0) d_ZEencode((T*)in, size, (T*)out, wpos, (T*)bitmap, temp_w);
+  wpos *= sizeof(T);
+  if (wpos >= avail) return false;
+  __syncthreads();
+
+  // check if not all zeros
+  if (wpos != 0) {
+    // iteratively compress bitmaps
+    int base = 0 / sizeof(T);
+    int range = 2048 / sizeof(T);
+    int cnt = avail - wpos;
+    if (!d_REencode<byte, 2048 / sizeof(T), true>(&bitmap[base], range, &out[wpos], cnt, &bitmap[base + range], temp_w)) return false;
+    wpos += cnt;
+    __syncthreads();
+
+    base = 2048 / sizeof(T);
+    range = 256 / sizeof(T);
+    cnt = avail - wpos;
+    if (!d_REencode<byte, 256 / sizeof(T), true>(&bitmap[base], range, &out[wpos], cnt, &bitmap[base + range], temp_w)) return false;
+    wpos += cnt;
+    __syncthreads();
+
+    base = (2048 + 256) / sizeof(T);
+    range = 32 / sizeof(T);
+    if constexpr (sizeof(T) < 8) {
+      cnt = avail - wpos;
+      if (!d_REencode<byte, 32 / sizeof(T), true>(&bitmap[base], range, &out[wpos], cnt, &bitmap[base + range], temp_w)) return false;
+      wpos += cnt;
+
+      base = (2048 + 256 + 32) / sizeof(T);
+      range = 4 / sizeof(T);
+    }
+
+    // output last level of bitmap
+    if (wpos >= avail - range) return false;
+    if (tid < range) {  // 4 / sizeof(T)
+      out[wpos + tid] = bitmap[base + tid];
+    }
+    wpos += range;
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    if (tid < extra) out[wpos + tid] = in[csize - extra + tid];
+  }
+
+  // output old csize and update csize
+  const int new_size = wpos + 2 + extra;
+  if (tid == 0) {
+    out[new_size - 2] = csize;  // bottom byte
+    out[new_size - 1] = csize >> 8;  // second byte
+  }
+  csize = new_size;
+  return true;
+}
+
+
+template <typename T>
+static __device__ inline void d_iRZE(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  const int tid = threadIdx.x;
+  int rpos = csize;
+  csize = (int)in[--rpos] << 8;  // second byte
+  csize |= in[--rpos];  // bottom byte
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  assert(CS == 16384);
+  assert(TPB >= 256);
+
+  // copy leftover byte
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    if (tid < extra) out[csize - extra + tid] = in[rpos - extra + tid];
+    rpos -= extra;
+  }
+
+  if (rpos == 0) {
+    // all zeros
+    T* const out_t = (T*)out;
+    for (int i = tid; i < size; i += TPB) {
+      out_t[i] = 0;
+    }
+  } else {
+    int* const temp_w = (int*)temp;
+    byte* const bitmap = (byte*)&temp_w[WS];
+
+    // iteratively decompress bitmaps
+    int base, range;
+    if constexpr (sizeof(T) == 8) {
+      base = (2048 + 256) / sizeof(T);
+      range = 32 / sizeof(T);
+      // read in last level of bitmap
+      rpos -= range;
+      if (tid < range) bitmap[base + tid] = in[rpos + tid];
+    } else {
+      base = (2048 + 256 + 32) / sizeof(T);
+      range = 4 / sizeof(T);
+      // read in last level of bitmap
+      rpos -= range;
+      if (tid < range) bitmap[base + tid] = in[rpos + tid];
+
+      rpos -= __syncthreads_count((tid < range * 8) && ((in[rpos + tid / 8] >> (tid % 8)) & 1));
+      base = (2048 + 256) / sizeof(T);
+      range = 32 / sizeof(T);
+      d_REdecode<byte, 32 / sizeof(T)>(range, &in[rpos], &bitmap[base + range], &bitmap[base], temp_w);
+    }
+    __syncthreads();
+
+    rpos -= __syncthreads_count((tid < range * 8) && ((bitmap[base + tid / 8] >> (tid % 8)) & 1));
+    base = 2048 / sizeof(T);
+    range = 256 / sizeof(T);
+    d_REdecode<byte, 256 / sizeof(T)>(range, &in[rpos], &bitmap[base + range], &bitmap[base], temp_w);
+    __syncthreads();
+
+    if constexpr (sizeof(T) >= 4) {
+      rpos -= __syncthreads_count((tid < range * 8) && ((bitmap[base + tid / 8] >> (tid % 8)) & 1));
+    }
+    if constexpr (sizeof(T) == 2) {
+      int sum = __syncthreads_count((tid < range * 8) && ((bitmap[base + tid / 8] >> (tid % 8)) & 1));
+      sum += __syncthreads_count((tid + TPB < range * 8) && ((bitmap[base + (tid + TPB) / 8] >> (tid % 8)) & 1));
+      rpos -= sum;
+    }
+    if constexpr (sizeof(T) == 1) {
+      int sum = 0;
+      for (int i = 0; i < TPB * 4; i += TPB) {
+        sum += __syncthreads_count((tid + i < range * 8) && ((bitmap[base + (tid + i) / 8] >> (tid % 8)) & 1));
+      }
+      rpos -= sum;
+    }
+    base = 0 / sizeof(T);
+    range = 2048 / sizeof(T);
+    d_REdecode<byte, 2048 / sizeof(T)>(range, &in[rpos], &bitmap[base + range], &bitmap[base], temp_w);
+    __syncthreads();
+
+    // copy non-zero values based on bitmap
+    if (size > 0) d_ZEdecode(size, (T*)in, (T*)bitmap, (T*)out, temp_w);
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/d_TCMS.h
+++ b/include/lc/components/include/d_TCMS.h
@@ -1,0 +1,91 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef GPU_TCMS
+#define GPU_TCMS
+
+
+template <typename T>
+static __device__ inline bool d_TCMS(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  const int size = csize / sizeof(T);
+  const int tid = threadIdx.x;
+
+  // convert from twos-complement to magnitude-sign format
+  for (int i = tid; i < size; i += TPB) {
+    const T data = in_t[i];
+    const T s = ((std::make_signed_t<T>)data) >> (sizeof(T) * 8 - 1);
+    out_t[i] = (data << 1) ^ s;
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  }
+  return true;
+}
+
+
+template <typename T>
+static __device__ inline void d_iTCMS(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  const int size = csize / sizeof(T);
+  const int tid = threadIdx.x;
+
+  // convert from magnitude-sign to twos-complement format
+  for (int i = tid; i < size; i += TPB) {
+    const T data = in_t[i];
+    const T s = ((std::make_signed_t<T>)(data << (sizeof(T) * 8 - 1))) >> (sizeof(T) * 8 - 1);
+    out_t[i] = (data >> 1) ^ s;
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    if (tid < extra) out[csize - extra + tid] = in[csize - extra + tid];
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/d_TUPL.h
+++ b/include/lc/components/include/d_TUPL.h
@@ -1,0 +1,87 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef GPU_TUPL
+#define GPU_TUPL
+
+
+template <typename T, int dim>
+static __device__ inline bool d_TUPL(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  assert(dim > 1);
+  const int tid = threadIdx.x;
+  const int tuples = csize / sizeof(T) / dim;  // tuples in chunk (rounded down)
+  const int size = tuples * dim;  // words in all tuples
+  const int extra = csize - sizeof(T) * size;  // leftover bytes
+  T* const buf_in = (T*)in;  // type cast
+  T* const buf_out = (T*)out;  // type cast
+
+  // copy leftover bytes
+  if (tid < extra) out[sizeof(T) * size + tid] = in[sizeof(T) * size + tid];
+
+  // distribute fields of structs
+  for (int i = tid; i < size; i += TPB) {
+    buf_out[(i / dim) + (i % dim) * tuples] = buf_in[i];
+  }
+  return true;
+}
+
+
+template <typename T, int dim>
+static __device__ inline void d_iTUPL(int& csize, byte in [CS], byte out [CS], byte temp [CS])
+{
+  assert(dim > 1);
+  const int tid = threadIdx.x;
+  const int tuples = csize / sizeof(T) / dim;  // tuples in chunk (rounded down)
+  const int size = tuples * dim;  // words in all tuples
+  const int extra = csize - sizeof(T) * size;  // leftover bytes
+  T* const buf_in = (T*)in;  // type cast
+  T* const buf_out = (T*)out;  // type cast
+
+  // copy leftover bytes
+  if (tid < extra) out[sizeof(T) * size + tid] = in[sizeof(T) * size + tid];
+
+  // recombine fields of structs
+  for (int i = tid; i < size; i += TPB) {
+    buf_out[i] = buf_in[(i / dim) + (i % dim) * tuples];
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/d_repetition_elimination.h
+++ b/include/lc/components/include/d_repetition_elimination.h
@@ -1,0 +1,878 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef repetition_elimination_device
+#define repetition_elimination_device
+
+
+//special case for byte and short data
+template <typename T, bool check = false>
+static __device__ inline bool d_REencodebyteshort(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  using type = T;
+  using ull = unsigned long long;
+  const int bitsperword = 8 * sizeof(type);
+  const int bitsperlong = 8 * sizeof(ull);
+  const int wordsperlong = bitsperlong / bitsperword;
+  const int bytesperthread = CS / TPB;
+  const ull* const in_l = (ull*)in;
+  const int csize = insize * sizeof(T);
+  assert(bytesperthread % sizeof(ull) == 0);
+  assert(bytesperthread / sizeof(type) <= sizeof(int) * 8);
+  assert(bytesperthread / sizeof(ull) * wordsperlong >= 8);
+  assert(std::is_unsigned<type>::value);
+
+  // output bitmaps and count non-repeating values
+  const int tid = threadIdx.x;
+  int bmp = 0, cnt = 0;
+  if (tid * bytesperthread < csize) {
+    type prev = (tid == 0) ? 0 : in[tid * (bytesperthread / sizeof(type)) - 1];
+    for (int i = 0; i < bytesperthread / sizeof(ull); i++) {
+      const ull lval = in_l[tid * (bytesperthread / sizeof(ull)) + i];
+      const ull pval = (bitsperword < bitsperlong) ? ((lval << bitsperword) | prev) : prev;
+      int bm = 0;
+      for (int j = 0; j < wordsperlong; j++) {
+        const type val = lval >> (j * bitsperword);
+        const type prv = pval >> (j * bitsperword);
+        bm |= (val != prv) << j;
+      }
+      prev = lval >> (bitsperlong - bitsperword);
+      bmp |= bm << (i * wordsperlong);
+    }
+    if (tid * bytesperthread - (csize - bytesperthread) > 0) {
+      bmp &= ~(-1 << ((csize % bytesperthread + sizeof(type) - 1) / sizeof(type)));
+    }
+    //if constexpr (sizeof(type) == 1) ((int*)bmout)[tid] = bmp;
+    if constexpr (sizeof(type) == 1) {
+      bmout[tid * 4] = bmp;
+      bmout[tid * 4 + 1] = bmp >> 8;
+      bmout[tid * 4 + 2] = bmp >> 16;
+      bmout[tid * 4 + 3] = bmp >> 24;
+    }
+    if constexpr (sizeof(type) == 2) bmout[tid] = bmp;
+    if constexpr (sizeof(type) == 4) ((byte*)bmout)[tid] = bmp;
+    cnt = __popc(bmp);
+  }
+
+  int pos = block_prefix_sum(cnt, temp_w);
+  if (tid == TPB - 1) temp_w[WS] = pos;
+  if constexpr (check) {
+    if (__syncthreads_or(pos > datasize)) return false;
+  } else {
+    __syncthreads();
+  }
+  pos -= cnt;
+
+  // output non-repeating values
+  if (bmp != 0) {
+    for (int i = 0; i < bytesperthread / sizeof(ull); i++) {
+      const ull lval = in_l[tid * (bytesperthread / sizeof(ull)) + i];
+      const int bm = bmp >> (i * wordsperlong);
+      for (int j = 0; j < wordsperlong; j++) {
+        if ((bm >> j) & 1) {
+          dataout[pos++] = lval >> (j * bitsperword);
+        }
+      }
+    }
+  }
+
+  datasize = temp_w[WS];
+  return true;
+}
+
+
+//warp-based one word per thread
+template <typename T, bool check = false>
+static __device__ inline bool d_REencode1wordperthread(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  byte* const bmout_b = (byte*)bmout;
+  const int tid = threadIdx.x;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // count non-repeating values and output bitmaps
+  const bool active = (tid < insize);
+  const T prev = !active ? 0 : ((tid == 0) ? 0 : in[tid - 1]);
+  const T val = active ? in[tid] : 0;
+  const bool havenonrepval = (active && (val != prev));
+#if defined(WS) && (WS == 64)
+  const unsigned long long tmp = __ballot_sync(~0, havenonrepval);
+  const int bm = (lane < 32) ? (int)tmp : (int)(tmp >> 32);
+#else
+  const int bm = __ballot_sync(~0, havenonrepval);
+#endif
+  const int cnt = __popc(bm);
+  const int subwarps = TPB / 32;
+#if defined(WS) && (WS == 64)
+  const int sublane = lane & 31;
+  const int subwarp = threadIdx.x / 32;
+  if (active && (sublane % 8 == 0)) bmout_b[tid / 8] = bm >> sublane;
+#else
+  const int sublane = lane;
+  const int subwarp = warp;
+  if (active && (lane % 8 == 0)) bmout_b[tid / 8] = bm >> lane;
+#endif
+  if constexpr (sizeof(T) > 1) {  //MB: (never used) maybe somewhere else zero out last word of bitmap before a barrier and calling this function?
+    if (warp == 0) {
+      const int base = (insize + 7) / 8;
+      const int top = (insize + (sizeof(T) * 8 - 1)) / 8;
+      if (base + tid < top) bmout_b[base + tid] = 0;
+    }
+  }
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  if constexpr (check) {
+    if (__syncthreads_or(sum > datasize)) return false;
+  } else {
+    __syncthreads();
+  }
+
+  // output non-repeating values
+  if (havenonrepval) {
+    const int loc = temp_w[subwarp] - cnt + __popc(bm & ((1 << sublane) - 1));
+    dataout[loc] = val;
+  }
+
+  datasize = temp_w[subwarps - 1];
+  return true;
+}
+
+
+//warp-based two words per thread
+template <typename T, bool check = false>
+static __device__ inline bool d_REencode2wordsperthread(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  byte* const bmout_b = (byte*)bmout;
+  const int tid = threadIdx.x;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // count non-repeating values and output bitmaps
+  const int tid1 = tid * 2;
+  const int tid2 = tid1 + 1;
+  const bool active1 = (tid1 < insize);
+  const bool active2 = (tid2 < insize);
+  const T prev = (!active1) ? 0 : ((tid1 == 0) ? 0 : in[tid1 - 1]);
+  const T val1 = active1 ? in[tid1] : 0;
+  const T val2 = active2 ? in[tid2] : 0;
+  const bool havenonrepval1 = (active1 && (val1 != prev));
+  const bool havenonrepval2 = (active2 && (val2 != val1));
+#if defined(WS) && (WS == 64)
+  const unsigned long long temp = __ballot_sync(~0, havenonrepval1);
+  const int bm1 = (lane < 32) ? (int)temp : (int)(temp >> 32);
+  const unsigned long long temp1 = __ballot_sync(~0, havenonrepval2);
+  const int bm2 = (lane < 32) ? (int)temp1 : (int)(temp1 >> 32);
+#else
+  const int bm1 = __ballot_sync(~0, havenonrepval1);
+  const int bm2 = __ballot_sync(~0, havenonrepval2);
+#endif
+  const int cnt = __popc(bm1) + __popc(bm2);
+  const int comb = havenonrepval1 + havenonrepval2 * 2;
+#if defined(WS) && (WS == 64)
+  const int sublane = lane & 31;
+  const int tmp1 = __shfl_sync(~0, comb, sublane / 2, 32) >> (lane % 2);
+  const unsigned long long temp2 = __ballot_sync(~0, tmp1 & 1);
+  const int bmlo = (lane < 32) ? (int)temp2 : (int)(temp2 >> 32);
+#else
+  const int sublane = lane;
+  const int tmp1 = __shfl_sync(~0, comb, lane / 2) >> (lane % 2);
+  const int bmlo = __ballot_sync(~0, tmp1 & 1);
+#endif
+#if defined(WS) && (WS == 64)
+  const int tmp2 = __shfl_sync(~0, comb, 16 + sublane / 2, 32) >> (lane % 2);
+  const unsigned long long temp3 =  __ballot_sync(~0, tmp2 & 1);
+  const int bmhi = (lane < 32) ? (int)temp3 : (int)(temp3 >> 32);
+#else
+  const int tmp2 = __shfl_sync(~0, comb, 16 + lane / 2) >> (lane % 2);
+  const int bmhi = __ballot_sync(~0, tmp2 & 1);
+#endif
+  const int subwarps = TPB / 32;
+#if defined(WS) && (WS == 64)
+  const int subwarp = threadIdx.x / 32;
+  if ((((__ballot_sync(~0, active1) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 8 + sublane / 8] = bmlo >> sublane;
+  if ((((__ballot_sync(~0, active2) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 8 + sublane / 8 + 4] = bmhi >> sublane;
+#else
+  const int subwarp = warp;
+  if (__any_sync(~0, active1) && (lane % 8 == 0)) bmout_b[warp * 8 + lane / 8] = bmlo >> lane;
+  if (__any_sync(~0, active2) && (lane % 8 == 0)) bmout_b[warp * 8 + lane / 8 + 4] = bmhi >> lane;
+#endif
+  if constexpr (sizeof(T) > 1) {  //MB: (never used) maybe somewhere else zero out last word of bitmap before a barrier and calling this function?
+    if (warp == 0) {
+      const int base = (insize + 7) / 8;
+      const int top = (insize + (sizeof(T) * 8 - 1)) / 8;
+      if (base + tid < top) bmout_b[base + tid] = 0;
+    }
+  }
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  if constexpr (check) {
+    if (__syncthreads_or(sum > datasize)) return false;
+  } else {
+    __syncthreads();
+  }
+
+  // output non-repeating values
+  int loc = temp_w[subwarp] - cnt + __popc(bm1 & ((1 << sublane) - 1)) + __popc(bm2 & ((1 << sublane) - 1));
+  if (havenonrepval1) dataout[loc++] = val1;
+  if (havenonrepval2) dataout[loc] = val2;
+
+  datasize = temp_w[subwarps - 1];
+  return true;
+}
+
+
+//warp-based four words per thread
+template <typename T, bool check = false>
+static __device__ inline bool d_REencode4wordsperthread(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  byte* const bmout_b = (byte*)bmout;
+  const int tid = threadIdx.x;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // count non-repeating values and output bitmaps
+  const int tid1 = tid * 4;
+  const int tid2 = tid1 + 1;
+  const int tid3 = tid2 + 1;
+  const int tid4 = tid3 + 1;
+  const bool active1 = (tid1 < insize);
+  const bool active2 = (tid2 < insize);
+  const bool active3 = (tid3 < insize);
+  const bool active4 = (tid4 < insize);
+  const T prev = !active1 ? 0 : ((tid1 == 0) ? 0 : in[tid1 - 1]);
+  const T val1 = active1 ? in[tid1] : 0;
+  const T val2 = active2 ? in[tid2] : 0;
+  const T val3 = active3 ? in[tid3] : 0;
+  const T val4 = active4 ? in[tid4] : 0;
+  const bool havenonrepval1 = (active1 && (val1 != prev));
+  const bool havenonrepval2 = (active2 && (val2 != val1));
+  const bool havenonrepval3 = (active3 && (val3 != val2));
+  const bool havenonrepval4 = (active4 && (val4 != val3));
+#if defined(WS) && (WS == 64)
+  const unsigned long long temp1 = __ballot_sync(~0, havenonrepval1);
+  const int bm1 = (lane < 32) ? (int)temp1 : (int)(temp1 >> 32);
+  const unsigned long long temp2 = __ballot_sync(~0, havenonrepval2);
+  const int bm2 = (lane < 32) ? (int)temp2 : (int)(temp2 >> 32);
+  const unsigned long long temp3 = __ballot_sync(~0, havenonrepval3);
+  const int bm3 = (lane < 32) ? (int)temp3 : (int)(temp3 >> 32);
+  const unsigned long long temp4 =  __ballot_sync(~0, havenonrepval4);
+  const int bm4 = (lane < 32) ? (int)temp4 : (int)(temp4 >> 32);
+#else
+  const int bm1 = __ballot_sync(~0, havenonrepval1);
+  const int bm2 = __ballot_sync(~0, havenonrepval2);
+  const int bm3 = __ballot_sync(~0, havenonrepval3);
+  const int bm4 = __ballot_sync(~0, havenonrepval4);
+#endif
+  const int cnt = __popc(bm1) + __popc(bm2) + __popc(bm3) + __popc(bm4);
+  const int comb = havenonrepval1 + havenonrepval2 * 2 + havenonrepval3 * 4 + havenonrepval4 * 8;
+#if defined(WS) && (WS == 64)
+  const int sublane = lane & 31;
+  const int tmp1 = __shfl_sync(~0, comb, sublane / 4, 32) >> (lane % 4);
+  const unsigned long long temp5 = __ballot_sync(~0, tmp1 & 1);
+  const int bmA = (lane < 32) ? (int)temp5 : (int)(temp5 >> 32);
+#else
+  const int sublane = lane;
+  const int tmp1 = __shfl_sync(~0, comb, lane / 4) >> (lane % 4);
+  const int bmA = __ballot_sync(~0, tmp1 & 1);
+#endif
+#if defined(WS) && (WS == 64)
+  const int tmp2 = __shfl_sync(~0, comb, 8 + sublane / 4, 32) >> (lane % 4);
+  const unsigned long long temp6 = __ballot_sync(~0, tmp2 & 1);
+  const int bmB = (lane < 32) ? (int)temp6 : (int)(temp6 >> 32);
+#else
+  const int tmp2 = __shfl_sync(~0, comb, 8 + lane / 4) >> (lane % 4);
+  const int bmB = __ballot_sync(~0, tmp2 & 1);
+#endif
+#if defined(WS) && (WS == 64)
+  const int tmp3 = __shfl_sync(~0, comb, 16 + sublane / 4, 32) >> (lane % 4);
+  const unsigned long long temp7 = __ballot_sync(~0, tmp3 & 1);
+  const int bmC = (lane < 32) ? (int)temp7 : (int)(temp7 >> 32);
+#else
+  const int tmp3 = __shfl_sync(~0, comb, 16 + lane / 4) >> (lane % 4);
+  const int bmC = __ballot_sync(~0, tmp3 & 1);
+#endif
+#if defined(WS) && (WS == 64)
+  const int tmp4 = __shfl_sync(~0, comb, 24 + sublane / 4, 32) >> (lane % 4);
+  const unsigned long long temp8 = __ballot_sync(~0, tmp4 & 1);
+  const int bmD = (lane < 32) ? (int)temp8 : (int)(temp8 >> 32);
+#else
+  const int tmp4 = __shfl_sync(~0, comb, 24 + lane / 4) >> (lane % 4);
+  const int bmD = __ballot_sync(~0, tmp4 & 1);
+#endif
+  const int subwarps = TPB / 32;
+#if defined(WS) && (WS == 64)
+  const int subwarp = threadIdx.x / 32;
+  if ((((__ballot_sync(~0, active1) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 16 + sublane / 8] = bmA >> sublane;
+  if ((((__ballot_sync(~0, active2) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 16 + sublane / 8 + 4] = bmB >> sublane;
+  if ((((__ballot_sync(~0, active3) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 16 + sublane / 8 + 8] = bmC >> sublane;
+  if ((((__ballot_sync(~0, active4) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 16 + sublane / 8 + 12] = bmD >> sublane;
+#else
+  const int subwarp = warp;
+  if (__any_sync(~0, active1) && (lane % 8 == 0)) bmout_b[warp * 16 + lane / 8] = bmA >> lane;
+  if (__any_sync(~0, active2) && (lane % 8 == 0)) bmout_b[warp * 16 + lane / 8 + 4] = bmB >> lane;
+  if (__any_sync(~0, active3) && (lane % 8 == 0)) bmout_b[warp * 16 + lane / 8 + 8] = bmC >> lane;
+  if (__any_sync(~0, active4) && (lane % 8 == 0)) bmout_b[warp * 16 + lane / 8 + 12] = bmD >> lane;
+#endif
+  if constexpr (sizeof(T) > 1) {  //MB: maybe somewhere else zero out last word of bitmap before a barrier and calling this function?
+    if (warp == 0) {
+      const int base = (insize + 7) / 8;
+      const int top = (insize + (sizeof(T) * 8 - 1)) / 8;
+      if (base + tid < top) bmout_b[base + tid] = 0;
+    }
+  }
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  if constexpr (check) {
+    if (__syncthreads_or(sum > datasize)) return false;
+  } else {
+    __syncthreads();
+  }
+
+  // output non-repeating values
+  int loc = temp_w[subwarp] - cnt + __popc(bm1 & ((1 << sublane) - 1)) + __popc(bm2 & ((1 << sublane) - 1)) + __popc(bm3 & ((1 << sublane) - 1)) + __popc(bm4 & ((1 << sublane) - 1));
+  if (havenonrepval1) dataout[loc++] = val1;
+  if (havenonrepval2) dataout[loc++] = val2;
+  if (havenonrepval3) dataout[loc++] = val3;
+  if (havenonrepval4) dataout[loc] = val4;
+
+  datasize = temp_w[subwarps - 1];
+  return true;
+}
+
+
+//thread-based X words per thread, X must be 8, 16, or 32
+template <int X, typename T, bool check = false>
+static __device__ inline bool d_REencodeXwordsperthread(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  assert((X == 8) || (X == 16) || (X == 32));
+
+  // count non-repeating values and output bitmaps
+  const int WPT = X;  // words per thread
+  const int tid = threadIdx.x;
+  int bmp = 0, cnt = 0;
+  if (tid * WPT < insize) {
+    T prev = (tid == 0) ? 0 : in[tid * WPT - 1];
+    for (int i = 0; i < WPT; i++) {
+      const T val = in[tid * WPT + i];
+      bmp |= (val != prev) << i;
+      prev = val;
+    }
+    if (tid * WPT - (insize - WPT) > 0) {
+      bmp &= ~(-1 << (insize % WPT));
+    }
+    if constexpr (X == 8) ((byte*)bmout)[tid] = bmp;
+    if constexpr (X == 16) ((short*)bmout)[tid] = bmp;
+    if constexpr (X == 32) ((int*)bmout)[tid] = bmp;
+    cnt = __popc(bmp);
+  }
+
+  // pad with zeros if necessary to alignment point
+  if constexpr (sizeof(T) * 8 > X) {  //MB: maybe somewhere else zero out last word of bitmap before a barrier and calling this function?
+    if (tid < WS) {
+      const int base = (insize + (X - 1)) / 8;
+      const int top = (insize + (sizeof(T) * 8 - 1)) / 8;
+      if (base + tid < top) ((byte*)bmout)[base + tid] = 0;
+    }
+  }
+
+  // compute prefix sum
+  int pos = block_prefix_sum(cnt, temp_w);
+  if (tid == TPB - 1) temp_w[WS] = pos;
+  if constexpr (check) {
+    if (__syncthreads_or(pos > datasize)) return false;
+  } else {
+    __syncthreads();
+  }
+  pos -= cnt;
+
+  // output non-repeating values
+  if (bmp != 0) {
+    for (int i = 0; i < WPT; i++) {
+      if ((bmp >> i) & 1) {
+        const T val = in[tid * WPT + i];
+        dataout[pos++] = val;
+      }
+    }
+  }
+
+  datasize = temp_w[WS];
+  return true;
+}
+
+
+template <typename T, int maxsize = CS, bool check = false>  // maxsize in bytes
+static __device__ inline bool d_REencode(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  assert((TPB & (TPB - 1)) == 0);
+  assert((maxsize & (maxsize - 1)) == 0);
+  assert(maxsize % sizeof(T) == 0);
+  assert((maxsize / sizeof(T) % TPB == 0) || (maxsize / sizeof(T) < TPB));
+  const int wordsperthread = maxsize / sizeof(T) / TPB;
+  if constexpr ((sizeof(T) <= 2) && (maxsize > 2048)) {
+    // special case for byte and short data
+    return d_REencodebyteshort<T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread <= 1) {
+    // warp-based 1 word per thread
+    return d_REencode1wordperthread<T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread == 2) {
+    // warp-based 2 words per thread
+    return d_REencode2wordsperthread<T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread == 4) {
+    // warp-based 4 words per thread
+    return d_REencode4wordsperthread<T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread == 8) {
+    // thread-based 8 words per thread
+    return d_REencodeXwordsperthread<8, T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread == 16) {
+    // thread-based 16 words per thread
+    return d_REencodeXwordsperthread<16, T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread == 32) {
+    // thread-based 32 words per thread
+    return d_REencodeXwordsperthread<32, T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else {
+    // unsupported
+    __trap();
+    return false;
+  }
+}
+
+
+template <typename T, typename U>  // U must be int or smaller; if smaller, it must be unsigned
+static __device__ inline void d_REdecode_specialized(const int decsize, const T* const datain, const U* const bmin_t, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  const int subWS = 32;
+  const int tid = threadIdx.x;
+  const int subwarp = tid / subWS;
+  const int subwarps = TPB / subWS;
+  const int sublane = tid % subWS;
+  int num = (decsize + subWS - 1) / subWS;  // number of subchunks (rounded up)
+  if constexpr (sizeof(T) == 8) num += num & 1;  // next higher even value
+
+  // count non-repeating values
+  const int beg = subwarp * num / subwarps;
+  const int end = (subwarp + 1) * num / subwarps;
+  int cnt = 0;
+
+  for (int i = beg * (4 / sizeof(U)) + sublane; i < end * (4 / sizeof(U)); i += subWS) {
+    const int bm = bmin_t[i];
+    cnt += __popc(bm);
+  }
+
+  for (int i = 1; i < subWS; i *= 2) {
+    cnt += __shfl_xor_sync(~0, cnt, i, subWS);
+  }
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  if (tid < WS) {
+    const int lane = tid % WS;
+    int sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  __syncthreads();
+
+  // output non-repeating values based on bitmap
+  int pos = temp_w[subwarp] - cnt;
+  for (int i = beg; i < end; i++) {
+    int bm;
+    if constexpr (sizeof(U) == 1) {
+      bm = (int)bmin_t[i * 4 + sublane / 8] << (sublane & ~7);
+      bm |= __shfl_xor_sync(~0, bm, 8, subWS);
+      bm |= __shfl_xor_sync(~0, bm, 16, subWS);
+    }
+    if constexpr (sizeof(U) == 2) {
+      bm = (int)bmin_t[i * 2 + sublane / 16] << (sublane & ~15);
+      bm |= __shfl_xor_sync(~0, bm, 16, subWS);
+    }
+    if constexpr (sizeof(U) == 4) {
+      bm = bmin_t[i];
+    }
+
+    const int offs = __popc(bm & ((1 << sublane) - 1)) - (((bm >> sublane) & 1) ^ 1);
+    const T val = (pos + offs < 0) ? 0 : datain[pos + offs];
+    const int loc = i * subWS + sublane;
+    if (loc < decsize) out[loc] = val;
+    pos += __popc(bm);
+  }
+}
+
+
+//warp-based one word per thread
+template <typename T>
+static __device__ inline void d_REdecode1wordperthread(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  const byte* const bmin_b = (byte*)bmin;
+  const int tid = threadIdx.x;
+  const int subWS = 32;
+  const int subwarps = TPB / subWS;
+  const int subwarp = tid / subWS;
+  const int sublane = tid % subWS;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // read bitmap and count non-repeating values
+  const bool active = (tid < decsize);
+  const bool havenonrepval = (active && ((bmin_b[tid / 8] >> (tid % 8)) & 1));
+#if defined(WS) && (WS == 64)
+  const unsigned long long tmp = __ballot_sync(~0, havenonrepval);
+  const int bm = (lane < 32) ? (int)tmp : (int)(tmp >> 32);
+#else
+  const int bm = __ballot_sync(~0, havenonrepval);
+#endif
+  const int cnt = __popc(bm);
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  __syncthreads();
+
+  // output values
+  if (active) {
+    const int loc = temp_w[subwarp] - cnt + __popc(bm & ((1 << sublane) - 1)) - (havenonrepval ^ 1);
+    out[tid] = (loc < 0) ? 0 : datain[loc];
+  }
+}
+
+
+//warp-based two words per thread
+template <typename T>
+static __device__ inline void d_REdecode2wordsperthread(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  const byte* const bmin_b = (byte*)bmin;
+  const int tid = threadIdx.x;
+  const int subWS = 32;
+  const int subwarps = TPB / subWS;
+  const int subwarp = tid / subWS;
+  const int sublane = tid % subWS;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // read bitmap and count non-repeating values
+  const int tid1 = tid * 2;
+  const int tid2 = tid1 + 1;
+  const bool active1 = (tid1 < decsize);
+  const bool active2 = (tid2 < decsize);
+  const byte b = active1 ? (bmin_b[tid1 / 8] >> (tid1 % 8)) : 0;
+  const bool havenonrepval1 = (active1 && (b & 1));
+  const bool havenonrepval2 = (active2 && (b & 2));
+#if defined(WS) && (WS == 64)
+  const unsigned long long temp = __ballot_sync(~0, havenonrepval1);
+  const int bm1 = (lane < 32) ? (int)temp : (int)(temp >> 32);
+  const unsigned long long temp1 = __ballot_sync(~0, havenonrepval2);
+  const int bm2 = (lane < 32) ? (int)temp1 : (int)(temp1 >> 32);
+#else
+  const int bm1 = __ballot_sync(~0, havenonrepval1);
+  const int bm2 = __ballot_sync(~0, havenonrepval2);
+#endif
+  const int cnt = __popc(bm1) + __popc(bm2);
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  __syncthreads();
+
+  // output values
+  const int common = temp_w[subwarp] - cnt + __popc(bm1 & ((1 << sublane) - 1)) + __popc(bm2 & ((1 << sublane) - 1));
+  const int loc1 = common - (havenonrepval1 ^ 1);
+  const int loc2 = common + havenonrepval1 - (havenonrepval2 ^ 1);
+  if (active1) out[tid1] = (loc1 < 0) ? 0 : datain[loc1];
+  if (active2) out[tid2] = (loc2 < 0) ? 0 : datain[loc2];
+}
+
+
+//warp-based four words per thread
+template <typename T>
+static __device__ inline void d_REdecode4wordsperthread(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  const byte* const bmin_b = (byte*)bmin;
+  const int tid = threadIdx.x;
+  const int subWS = 32;
+  const int subwarps = TPB / subWS;
+  const int subwarp = tid / subWS;
+  const int sublane = tid % subWS;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // read bitmap and count non-repeating values
+  const int tid1 = tid * 4;
+  const int tid2 = tid1 + 1;
+  const int tid3 = tid2 + 1;
+  const int tid4 = tid3 + 1;
+  const bool active1 = (tid1 < decsize);
+  const bool active2 = (tid2 < decsize);
+  const bool active3 = (tid3 < decsize);
+  const bool active4 = (tid4 < decsize);
+  const byte b = active1 ? (bmin_b[tid1 / 8] >> (tid1 % 8)) : 0;
+  const bool havenonrepval1 = (active1 && (b & 1));
+  const bool havenonrepval2 = (active2 && (b & 2));
+  const bool havenonrepval3 = (active3 && (b & 4));
+  const bool havenonrepval4 = (active4 && (b & 8));
+#if defined(WS) && (WS == 64)
+  const unsigned long long temp = __ballot_sync(~0, havenonrepval1);
+  const int bm1 = (lane < 32) ? (int)temp : (int)(temp >> 32);
+  const unsigned long long temp1 = __ballot_sync(~0, havenonrepval2);
+  const int bm2 = (lane < 32) ? (int)temp1 : (int)(temp1 >> 32);
+  const unsigned long long temp2 = __ballot_sync(~0, havenonrepval3);
+  const int bm3 = (lane < 32) ? (int)temp2 : (int)(temp2 >> 32);
+  const unsigned long long temp3 = __ballot_sync(~0, havenonrepval4);
+  const int bm4 = (lane < 32) ? (int)temp3 : (int)(temp3 >> 32);
+#else
+  const int bm1 = __ballot_sync(~0, havenonrepval1);
+  const int bm2 = __ballot_sync(~0, havenonrepval2);
+  const int bm3 = __ballot_sync(~0, havenonrepval3);
+  const int bm4 = __ballot_sync(~0, havenonrepval4);
+#endif
+  const int cnt = __popc(bm1) + __popc(bm2) + __popc(bm3) + __popc(bm4);
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  __syncthreads();
+
+  // output values
+  const int common = temp_w[subwarp] - cnt + __popc(bm1 & ((1 << sublane) - 1)) + __popc(bm2 & ((1 << sublane) - 1)) + __popc(bm3 & ((1 << sublane) - 1)) + __popc(bm4 & ((1 << sublane) - 1));
+  const int loc1 = common - (havenonrepval1 ^ 1);
+  const int loc2 = common + havenonrepval1 - (havenonrepval2 ^ 1);
+  const int loc3 = common + havenonrepval1 + havenonrepval2 - (havenonrepval3 ^ 1);
+  const int loc4 = common + havenonrepval1 + havenonrepval2 + havenonrepval3 - (havenonrepval4 ^ 1);
+  if (active1) out[tid1] = (loc1 < 0) ? 0 : datain[loc1];
+  if (active2) out[tid2] = (loc2 < 0) ? 0 : datain[loc2];
+  if (active3) out[tid3] = (loc3 < 0) ? 0 : datain[loc3];
+  if (active4) out[tid4] = (loc4 < 0) ? 0 : datain[loc4];
+}
+
+
+//thread-based X words per thread, X must be 8, 16, or 32
+template <int X, typename T>
+static __device__ inline void d_REdecodeXwordsperthread(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  assert((X == 8) || (X == 16) || (X == 32));
+
+  // read bitmap and count non-repeating values
+  const int WPT = X;  // words per thread
+  const int tid = threadIdx.x;
+  int bmp, cnt = 0;
+  if (tid * WPT < decsize) {
+    if constexpr (X == 8) bmp = ((byte*)bmin)[tid];
+    if constexpr (X == 16) bmp = ((unsigned short*)bmin)[tid];
+    if constexpr (X == 32) bmp = ((int*)bmin)[tid];
+    cnt = __popc(bmp);
+  }
+
+  // compute prefix sum
+  int pos = block_prefix_sum(cnt, temp_w) - cnt;
+
+  // output values
+  if (tid * WPT < decsize) {
+    T val = (bmp & 1) ? 0 : ((pos > 0) ? datain[pos - 1] : 0);
+    if ((tid | 31) * WPT + (WPT - 1) < decsize) {
+      for (int i = 0; i < WPT; i++) {
+        if ((bmp >> i) & 1) val = datain[pos++];
+        out[tid * WPT + i] = val;
+      }
+    } else {
+      for (int i = 0; i < WPT; i++) {
+        if (tid * WPT + i >= decsize) break;
+        if ((bmp >> i) & 1) val = datain[pos++];
+        out[tid * WPT + i] = val;
+      }
+    }
+  }
+}
+
+
+template <typename T, int maxsize = CS>  // maxsize in bytes
+static __device__ inline void d_REdecode_small(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  assert((TPB & (TPB - 1)) == 0);
+  assert((maxsize & (maxsize - 1)) == 0);
+  assert(maxsize % sizeof(T) == 0);
+  assert((maxsize / sizeof(T) % TPB == 0) || (maxsize / sizeof(T) < TPB));
+  const int wordsperthread = maxsize / sizeof(T) / TPB;
+  if constexpr (wordsperthread <= 1) {
+    // warp-based 1 word per thread
+    d_REdecode1wordperthread<T>(decsize, datain, bmin, out, temp_w);
+  } else if constexpr (wordsperthread == 2) {
+    // warp-based 2 words per thread
+    d_REdecode2wordsperthread<T>(decsize, datain, bmin, out, temp_w);
+  } else if constexpr (wordsperthread == 4) {
+    // warp-based 4 words per thread
+    d_REdecode4wordsperthread<T>(decsize, datain, bmin, out, temp_w);
+  } else if constexpr (wordsperthread == 8) {
+    // thread-based 8 words per thread
+    d_REdecodeXwordsperthread<8, T>(decsize, datain, bmin, out, temp_w);
+  } else if constexpr (wordsperthread == 16) {
+    // thread-based 16 words per thread
+    d_REdecodeXwordsperthread<16, T>(decsize, datain, bmin, out, temp_w);
+  } else if constexpr (wordsperthread == 32) {
+    // thread-based 32 words per thread
+    d_REdecodeXwordsperthread<32, T>(decsize, datain, bmin, out, temp_w);
+  } else {
+    // unsupported
+    __trap();
+  }
+}
+
+
+template <typename T, int maxsize = CS>
+static __device__ inline void d_REdecode(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  if constexpr (maxsize <= 2048) {
+    d_REdecode_small<T, maxsize>(decsize, datain, bmin, out, temp_w);
+  } else if ((sizeof(T) >= 4) /*|| (((size_t)bmin & 3) == 0)*/) {  // at least int aligned
+    d_REdecode_specialized(decsize, datain, (int*)bmin, out, temp_w);
+  } else if constexpr (sizeof(T) == 2) {  // short aligned
+    const int tid = threadIdx.x;
+    const int num = (decsize + 15) / 16;  // number of subchunks (rounded up)
+
+    // count non-repeating values
+    const int beg = tid * num / TPB;
+    const int end = (tid + 1) * num / TPB;
+    int cnt = 0;
+    for (int i = beg; i < end; i++) {
+      const unsigned short bm = bmin[i];
+      cnt += __popc((int)bm);
+    }
+    int pos = block_prefix_sum(cnt, temp_w) - cnt;
+
+    // output non-repeating values based on bitmap
+    short val = (pos > 0) ? datain[pos - 1] : 0;
+    for (int i = beg; i < end; i++) {
+      const unsigned short bm = bmin[i];
+      for (int j = 0; j < 16; j++) {
+        if ((bm >> j) & 1) val = datain[pos++];
+        if (i * 16 + j < decsize) out[i * 16 + j] = val;
+      }
+    }
+  } else {  // byte aligned
+    const int tid = threadIdx.x;
+    const int num = (decsize + 7) / 8;  // number of subchunks (rounded up)
+    long long* const out_l = (long long*)out;
+    assert(num <= TPB * 4);
+
+    // count non-zeros
+    const int beg = tid * num / TPB;
+    const int end = (tid + 1) * num / TPB;
+    int bmp = 0;
+    for (int i = beg; i < end; i++) {
+      bmp |= (int)bmin[i] << (8 * (i - beg));
+    }
+    const int cnt = __popc(bmp);
+    int pos = block_prefix_sum(cnt, temp_w) - cnt;
+
+    // output non-repeating values based on bitmap
+    long long val = (pos > 0) ? datain[pos - 1] : 0;
+    for (int i = beg; i < end; i++) {
+      const byte bm = bmp >> (8 * (i - beg));
+      long long lval = 0;
+      for (int j = 0; j < 8; j++) {
+        if ((bm >> j) & 1) val = datain[pos++];
+        lval |= val << (j * 8);
+      }
+      out_l[i] = lval;
+    }
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/d_zero_elimination.h
+++ b/include/lc/components/include/d_zero_elimination.h
@@ -1,0 +1,873 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef zero_elimination_device
+#define zero_elimination_device
+
+
+//special case for byte and short data
+template <typename T, bool check = false>
+static __device__ inline bool d_ZEencodebyteshort(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  using type = T;
+  using ull = unsigned long long;
+  const int bitsperword = 8 * sizeof(type);
+  const int bitsperlong = 8 * sizeof(ull);
+  const int wordsperlong = bitsperlong / bitsperword;
+  const int bytesperthread = CS / TPB;
+  const ull* const in_l = (ull*)in;
+  const int csize = insize * sizeof(T);
+  assert(bytesperthread % sizeof(ull) == 0);
+  assert(bytesperthread / sizeof(type) <= sizeof(int) * 8);
+  assert(bytesperthread / sizeof(ull) * wordsperlong >= 8);
+  assert(std::is_unsigned<type>::value);
+
+  // output bitmaps and count non-zero values
+  const int tid = threadIdx.x;
+  int bmp = 0, cnt = 0;
+  if (tid * bytesperthread < csize) {
+    for (int i = 0; i < bytesperthread / sizeof(ull); i++) {
+      const ull lval = in_l[tid * (bytesperthread / sizeof(ull)) + i];
+      int bm = 0;
+      for (int j = 0; j < wordsperlong; j++) {
+        const type val = lval >> (j * bitsperword);
+        bm |= (val != 0) << j;
+      }
+      bmp |= bm << (i * wordsperlong);
+    }
+    if (tid * bytesperthread - (csize - bytesperthread) > 0) {
+      bmp &= ~(-1 << ((csize % bytesperthread + sizeof(type) - 1) / sizeof(type)));
+    }
+    //if constexpr (sizeof(type) == 1) ((int*)bmout)[tid] = bmp;
+    if constexpr (sizeof(type) == 1) {
+      bmout[tid * 4] = bmp;
+      bmout[tid * 4 + 1] = bmp >> 8;
+      bmout[tid * 4 + 2] = bmp >> 16;
+      bmout[tid * 4 + 3] = bmp >> 24;
+    }
+    if constexpr (sizeof(type) == 2) bmout[tid] = bmp;
+    if constexpr (sizeof(type) == 4) ((byte*)bmout)[tid] = bmp;
+    cnt = __popc(bmp);
+  }
+
+  int pos = block_prefix_sum(cnt, temp_w);
+  if (tid == TPB - 1) temp_w[WS] = pos;
+  if constexpr (check) {
+    if (__syncthreads_or(pos > datasize)) return false;
+  } else {
+    __syncthreads();
+  }
+  pos -= cnt;
+
+  // output non-zero values
+  if (bmp != 0) {
+    for (int i = 0; i < bytesperthread / sizeof(ull); i++) {
+      const ull lval = in_l[tid * (bytesperthread / sizeof(ull)) + i];
+      const int bm = bmp >> (i * wordsperlong);
+      for (int j = 0; j < wordsperlong; j++) {
+        if ((bm >> j) & 1) {
+          dataout[pos++] = lval >> (j * bitsperword);
+        }
+      }
+    }
+  }
+
+  datasize = temp_w[WS];
+  return true;
+}
+
+
+//warp-based one word per thread
+template <typename T, bool check = false>
+static __device__ inline bool d_ZEencode1wordperthread(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  byte* const bmout_b = (byte*)bmout;
+  const int tid = threadIdx.x;
+  const int warps = TPB / WS;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // count non-zero values and output bitmaps
+  const bool active = (tid < insize);
+  const T val = active ? in[tid] : 0;
+  const bool havenonzeroval = (active && (val != 0));
+#if defined(WS) && (WS == 64)
+  const unsigned long long tmp = __ballot_sync(~0, havenonzeroval);
+  const int bm = (lane < 32) ? (int)tmp : (int)(tmp >> 32);
+#else  
+  const int bm = __ballot_sync(~0, havenonzeroval);
+#endif  
+  const int cnt = __popc(bm);
+  const int subwarps = TPB / 32;
+#if defined(WS) && (WS == 64)
+  const int sublane = lane & 31;
+  const int subwarp = threadIdx.x / 32;
+  if (active && (sublane % 8 == 0)) bmout_b[tid / 8] = bm >> sublane;
+#else
+  const int sublane = lane;
+  const int subwarp = warp;
+  if (active && (lane % 8 == 0)) bmout_b[tid / 8] = bm >> lane;
+#endif 
+  if constexpr (sizeof(T) > 1) {  //MB: (never used) maybe somewhere else zero out last word of bitmap before a barrier and calling this function?
+    if (warp == 0) {
+      const int base = (insize + 7) / 8;
+      const int top = (insize + (sizeof(T) * 8 - 1)) / 8;
+      if (base + tid < top) bmout_b[base + tid] = 0;
+    }
+  }
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  if constexpr (check) {
+    if (__syncthreads_or(sum > datasize)) return false;
+  } else {
+    __syncthreads();
+  }
+
+  // output non-zero values
+  if (havenonzeroval) {
+    const int loc = temp_w[subwarp] - cnt + __popc(bm & ((1 << sublane) - 1));
+    dataout[loc] = val;
+  }
+
+  datasize = temp_w[subwarps - 1];
+  return true;
+}
+
+
+//warp-based two words per thread
+template <typename T, bool check = false>
+static __device__ inline bool d_ZEencode2wordsperthread(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  byte* const bmout_b = (byte*)bmout;
+  const int tid = threadIdx.x;
+  const int warps = TPB / WS;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // count non-zero values and output bitmaps
+  const int tid1 = tid * 2;
+  const int tid2 = tid1 + 1;
+  const bool active1 = (tid1 < insize);
+  const bool active2 = (tid2 < insize);
+  const T val1 = active1 ? in[tid1] : 0;
+  const T val2 = active2 ? in[tid2] : 0;
+  const bool havenonzeroval1 = (active1 && (val1 != 0));
+  const bool havenonzeroval2 = (active2 && (val2 != 0));
+#if defined(WS) && (WS == 64)
+  const unsigned long long temp = __ballot_sync(~0, havenonzeroval1);
+  const int bm1 = (lane < 32) ? (int)temp : (int)(temp >> 32);  
+  const unsigned long long temp1 = __ballot_sync(~0, havenonzeroval2);
+  const int bm2 = (lane < 32) ? (int)temp1 : (int)(temp1 >> 32);
+#else    
+  const int bm1 = __ballot_sync(~0, havenonzeroval1);
+  const int bm2 = __ballot_sync(~0, havenonzeroval2);
+#endif 
+  const int cnt = __popc(bm1) + __popc(bm2);
+  const int comb = havenonzeroval1 + havenonzeroval2 * 2;
+#if defined(WS) && (WS == 64)
+  const int sublane = lane & 31;
+  const int tmp1 = __shfl_sync(~0, comb, sublane / 2, 32) >> (lane % 2);
+  const unsigned long long temp2 = __ballot_sync(~0, tmp1 & 1);
+  const int bmlo = (lane < 32) ? (int)temp2 : (int)(temp2 >> 32);
+#else
+  const int sublane = lane;
+  const int tmp1 = __shfl_sync(~0, comb, lane / 2) >> (lane % 2);
+  const int bmlo = __ballot_sync(~0, tmp1 & 1);
+#endif
+#if defined(WS) && (WS == 64)
+  const int tmp2 = __shfl_sync(~0, comb, 16 + sublane / 2, 32) >> (lane % 2);
+  const unsigned long long temp3 = __ballot_sync(~0, tmp2 & 1);
+  const int bmhi = (lane < 32) ? (int)temp3 : (int)(temp3 >> 32);
+#else
+  const int tmp2 = __shfl_sync(~0, comb, 16 + lane / 2) >> (lane % 2);
+  const int bmhi = __ballot_sync(~0, tmp2 & 1);
+#endif
+  const int subwarps = TPB / 32;
+#if defined(WS) && (WS == 64)
+  const int subwarp = threadIdx.x / 32;
+  if ((((__ballot_sync(~0, active1) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 8 + sublane / 8] = bmlo >> sublane;
+  if ((((__ballot_sync(~0, active2) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 8 + sublane / 8 + 4] = bmhi >> sublane;
+#else
+  const int subwarp = warp;
+  if (__any_sync(~0, active1) && (lane % 8 == 0)) bmout_b[warp * 8 + lane / 8] = bmlo >> lane;
+  if (__any_sync(~0, active2) && (lane % 8 == 0)) bmout_b[warp * 8 + lane / 8 + 4] = bmhi >> lane;
+#endif 
+  if constexpr (sizeof(T) > 1) {  //MB: (never used) maybe somewhere else zero out last word of bitmap before a barrier and calling this function?
+    if (warp == 0) {
+      const int base = (insize + 7) / 8;
+      const int top = (insize + (sizeof(T) * 8 - 1)) / 8;
+      if (base + tid < top) bmout_b[base + tid] = 0;
+    }
+  }
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  if constexpr (check) {
+    if (__syncthreads_or(sum > datasize)) return false;
+  } else {
+    __syncthreads();
+  }
+
+  // output non-zero values
+  int loc = temp_w[subwarp] - cnt + __popc(bm1 & ((1 << sublane) - 1)) + __popc(bm2 & ((1 << sublane) - 1));
+  if (havenonzeroval1) dataout[loc++] = val1;
+  if (havenonzeroval2) dataout[loc] = val2;
+
+  datasize = temp_w[subwarps - 1];
+  return true;
+}
+
+
+//warp-based four words per thread
+template <typename T, bool check = false>
+static __device__ inline bool d_ZEencode4wordsperthread(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  byte* const bmout_b = (byte*)bmout;
+  const int tid = threadIdx.x;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // count non-zero values and output bitmaps
+  const int tid1 = tid * 4;
+  const int tid2 = tid1 + 1;
+  const int tid3 = tid2 + 1;
+  const int tid4 = tid3 + 1;
+  const bool active1 = (tid1 < insize);
+  const bool active2 = (tid2 < insize);
+  const bool active3 = (tid3 < insize);
+  const bool active4 = (tid4 < insize);
+  const T val1 = active1 ? in[tid1] : 0;
+  const T val2 = active2 ? in[tid2] : 0;
+  const T val3 = active3 ? in[tid3] : 0;
+  const T val4 = active4 ? in[tid4] : 0;
+  const bool havenonzeroval1 = (active1 && (val1 != 0));
+  const bool havenonzeroval2 = (active2 && (val2 != 0));
+  const bool havenonzeroval3 = (active3 && (val3 != 0));
+  const bool havenonzeroval4 = (active4 && (val4 != 0));
+#if defined(WS) && (WS == 64)
+  const unsigned long long temp1 = __ballot_sync(~0, havenonzeroval1);
+  const int bm1 = (lane < 32) ? (int)temp1 : (int)(temp1 >> 32);
+  const unsigned long long temp2 = __ballot_sync(~0, havenonzeroval2);
+  const int bm2 = (lane < 32) ? (int)temp2 : (int)(temp2 >> 32);
+  const unsigned long long temp3 = __ballot_sync(~0, havenonzeroval3);
+  const int bm3 = (lane < 32) ? (int)temp3 : (int)(temp3 >> 32);
+  const unsigned long long temp4 = __ballot_sync(~0, havenonzeroval4);
+  const int bm4 = (lane < 32) ? (int)temp4 : (int)(temp4 >> 32);
+#else  
+  const int bm1 = __ballot_sync(~0, havenonzeroval1);
+  const int bm2 = __ballot_sync(~0, havenonzeroval2);
+  const int bm3 = __ballot_sync(~0, havenonzeroval3);
+  const int bm4 = __ballot_sync(~0, havenonzeroval4);
+#endif  
+  const int cnt = __popc(bm1) + __popc(bm2) + __popc(bm3) + __popc(bm4);
+  const int comb = havenonzeroval1 + havenonzeroval2 * 2 + havenonzeroval3 * 4 + havenonzeroval4 * 8;
+#if defined(WS) && (WS == 64)
+  const int sublane = lane & 31;
+  const int tmp1 = __shfl_sync(~0, comb, sublane / 4, 32) >> (lane % 4);
+  const unsigned long long temp5 = __ballot_sync(~0, tmp1 & 1);
+  const int bmA = (lane < 32) ? (int)temp5 : (int)(temp5 >> 32);
+#else
+  const int sublane = lane;    
+  const int tmp1 = __shfl_sync(~0, comb, lane / 4) >> (lane % 4);
+  const int bmA = __ballot_sync(~0, tmp1 & 1);
+#endif  
+#if defined(WS) && (WS == 64)
+  const int tmp2 = __shfl_sync(~0, comb, 8 + sublane / 4, 32) >> (lane % 4);
+  const unsigned long long temp6 = __ballot_sync(~0, tmp2 & 1);
+  const int bmB = (lane < 32) ? (int)temp6 : (int)(temp6 >> 32);
+#else  
+  const int tmp2 = __shfl_sync(~0, comb, 8 + lane / 4) >> (lane % 4);
+  const int bmB = __ballot_sync(~0, tmp2 & 1);
+#endif 
+#if defined(WS) && (WS == 64)
+  const int tmp3 = __shfl_sync(~0, comb, 16 + sublane / 4, 32) >> (lane % 4);
+  const unsigned long long temp7 = __ballot_sync(~0, tmp3 & 1);
+  const int bmC = (lane < 32) ? (int)temp7 : (int)(temp7 >> 32);
+#else
+  const int tmp3 = __shfl_sync(~0, comb, 16 + lane / 4) >> (lane % 4);
+  const int bmC = __ballot_sync(~0, tmp3 & 1);
+#endif
+#if defined(WS) && (WS == 64)
+  const int tmp4 = __shfl_sync(~0, comb, 24 + sublane / 4, 32) >> (lane % 4);
+  const unsigned long long temp8 = __ballot_sync(~0, tmp4 & 1);
+  const int bmD = (lane < 32) ? (int)temp8 : (int)(temp8 >> 32);
+#else
+  const int tmp4 = __shfl_sync(~0, comb, 24 + lane / 4) >> (lane % 4);
+  const int bmD = __ballot_sync(~0, tmp4 & 1);
+#endif
+const int subwarps = TPB / 32;
+#if defined(WS) && (WS == 64)
+  const int subwarp = threadIdx.x / 32;
+  if ((((__ballot_sync(~0, active1) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 16 + sublane / 8] = bmA >> sublane;
+  if ((((__ballot_sync(~0, active2) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 16 + sublane / 8 + 4] = bmB >> sublane;
+  if ((((__ballot_sync(~0, active3) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 16 + sublane / 8 + 8] = bmC >> sublane;
+  if ((((__ballot_sync(~0, active4) >> (lane & 32)) & 0xffff'ffff) != 0) && (sublane % 8 == 0)) bmout_b[subwarp * 16 + sublane / 8 + 12] = bmD >> sublane;
+#else
+  const int subwarp = warp;
+  if (__any_sync(~0, active1) && (lane % 8 == 0)) bmout_b[warp * 16 + lane / 8] = bmA >> lane;
+  if (__any_sync(~0, active2) && (lane % 8 == 0)) bmout_b[warp * 16 + lane / 8 + 4] = bmB >> lane;
+  if (__any_sync(~0, active3) && (lane % 8 == 0)) bmout_b[warp * 16 + lane / 8 + 8] = bmC >> lane;
+  if (__any_sync(~0, active4) && (lane % 8 == 0)) bmout_b[warp * 16 + lane / 8 + 12] = bmD >> lane;
+#endif  
+  if constexpr (sizeof(T) > 1) {  //MB: maybe somewhere else zero out last word of bitmap before a barrier and calling this function?
+    if (warp == 0) {
+      const int base = (insize + 7) / 8;
+      const int top = (insize + (sizeof(T) * 8 - 1)) / 8;
+      if (base + tid < top) bmout_b[base + tid] = 0;
+    }
+  }
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  if constexpr (check) {
+    if (__syncthreads_or(sum > datasize)) return false;
+  } else {
+    __syncthreads();
+  }
+
+  // output non-zero values
+  int loc = temp_w[subwarp] - cnt + __popc(bm1 & ((1 << sublane) - 1)) + __popc(bm2 & ((1 << sublane) - 1)) + __popc(bm3 & ((1 << sublane) - 1)) + __popc(bm4 & ((1 << sublane) - 1));
+  if (havenonzeroval1) dataout[loc++] = val1;
+  if (havenonzeroval2) dataout[loc++] = val2;
+  if (havenonzeroval3) dataout[loc++] = val3;
+  if (havenonzeroval4) dataout[loc] = val4;
+
+  datasize = temp_w[subwarps - 1];
+  return true;
+}
+
+
+//thread-based X words per thread, X must be 8, 16, or 32
+template <int X, typename T, bool check = false>
+static __device__ inline bool d_ZEencodeXwordsperthread(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  assert((X == 8) || (X == 16) || (X == 32));
+
+  // count non-zero values and output bitmaps
+  const int WPT = X;  // words per thread
+  const int tid = threadIdx.x;
+  int bmp = 0, cnt = 0;
+  if (tid * WPT < insize) {
+    for (int i = 0; i < WPT; i++) {
+      const T val = in[tid * WPT + i];
+      bmp |= (val != 0) << i;
+    }
+    if (tid * WPT - (insize - WPT) > 0) {
+      bmp &= ~(-1 << (insize % WPT));
+    }
+    if constexpr (X == 8) ((byte*)bmout)[tid] = bmp;
+    if constexpr (X == 16) ((short*)bmout)[tid] = bmp;
+    if constexpr (X == 32) ((int*)bmout)[tid] = bmp;
+    cnt = __popc(bmp);
+  }
+
+  // pad with zeros if necessary to alignment point
+  if constexpr (sizeof(T) * 8 > X) {  //MB: maybe somewhere else zero out last word of bitmap before a barrier and calling this function?
+    if (tid < WS) {
+      const int base = (insize + (X - 1)) / 8;
+      const int top = (insize + (sizeof(T) * 8 - 1)) / 8;
+      if (base + tid < top) ((byte*)bmout)[base + tid] = 0;
+    }
+  }
+
+  // compute prefix sum
+  int pos = block_prefix_sum(cnt, temp_w);
+  if (tid == TPB - 1) temp_w[WS] = pos;
+  if constexpr (check) {
+    if (__syncthreads_or(pos > datasize)) return false;
+  } else {
+    __syncthreads();
+  }
+  pos -= cnt;
+
+  // output non-zero values
+  if (bmp != 0) {
+    for (int i = 0; i < WPT; i++) {
+      if ((bmp >> i) & 1) {
+        const T val = in[tid * WPT + i];
+        dataout[pos++] = val;
+      }
+    }
+  }
+
+  datasize = temp_w[WS];
+  return true;
+}
+
+
+template <typename T, int maxsize = CS, bool check = false>  // maxsize in bytes
+static __device__ inline bool d_ZEencode(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout, int* const temp_w)  // all sizes in number of words
+{
+  assert((TPB & (TPB - 1)) == 0);
+  assert((maxsize & (maxsize - 1)) == 0);
+  assert(maxsize % sizeof(T) == 0);
+  assert((maxsize / sizeof(T) % TPB == 0) || (maxsize / sizeof(T) < TPB));
+  const int wordsperthread = maxsize / sizeof(T) / TPB;
+  if constexpr ((sizeof(T) <= 2) && (maxsize > 2048)) {
+    // special case for byte and short data
+    return d_ZEencodebyteshort<T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread <= 1) {
+    // warp-based 1 word per thread
+    return d_ZEencode1wordperthread<T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread == 2) {
+    // warp-based 2 words per thread
+    return d_ZEencode2wordsperthread<T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread == 4) {
+    // warp-based 4 words per thread
+    return d_ZEencode4wordsperthread<T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread == 8) {
+    // thread-based 8 words per thread
+    return d_ZEencodeXwordsperthread<8, T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread == 16) {
+    // thread-based 16 words per thread
+    return d_ZEencodeXwordsperthread<16, T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else if constexpr (wordsperthread == 32) {
+    // thread-based 32 words per thread
+    return d_ZEencodeXwordsperthread<32, T, check>(in, insize, dataout, datasize, bmout, temp_w);
+  } else {
+    // unsupported
+    __trap();
+    return false;
+  }
+}
+
+
+template <typename T, typename U>  // U must be int or smaller; if smaller, it must be unsigned
+static __device__ inline void d_ZEdecode_specialized(const int decsize, const T* const datain, const U* const bmin_t, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  const int subWS = 32;
+  const int tid = threadIdx.x;
+  const int subwarp = tid / subWS;
+  const int subwarps = TPB / subWS;
+  const int sublane = tid % subWS;
+  int num = (decsize + subWS - 1) / subWS;  // number of subchunks (rounded up)
+  if constexpr (sizeof(T) == 8) num += num & 1;  // next higher even value
+
+  // count non-zero values
+  const int beg = subwarp * num / subwarps;
+  const int end = (subwarp + 1) * num / subwarps;
+  int cnt = 0;
+
+  for (int i = beg * (4 / sizeof(U)) + sublane; i < end * (4 / sizeof(U)); i += subWS) {
+    const int bm = bmin_t[i];
+    cnt += __popc(bm);
+  }
+
+  for (int i = 1; i < subWS; i *= 2) {
+    cnt += __shfl_xor_sync(~0, cnt, i, subWS);
+  }
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  if (tid < WS) {
+    const int lane = tid % WS;
+    int sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  __syncthreads();
+
+  // output non-zero values based on bitmap
+  int pos = temp_w[subwarp] - cnt;
+  for (int i = beg; i < end; i++) {
+    int bm;
+    if constexpr (sizeof(U) == 1) {
+      bm = (int)bmin_t[i * 4 + sublane / 8] << (sublane & ~7);
+      bm |= __shfl_xor_sync(~0, bm, 8, subWS);
+      bm |= __shfl_xor_sync(~0, bm, 16, subWS);
+    }
+    if constexpr (sizeof(U) == 2) {
+      bm = (int)bmin_t[i * 2 + sublane / 16] << (sublane & ~15);
+      bm |= __shfl_xor_sync(~0, bm, 16, subWS);
+    }
+    if constexpr (sizeof(U) == 4) {
+      bm = bmin_t[i];
+    }
+    const int offs = __popc(bm & ((1 << sublane) - 1)) - (((bm >> sublane) & 1) ^ 1);
+    const int loc = i * subWS + sublane;
+    if (loc < decsize) out[loc] = ((bm >> sublane) & 1) ? datain[pos + offs] : (T)0;
+    pos += __popc(bm);
+  }
+}
+
+
+//warp-based one word per thread
+template <typename T>
+static __device__ inline void d_ZEdecode1wordperthread(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  const byte* const bmin_b = (byte*)bmin;
+  const int tid = threadIdx.x;
+  const int subWS = 32;
+  const int subwarps = TPB / subWS;
+  const int subwarp = tid / subWS;
+  const int sublane = tid % subWS;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // read bitmap and count non-zero values
+  const bool active = (tid < decsize);
+  const bool havenonzeroval = (active && ((bmin_b[tid / 8] >> (tid % 8)) & 1));
+#if defined(WS) && (WS == 64)
+  const unsigned long long tmp = __ballot_sync(~0, havenonzeroval);
+  const int bm = (lane < 32) ? (int)tmp : (int)(tmp >> 32);
+#else  
+  const int bm = __ballot_sync(~0, havenonzeroval);
+#endif
+  const int cnt = __popc(bm);
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  __syncthreads();
+
+  // output values
+  if (active) {
+    const int loc = temp_w[subwarp] - cnt + __popc(bm & ((1 << sublane) - 1)) - (havenonzeroval ^ 1);
+    out[tid] = havenonzeroval ? datain[loc] : (T)0;
+  }
+}
+
+
+//warp-based two words per thread
+template <typename T>
+static __device__ inline void d_ZEdecode2wordsperthread(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  const byte* const bmin_b = (byte*)bmin;
+  const int tid = threadIdx.x;
+  const int subWS = 32;
+  const int subwarps = TPB / subWS;
+  const int subwarp = tid / subWS;
+  const int sublane = tid % subWS;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // read bitmap and count non-zero values
+  const int tid1 = tid * 2;
+  const int tid2 = tid1 + 1;
+  const bool active1 = (tid1 < decsize);
+  const bool active2 = (tid2 < decsize);
+  const byte b = active1 ? (bmin_b[tid1 / 8] >> (tid1 % 8)) : 0;
+  const bool havenonzeroval1 = (active1 && (b & 1));
+  const bool havenonzeroval2 = (active2 && (b & 2));
+#if defined(WS) && (WS == 64)
+  const unsigned long long temp = __ballot_sync(~0, havenonzeroval1);
+  const int bm1 = (lane < 32) ? (int)temp : (int)(temp >> 32);
+  const unsigned long long temp1 = __ballot_sync(~0, havenonzeroval2);
+  const int bm2 = (lane < 32) ? (int)temp1 : (int)(temp1 >> 32);
+#else
+  const int bm1 = __ballot_sync(~0, havenonzeroval1);
+  const int bm2 = __ballot_sync(~0, havenonzeroval2);
+#endif
+  const int cnt = __popc(bm1) + __popc(bm2);
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  __syncthreads();
+
+  // output values
+  const int common = temp_w[subwarp] - cnt + __popc(bm1 & ((1 << sublane) - 1)) + __popc(bm2 & ((1 << sublane) - 1));
+  const int loc1 = common - (havenonzeroval1 ^ 1);
+  const int loc2 = common + havenonzeroval1 - (havenonzeroval2 ^ 1);
+  if (active1) out[tid1] = havenonzeroval1 ? datain[loc1] : (T)0;
+  if (active2) out[tid2] = havenonzeroval2 ? datain[loc2] : (T)0;
+}
+
+
+//warp-based four words per thread
+template <typename T>
+static __device__ inline void d_ZEdecode4wordsperthread(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  const byte* const bmin_b = (byte*)bmin;
+  const int tid = threadIdx.x;
+  const int subWS = 32;
+  const int subwarps = TPB / subWS;
+  const int subwarp = tid / subWS;
+  const int sublane = tid % subWS;
+  const int warp = tid / WS;
+  const int lane = tid % WS;
+
+  // read bitmap and count non-zero values
+  const int tid1 = tid * 4;
+  const int tid2 = tid1 + 1;
+  const int tid3 = tid2 + 1;
+  const int tid4 = tid3 + 1;
+  const bool active1 = (tid1 < decsize);
+  const bool active2 = (tid2 < decsize);
+  const bool active3 = (tid3 < decsize);
+  const bool active4 = (tid4 < decsize);
+  const byte b = active1 ? (bmin_b[tid1 / 8] >> (tid1 % 8)) : 0;
+  const bool havenonzeroval1 = (active1 && (b & 1));
+  const bool havenonzeroval2 = (active2 && (b & 2));
+  const bool havenonzeroval3 = (active3 && (b & 4));
+  const bool havenonzeroval4 = (active4 && (b & 8));
+#if defined(WS) && (WS == 64)
+  const unsigned long long temp = __ballot_sync(~0, havenonzeroval1);
+  const int bm1 = (lane < 32) ? (int)temp : (int)(temp >> 32);  
+  const unsigned long long temp1 = __ballot_sync(~0, havenonzeroval2);
+  const int bm2 = (lane < 32) ? (int)temp1 : (int)(temp1 >> 32);
+  const unsigned long long temp2 = __ballot_sync(~0, havenonzeroval3);
+  const int bm3 = (lane < 32) ? (int)temp2 : (int)(temp2 >> 32);
+  const unsigned long long temp3 = __ballot_sync(~0, havenonzeroval4);
+  const int bm4 = (lane < 32) ? (int)temp3 : (int)(temp3 >> 32);
+#else  
+  const int bm1 = __ballot_sync(~0, havenonzeroval1);
+  const int bm2 = __ballot_sync(~0, havenonzeroval2);
+  const int bm3 = __ballot_sync(~0, havenonzeroval3);
+  const int bm4 = __ballot_sync(~0, havenonzeroval4);
+#endif
+  const int cnt = __popc(bm1) + __popc(bm2) + __popc(bm3) + __popc(bm4);
+  if (sublane == 0) temp_w[subwarp] = cnt;
+  __syncthreads();
+
+  // compute prefix sum
+  int sum = 0;
+  if (warp == 0) {
+    if (lane < subwarps) sum = temp_w[lane];
+    for (int i = 1; i < subwarps; i *= 2) {
+      const int tmp = __shfl_up_sync(~0, sum, i);
+      if (lane >= i) sum += tmp;
+    }
+    temp_w[lane] = sum;
+  }
+  __syncthreads();
+
+  // output values
+  const int common = temp_w[subwarp] - cnt + __popc(bm1 & ((1 << sublane) - 1)) + __popc(bm2 & ((1 << sublane) - 1)) + __popc(bm3 & ((1 << sublane) - 1)) + __popc(bm4 & ((1 << sublane) - 1));
+  const int loc1 = common - (havenonzeroval1 ^ 1);
+  const int loc2 = common + havenonzeroval1 - (havenonzeroval2 ^ 1);
+  const int loc3 = common + havenonzeroval1 + havenonzeroval2 - (havenonzeroval3 ^ 1);
+  const int loc4 = common + havenonzeroval1 + havenonzeroval2 + havenonzeroval3 - (havenonzeroval4 ^ 1);
+  if (active1) out[tid1] = havenonzeroval1 ? datain[loc1] : (T)0;
+  if (active2) out[tid2] = havenonzeroval2 ? datain[loc2] : (T)0;
+  if (active3) out[tid3] = havenonzeroval3 ? datain[loc3] : (T)0;
+  if (active4) out[tid4] = havenonzeroval4 ? datain[loc4] : (T)0;
+}
+
+
+//thread-based X words per thread, X must be 8, 16, or 32
+template <int X, typename T>
+static __device__ inline void d_ZEdecodeXwordsperthread(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  assert((X == 8) || (X == 16) || (X == 32));
+
+  // read bitmap and count non-zero values
+  const int WPT = X;  // words per thread
+  const int tid = threadIdx.x;
+  int bmp, cnt = 0;
+  if (tid * WPT < decsize) {
+    if constexpr (X == 8) bmp = ((byte*)bmin)[tid];
+    if constexpr (X == 16) bmp = ((unsigned short*)bmin)[tid];
+    if constexpr (X == 32) bmp = ((int*)bmin)[tid];
+    cnt = __popc(bmp);
+  }
+
+  // compute prefix sum
+  int pos = block_prefix_sum(cnt, temp_w) - cnt;
+
+  // output values
+  if (tid * WPT < decsize) {
+    if ((tid | 31) * WPT + (WPT - 1) < decsize) {
+      for (int i = 0; i < WPT; i++) {
+        T val = 0;
+        if ((bmp >> i) & 1) val = datain[pos++];
+        out[tid * WPT + i] = val;
+      }
+    } else {
+      for (int i = 0; i < WPT; i++) {
+        if (tid * WPT + i >= decsize) break;
+        T val = 0;
+        if ((bmp >> i) & 1) val = datain[pos++];
+        out[tid * WPT + i] = val;
+      }
+    }
+  }
+}
+
+
+template <typename T, int maxsize = CS>  // maxsize in bytes
+static __device__ inline void d_ZEdecode_small(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  assert((TPB & (TPB - 1)) == 0);
+  assert((maxsize & (maxsize - 1)) == 0);
+  assert(maxsize % sizeof(T) == 0);
+  assert((maxsize / sizeof(T) % TPB == 0) || (maxsize / sizeof(T) < TPB));
+  const int wordsperthread = maxsize / sizeof(T) / TPB;
+  if constexpr (wordsperthread <= 1) {
+    // warp-based 1 word per thread
+    d_ZEdecode1wordperthread<T>(decsize, datain, bmin, out, temp_w);
+  } else if constexpr (wordsperthread == 2) {
+    // warp-based 2 words per thread
+    d_ZEdecode2wordsperthread<T>(decsize, datain, bmin, out, temp_w);
+  } else if constexpr (wordsperthread == 4) {
+    // warp-based 4 words per thread
+    d_ZEdecode4wordsperthread<T>(decsize, datain, bmin, out, temp_w);
+  } else if constexpr (wordsperthread == 8) {
+    // thread-based 8 words per thread
+    d_ZEdecodeXwordsperthread<8, T>(decsize, datain, bmin, out, temp_w);
+  } else if constexpr (wordsperthread == 16) {
+    // thread-based 16 words per thread
+    d_ZEdecodeXwordsperthread<16, T>(decsize, datain, bmin, out, temp_w);
+  } else if constexpr (wordsperthread == 32) {
+    // thread-based 32 words per thread
+    d_ZEdecodeXwordsperthread<32, T>(decsize, datain, bmin, out, temp_w);
+  } else {
+    // unsupported
+    __trap();
+  }
+}
+
+
+template <typename T, int maxsize = CS>
+static __device__ inline void d_ZEdecode(const int decsize, const T* const datain, const T* const bmin, T* const out, int* const temp_w)  // all sizes in number of words
+{
+  if constexpr (maxsize <= 2048) {
+//    assert(false);
+    d_ZEdecode_small<T, maxsize>(decsize, datain, bmin, out, temp_w);
+  } else if ((sizeof(T) >= 4) /*|| (((size_t)bmin & 3) == 0)*/) {  // at least int aligned
+//    assert(false);
+    d_ZEdecode_specialized(decsize, datain, (int*)bmin, out, temp_w);
+  } else if constexpr (sizeof(T) == 2) {  // short aligned
+//    assert(false);
+    const int tid = threadIdx.x;
+    const int num = (decsize + 15) / 16;  // number of subchunks (rounded up)
+
+    // count non-zero values
+    const int beg = tid * num / TPB;
+    const int end = (tid + 1) * num / TPB;
+    int cnt = 0;
+    for (int i = beg; i < end; i++) {
+      const unsigned short bm = bmin[i];
+      cnt += __popc((int)bm);
+    }
+    int pos = block_prefix_sum(cnt, temp_w) - cnt;
+
+    // output non-zero values based on bitmap
+    for (int i = beg; i < end; i++) {
+      const unsigned short bm = bmin[i];
+      for (int j = 0; j < 16; j++) {
+        short val = 0;
+        if ((bm >> j) & 1) val = datain[pos++];
+        if (i * 16 + j < decsize) out[i * 16 + j] = val;
+      }
+    }
+  } else {  // byte aligned
+    const int tid = threadIdx.x;
+    const int num = (decsize + 7) / 8;  // number of subchunks (rounded up)
+    long long* const out_l = (long long*)out;
+    assert(num <= TPB * 4);
+
+    // count non-zeros
+    const int beg = tid * num / TPB;
+    const int end = (tid + 1) * num / TPB;
+    int bmp = 0;
+    for (int i = beg; i < end; i++) {
+      bmp |= (int)bmin[i] << (8 * (i - beg));
+    }
+    const int cnt = __popc(bmp);
+    int pos = block_prefix_sum(cnt, temp_w) - cnt;
+
+    // output non-zero values based on bitmap
+    for (int i = beg; i < end; i++) {
+      const byte bm = bmp >> (8 * (i - beg));
+      long long lval = 0;
+      for (int j = 0; j < 8; j++) {
+        long long val = 0;
+        if ((bm >> j) & 1) val = datain[pos++];
+        lval |= val << (j * 8);
+      }
+      out_l[i] = lval;
+    }
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/h_CLOG.h
+++ b/include/lc/components/include/h_CLOG.h
@@ -1,0 +1,183 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef CPU_CLOG
+#define CPU_CLOG
+
+
+template <typename T>
+static inline bool h_CLOG(int& csize, byte in [CS], byte out [CS])
+{
+  assert(std::is_unsigned<T>::value);
+  const int TB = sizeof(T) * 8;  // number of bits in T
+  const int SC = 32;  // subchunks
+  const int CB = (32 - __builtin_clz(sizeof(T))) + 3;  // counter bits
+  assert((1 << CB) > TB);
+  assert((1 << (CB - 1)) <= TB);
+
+  // T casts
+  T* in_t = (T*)in;
+  T* out_t = (T*)out;
+  const int size = csize / sizeof(T);
+
+  // determine bits needed for each subchunk
+  byte ln [SC];
+  int bits = 0;
+  int end = 0;
+  for (int i = 0; i < SC; i++) {
+    const int beg = end;
+    end = (i + 1) * size / SC;
+    T max_val = 0;
+    for (int j = beg; j < end; j++) {
+      max_val = std::max(max_val, in_t[j]);
+    }
+    int cnt = 0;
+    if (max_val != 0) {
+      cnt = (sizeof(T) == 8) ? (sizeof(unsigned long long) * 8 - __builtin_clzll((unsigned long long)max_val)) : (sizeof(unsigned int) * 8 - __builtin_clz((unsigned int)max_val));
+    }
+    bits += cnt * (end - beg);
+    ln[i] = cnt;
+  }
+
+  // check if encoded data fits
+  const int extra = csize % sizeof(T);
+  const int newsize = (16 + CB * SC + bits + 7) / 8;
+  if (newsize + extra >= CS) return false;
+
+  // clear out buffer
+  memset(out_t, 0, newsize);
+
+  out[0] = csize & 0xFF;
+  out[1] = csize >> 8;
+  int loc = 16;
+  // encode logn values
+  for (int i = 0; i < SC; i++) {
+    const T val = ln[i];
+    const int pos = loc / TB;
+    const int shift = loc % TB;
+    out_t[pos] |= val << shift;
+    if (TB - CB < shift) {
+      out_t[pos + 1] = val >> (TB - shift);
+    }
+    loc += CB;
+  }
+
+  // encode data values
+  end = 0;
+  for (int i = 0; i < SC; i++) {
+    const int logn = ln[i];
+    const int beg = end;
+    end = (i + 1) * size / SC;
+    for (int j = beg; j < end; j++) {
+      const T val = in_t[j];
+      const int pos = loc / TB;
+      const int shift = loc % TB;
+      out_t[pos] |= val << shift;
+      if (TB - logn < shift) {
+        out_t[pos + 1] = val >> (TB - shift);
+      }
+      loc += logn;
+    }
+  }
+
+  // copy extra bytes at end and update csize
+  for (int i = 0; i < extra; i++) out[newsize + i] = in[csize - extra + i];
+  csize = newsize + extra;
+  return true;
+}
+
+
+template <typename T>
+static inline void h_iCLOG(int& csize, byte in [CS], byte out [CS])
+{
+  assert(std::is_unsigned<T>::value);
+  const int TB = sizeof(T) * 8;  // number of bits in T
+  const int SC = 32;  // subchunks
+  const int CB = (32 - __builtin_clz(sizeof(T))) + 3;  // counter bits
+  assert((1 << CB) > TB);
+  assert((1 << (CB - 1)) <= TB);
+
+  // T casts
+  T* in_t = (T*)in;
+  T* out_t = (T*)out;
+
+  // decode logn values
+  byte ln [SC];
+  int loc = 16;
+  const T mask = ((1 << CB) - 1);
+  for (int i = 0; i < SC; i++) {
+    const int pos = loc / TB;
+    const int shift = loc % TB;
+    T res = in_t[pos] >> shift;
+    if (TB - CB < shift) {
+      res |= in_t[pos + 1] << (TB - shift);
+    }
+    ln[i] = res & mask;
+    loc += CB;
+  }
+
+  // decode data values
+  const int orig_csize = *((unsigned short*)in);
+  const int size = orig_csize / sizeof(T);
+  int end = 0;
+  for (int i = 0; i < SC; i++) {
+    const int logn = ln[i];
+    const int beg = end;
+    end = (i + 1) * size / SC;
+    const T mask = (sizeof(T) < 8) ? ((1ULL << logn) - 1) : ((logn == 64) ? (~0ULL) : ((1ULL << logn) - 1));
+    for (int j = beg; j < end; j++) {
+      const int pos = loc / TB;
+      const int shift = loc % TB;
+      T res = in_t[pos] >> shift;
+      if (TB - logn < shift) {
+        res |= in_t[pos + 1] << (TB - shift);
+      }
+      out_t[j] = res & mask;
+      loc += logn;
+    }
+  }
+
+  // copy extra bytes at end and update csize
+  const int extra = orig_csize % sizeof(T);
+  for (int i = 0; i < extra; i++) out[orig_csize - extra + i] = in[csize - extra + i];
+  csize = orig_csize;
+}
+
+
+#endif

--- a/include/lc/components/include/h_DIFF.h
+++ b/include/lc/components/include/h_DIFF.h
@@ -1,0 +1,94 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef CPU_DIFF
+#define CPU_DIFF
+
+
+template <typename T>
+static inline bool h_DIFF(int& csize, byte in [CS], byte out [CS])
+{
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  T* const in_t = (T*)in;  // T cast
+  T* const out_t = (T*)out;
+
+  // compute difference sequence
+  T prev = 0;
+  for (int i = 0; i < size; i++) {
+    const T val = in_t[i];
+    out_t[i] = val - prev;
+    prev = val;
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    for (int i = 0; i < extra; i++) {
+      out[csize - extra + i] = in[csize - extra + i];
+    }
+  }
+  return true;
+}
+
+
+template <typename T>
+static inline void h_iDIFF(int& csize, byte in [CS], byte out [CS])
+{
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  T* const in_t = (T*)in;  // T cast
+  T* const out_t = (T*)out;
+
+  // compute prefix sum
+  T sum = 0;
+  for (int i = 0; i < size; i++) {
+    sum += in_t[i];
+    out_t[i] = sum;
+  }
+
+  // copy leftover byte
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    for (int i = 0; i < extra; i++) {
+      out[csize - extra + i] = in[csize - extra + i];
+    }
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/h_DIFFMS.h
+++ b/include/lc/components/include/h_DIFFMS.h
@@ -1,0 +1,97 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef CPU_DIFFMS
+#define CPU_DIFFMS
+
+
+template <typename T>
+static inline bool h_DIFFMS(int& csize, byte in [CS], byte out [CS])
+{
+  T* const in_t = (T*)in;  // T cast
+  T* const out_t = (T*)out;
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+
+  // compute difference sequence plus TCMS
+  T prev = 0;
+  for (int i = 0; i < size; i++) {
+    const T val = in_t[i];
+    const T data = val - prev;
+    prev = val;
+    out_t[i] = (data << 1) ^ ((std::make_signed_t<T>)data) >> (sizeof(T) * 8 - 1);
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    for (int i = 0; i < extra; i++) {
+      out[csize - extra + i] = in[csize - extra + i];
+    }
+  }
+  return true;
+}
+
+
+template <typename T>
+static inline void h_iDIFFMS(int& csize, byte in [CS], byte out [CS])
+{
+  T* const in_t = (T*)in;  // T cast
+  T* const out_t = (T*)out;
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+
+  // compute prefix sum
+  T sum = 0;
+  for (int i = 0; i < size; i++) {
+    const T data = in_t[i];
+    const T val = (data >> 1) ^ ((std::make_signed_t<T>)(data << (sizeof(T) * 8 - 1))) >> (sizeof(T) * 8 - 1);
+    sum += val;
+    out_t[i] = sum;
+  }
+
+  // copy leftover byte
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    for (int i = 0; i < extra; i++) {
+      out[csize - extra + i] = in[csize - extra + i];
+    }
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/h_HCLOG.h
+++ b/include/lc/components/include/h_HCLOG.h
@@ -1,0 +1,213 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef CPU_HCLOG
+#define CPU_HCLOG
+
+
+template <typename T>
+static inline bool h_HCLOG(int& csize, byte in [CS], byte out [CS])
+{
+  assert(std::is_unsigned<T>::value);
+  const int TB = sizeof(T) * 8;  // number of bits in T
+  const int SC = 32;  // subchunks [do not change]
+  const int CB = (32 - __builtin_clz(sizeof(T))) + 3;  // counter bits
+  assert((1 << CB) > TB);
+  assert((1 << (CB - 1)) <= TB);
+  assert(SC == sizeof(int) * 8);
+
+  // T casts
+  T* in_t = (T*)in;
+  T* out_t = (T*)out;
+  const int size = csize / sizeof(T);
+
+  // determine bits needed for each subchunk
+  byte ln [SC];
+  int flags = 0;
+  int bits = 0;
+  int end = 0;
+  for (int i = 0; i < SC; i++) {
+    // compute maximum value using both approaches
+    const int beg = end;
+    end = (i + 1) * size / SC;
+    T max_val1 = 0;
+    T max_val2 = 0;
+    for (int j = beg; j < end; j++) {
+      const T val1 = in_t[j];
+      const T val2 = (val1 << 1) ^ (((std::make_signed_t<T>)val1) >> (sizeof(T) * 8 - 1));  // TCMS
+      max_val1 = std::max(max_val1, val1);
+      max_val2 = std::max(max_val2, val2);
+    }
+
+    // use approach yielding smaller max_val
+    const T max_val = std::min(max_val1, max_val2);
+    if (max_val2 < max_val1) {
+      flags |= 1 << i;
+    }
+
+    // figure out number of bits needed
+    int cnt = 0;
+    if (max_val != 0) {
+      cnt = (sizeof(T) == 8) ? (64 - __builtin_clzll(max_val)) : (sizeof(unsigned int) * 8 - __builtin_clz((unsigned int)max_val));
+    }
+    bits += cnt * (end - beg);
+    ln[i] = cnt;
+  }
+
+  // check if encoded data fits
+  const int extra = csize % sizeof(T);
+  const int newsize = (SC + 16 + CB * SC + bits + 7) / 8;
+  if (newsize + extra >= CS) return false;
+
+  // clear out buffer
+  memset(out_t, 0, newsize);
+
+  *((int*)out) = flags;
+  out[4] = csize;
+  out[5] = csize >> 8;
+  int loc = SC + 16;
+  // encode logn values
+  for (int i = 0; i < SC; i++) {
+    const T val = ln[i];
+    const int pos = loc / TB;
+    const int shift = loc % TB;
+    out_t[pos] |= val << shift;
+    if (TB - CB < shift) {
+      out_t[pos + 1] = val >> (TB - shift);
+    }
+    loc += CB;
+  }
+
+  // encode data values
+  end = 0;
+  for (int i = 0; i < SC; i++) {
+    const int logn = ln[i];
+    const int beg = end;
+    end = (i + 1) * size / SC;
+    const bool flag = flags & (1 << i);
+    for (int j = beg; j < end; j++) {
+      T val = in_t[j];
+      if (flag) {
+        val = (val << 1) ^ (((std::make_signed_t<T>)val) >> (sizeof(T) * 8 - 1));  // TCMS
+      }
+      const int pos = loc / TB;
+      const int shift = loc % TB;
+      out_t[pos] |= val << shift;
+      if (TB - logn < shift) {
+        out_t[pos + 1] = val >> (TB - shift);
+      }
+      loc += logn;
+    }
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    for (int i = 0; i < extra; i++) out[newsize + i] = in[csize - extra + i];
+  }
+  csize = newsize + extra;
+  return true;
+}
+
+
+template <typename T>
+static inline void h_iHCLOG(int& csize, byte in [CS], byte out [CS])
+{
+  assert(std::is_unsigned<T>::value);
+  const int TB = sizeof(T) * 8;  // number of bits in T
+  const int SC = 32;  // subchunks [do not change]
+  const int CB = (32 - __builtin_clz(sizeof(T))) + 3;  // counter bits
+  assert((1 << CB) > TB);
+  assert((1 << (CB - 1)) <= TB);
+
+  // T casts
+  T* in_t = (T*)in;
+  T* out_t = (T*)out;
+
+  // decode logn values
+  const int flags = *((int*)in);
+  byte ln [SC];
+  int loc = SC + 16;
+  const T mask = ((1 << CB) - 1);
+  for (int i = 0; i < SC; i++) {
+    const int pos = loc / TB;
+    const int shift = loc % TB;
+    T res = in_t[pos] >> shift;
+    if (TB - CB < shift) {
+      res |= in_t[pos + 1] << (TB - shift);
+    }
+    ln[i] = res & mask;
+    loc += CB;
+  }
+
+  // decode data values
+  const int orig_csize = in[4] + ((int)in[5] << 8);
+  const int size = orig_csize / sizeof(T);
+  int end = 0;
+  for (int i = 0; i < SC; i++) {
+    const int logn = ln[i];
+    const int beg = end;
+    end = (i + 1) * size / SC;
+    const T mask = (sizeof(T) < 8) ? ((1ULL << logn) - 1) : ((logn == 64) ? (~0ULL) : ((1ULL << logn) - 1));
+    const bool flag = flags & (1 << i);
+    for (int j = beg; j < end; j++) {
+      const int pos = loc / TB;
+      const int shift = loc % TB;
+      T res = in_t[pos] >> shift;
+      if (TB - logn < shift) {
+        res |= in_t[pos + 1] << (TB - shift);
+      }
+      T val = res & mask;
+      if (flag) {
+        val = (val >> 1) ^ ((std::make_signed_t<T>)(val << (sizeof(T) * 8 - 1))) >> (sizeof(T) * 8 - 1);  // iTCMS
+      }
+      out_t[j] = val;
+      loc += logn;
+    }
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    const int extra = orig_csize % sizeof(T);
+    for (int i = 0; i < extra; i++) out[orig_csize - extra + i] = in[csize - extra + i];
+  }
+  csize = orig_csize;
+}
+
+
+#endif

--- a/include/lc/components/include/h_RLE.h
+++ b/include/lc/components/include/h_RLE.h
@@ -1,0 +1,155 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef CPU_RLE
+#define CPU_RLE
+
+
+template <typename T>
+static inline bool h_RLE(int& csize, byte in [CS], byte out [CS])
+{
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  byte counts [CS / sizeof(T)];  // upper bound on size
+  const int elems = csize / sizeof(T);
+  const int extra = csize % sizeof(T);
+  int cpos = 0;  // count position
+  int vpos = 0;  // value position
+
+  // look for repeating and non-repeating values
+  T prev = ~in_t[0];
+  int repeat = 0;
+  int nrepeat = 0;
+  for (int i = 0; i < elems; i++) {
+    const T curr = in_t[i];
+    if (prev != curr) {  // not repeating
+      prev = curr;
+      out_t[vpos++] = curr;  // output non-repeating value
+      nrepeat++;
+      // output repeat counts
+      while (repeat > 0) {
+        const int rep = std::min(128, repeat);
+        counts[cpos++] = 0x80 | (rep - 1);
+        repeat -= rep;
+      }
+    } else {  // repeating
+      repeat++;
+      // output non-repeat counts
+      while (nrepeat > 0) {
+        const int nrep = std::min(128, nrepeat);
+        counts[cpos++] = nrep - 1;
+        nrepeat -= nrep;
+      }
+    }
+  }
+
+  // output and remaining counts
+  while (repeat > 0) {
+    const int rep = std::min(128, repeat);
+    counts[cpos++] = 0x80 | (rep - 1);
+    repeat -= rep;
+  }
+  while (nrepeat > 0) {
+    const int nrep = std::min(128, nrepeat);
+    counts[cpos++] = nrep - 1;
+    nrepeat -= nrep;
+  }
+
+  // check compressed size
+  int wpos = vpos * sizeof(T);
+  const int newsize = wpos + cpos + extra + 2;
+  if (newsize >= CS) return false;
+
+  // copy extra bytes at end
+  for (int j = 0; j < extra; j++) {
+    out[wpos++] = in[csize - extra + j];
+  }
+
+  // copy counts to output
+  for (int j = 0; j < cpos; j++) {
+    out[wpos + j] = counts[j];
+  }
+
+  // store position where counts start
+  out[newsize - 2] = wpos & 0xff;
+  out[newsize - 1] = (wpos >> 8) & 0xff;
+  csize = newsize;
+  return true;
+}
+
+
+template <typename T>
+static inline void h_iRLE(int& csize, byte in [CS], byte out[CS])
+{
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  const int cpos = (((int)in[csize - 1]) << 8) | in[csize - 2];
+  const int extra = cpos % sizeof(T);
+
+  int wpos = 0;  // write position
+  int vpos = 0;  // value position
+  T val = 0;
+  for (int i = cpos; i < csize - 2; i++) {
+    const int rep = in[i];  // int instead of byte
+    if (rep & 0x80) {
+      // write repeating values
+      const int repeat = (rep & 0x7f) + 1;
+      for (int j = 0; j < repeat; j++) {
+        out_t[wpos++] = val;
+      }
+    } else {
+      // write non-repeating values
+      const int nrepeat = rep + 1;
+      for (int j = 0; j < nrepeat; j++) {
+        val = in_t[vpos++];
+        out_t[wpos++] = val;
+      }
+    }
+  }
+
+  // copy extra bytes at end
+  wpos *= sizeof(T);
+  for (int j = 0; j < extra; j++) {
+    out[wpos++] = in[cpos - extra + j];
+  }
+  csize = wpos;
+}
+
+
+#endif

--- a/include/lc/components/include/h_RRE.h
+++ b/include/lc/components/include/h_RRE.h
@@ -1,0 +1,184 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef CPU_RRE
+#define CPU_RRE
+
+
+#include "h_repetition_elimination.h"
+
+
+template <typename T>
+static inline bool h_RRE(int& csize, byte in [CS], byte out [CS])
+{
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  const int extra = csize % sizeof(T);
+  const int bits = 8 * sizeof(T);
+  const int num = (2048 + 256 + 32 + 4) / sizeof(T);
+  assert(CS == 16384);
+
+  // zero out end of bitmap
+  byte bitmap [num];
+  if (csize < CS) {
+    memset(&bitmap[csize / bits], 0, CS / bits - csize / bits);
+  }
+
+  // copy non-repeating values and generate bitmap
+  int wpos = 0;
+  if (size > 0) h_REencode((T*)in, size, (T*)out, wpos, (T*)bitmap);
+  wpos *= sizeof(T);
+  if (wpos >= CS - 2 - extra) return false;
+
+  // check if not all zeros
+  if (wpos != 0) {
+    int base = 0;
+    int range = CS / bits;
+
+    // iteratively compress bitmap
+    while (range >= 8) {  // 2048 256 32 / sizeof(T)
+      byte prev = 0;
+      for (int i = 0; i < range; i += 8) {
+        const long long lval = *((long long*)(&bitmap[base + i]));
+        byte bmp = 0;
+        for (int j = 0; j < 8; j++) {
+          const byte val = (lval >> (j * 8)) & 0xff;
+          if (val != prev) {
+            out[wpos++] = prev = val;
+            bmp |= 1 << j;
+            if (wpos >= CS - 2 - extra) return false;
+          }
+        }
+        bitmap[base + range + i / 8] = bmp;
+      }
+      base += range;
+      range /= 8;
+    }
+
+    // output last level of bitmap
+    if (wpos >= CS - 2 - extra - range) return false;
+    for (int i = 0; i < range; i++) {  // 4 / sizeof(T)
+      out[wpos++] = bitmap[base + i];
+    }
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    for (int i = 0; i < extra; i++) {
+      out[wpos++] = in[csize - extra + i];
+    }
+  }
+
+  // output old csize and update csize
+  out[wpos++] = csize;  // bottom byte
+  out[wpos++] = csize >> 8;  // second byte
+  csize = wpos;
+  return true;
+}
+
+
+template <typename T>
+static inline void h_iRRE(int& csize, byte in [CS], byte out [CS])
+{
+  int rpos = csize;
+  csize = (int)in[--rpos] << 8;  // second byte
+  csize |= in[--rpos];  // bottom byte
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  const int bits = 8 * sizeof(T);
+  const int num = (2048 + 256 + 32 + 4) / sizeof(T);
+  assert(CS == 16384);
+
+  // copy leftover byte
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    for (int i = 0; i < extra; i++) {
+      out[csize - extra + i] = in[rpos - extra + i];
+    }
+    rpos -= extra;
+  }
+
+  if (rpos == 0) {
+    // all zeros
+    memset(out, 0, size * sizeof(T));
+  } else {
+    int base = 0;
+    int range = CS / bits;
+    while (range >= 8) {  // 2048 256 32 / sizeof(T)
+      base += range;
+      range /= 8;
+    }
+
+    // read in last level of bitmap
+    byte bitmap [num];
+    rpos -= range;
+    for (int i = 0; i < range; i++) {  // 4 / sizeof(T)
+      bitmap[base + i] = in[rpos + i];
+    }
+
+    // iteratively decompress bitmap
+    while (range < CS / bits) {  // 32 256 2048 / sizeof(T)
+      range *= 8;
+      base -= range;
+
+      if (range % 64 != 0) {
+        for (int i = 0; i < range; i += 8) {
+          rpos -= __builtin_popcount((int)bitmap[base + range + i / 8]);
+        }
+      } else {
+        for (int i = 0; i < range; i += 64) {
+          rpos -= __builtin_popcountll(*((long long*)(&bitmap[base + range + i / 8])));
+        }
+      }
+
+      int pos = rpos;
+      byte val = 0;
+      for (int i = 0; i < range; i++) {
+        if (bitmap[base + range + i / 8] & (1 << (i % 8))) {
+          val = in[pos++];
+        }
+        bitmap[base + i] = val;
+      }
+    }
+
+    // copy non-repeating values based on bitmap
+    if (size > 0) h_REdecode(size, (T*)in, (T*)bitmap, (T*)out);
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/h_RZE.h
+++ b/include/lc/components/include/h_RZE.h
@@ -1,0 +1,184 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef CPU_RZE
+#define CPU_RZE
+
+
+#include "h_zero_elimination.h"
+
+
+template <typename T>
+static inline bool h_RZE(int& csize, byte in [CS], byte out [CS])
+{
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  const int extra = csize % sizeof(T);
+  const int bits = 8 * sizeof(T);
+  const int num = (2048 + 256 + 32 + 4) / sizeof(T);
+  assert(CS == 16384);
+
+  // zero out end of bitmap
+  byte bitmap [num];
+  if (csize < CS) {
+    memset(&bitmap[csize / bits], 0, CS / bits - csize / bits);
+  }
+
+  // copy non-zero values and generate bitmap
+  int wpos = 0;
+  if (size > 0) h_ZEencode((T*)in, size, (T*)out, wpos, (T*)bitmap);
+  wpos *= sizeof(T);
+  if (wpos >= CS - 2 - extra) return false;
+
+  // check if not all zeros
+  if (wpos != 0) {
+    int base = 0;
+    int range = CS / bits;
+
+    // iteratively compress bitmap
+    while (range >= 8) {  // 2048 256 32 / sizeof(T)
+      byte prev = 0;
+      for (int i = 0; i < range; i += 8) {
+        const long long lval = *((long long*)(&bitmap[base + i]));
+        byte bmp = 0;
+        for (int j = 0; j < 8; j++) {
+          const byte val = (lval >> (j * 8)) & 0xff;
+          if (val != prev) {
+            out[wpos++] = prev = val;
+            bmp |= 1 << j;
+            if (wpos >= CS - 2 - extra) return false;
+          }
+        }
+        bitmap[base + range + i / 8] = bmp;
+      }
+      base += range;
+      range /= 8;
+    }
+
+    // output last level of bitmap
+    if (wpos >= CS - 2 - extra - range) return false;
+    for (int i = 0; i < range; i++) {  // 4 / sizeof(T)
+      out[wpos++] = bitmap[base + i];
+    }
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    for (int i = 0; i < extra; i++) {
+      out[wpos++] = in[csize - extra + i];
+    }
+  }
+
+  // output old csize and update csize
+  out[wpos++] = csize;  // bottom byte
+  out[wpos++] = csize >> 8;  // second byte
+  csize = wpos;
+  return true;
+}
+
+
+template <typename T>
+static inline void h_iRZE(int& csize, byte in [CS], byte out [CS])
+{
+  int rpos = csize;
+  csize = (int)in[--rpos] << 8;  // second byte
+  csize |= in[--rpos];  // bottom byte
+  const int size = csize / sizeof(T);  // words in chunk (rounded down)
+  const int bits = 8 * sizeof(T);
+  const int num = (2048 + 256 + 32 + 4) / sizeof(T);
+  assert(CS == 16384);
+
+  // copy leftover byte
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    for (int i = 0; i < extra; i++) {
+      out[csize - extra + i] = in[rpos - extra + i];
+    }
+    rpos -= extra;
+  }
+
+  if (rpos == 0) {
+    // all zeros
+    memset(out, 0, size * sizeof(T));
+  } else {
+    int base = 0;
+    int range = CS / bits;
+    while (range >= 8) {  // 2048 256 32 / sizeof(T)
+      base += range;
+      range /= 8;
+    }
+
+    // read in last level of bitmap
+    byte bitmap [num];
+    rpos -= range;
+    for (int i = 0; i < range; i++) {  // 4 / sizeof(T)
+      bitmap[base + i] = in[rpos + i];
+    }
+
+    // iteratively decompress bitmap
+    while (range < CS / bits) {  // 32 256 2048 / sizeof(T)
+      range *= 8;
+      base -= range;
+
+      if (range % 64 != 0) {
+        for (int i = 0; i < range; i += 8) {
+          rpos -= __builtin_popcount((int)bitmap[base + range + i / 8]);
+        }
+      } else {
+        for (int i = 0; i < range; i += 64) {
+          rpos -= __builtin_popcountll(*((long long*)(&bitmap[base + range + i / 8])));
+        }
+      }
+
+      int pos = rpos;
+      byte val = 0;
+      for (int i = 0; i < range; i++) {
+        if (bitmap[base + range + i / 8] & (1 << (i % 8))) {
+          val = in[pos++];
+        }
+        bitmap[base + i] = val;
+      }
+    }
+
+    // copy non-zero values based on bitmap
+    if (size > 0) h_ZEdecode(size, (T*)in, (T*)bitmap, (T*)out);
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/h_TCMS.h
+++ b/include/lc/components/include/h_TCMS.h
@@ -1,0 +1,93 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef CPU_TCMS
+#define CPU_TCMS
+
+
+template <typename T>
+static inline bool h_TCMS(int& csize, byte in [CS], byte out [CS])
+{
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  const int size = csize / sizeof(T);
+
+  // convert from twos-complement to magnitude-sign format
+  for (int i = 0; i < size; i++) {
+    const T data = in_t[i];
+    const T s = ((std::make_signed_t<T>)data) >> (sizeof(T) * 8 - 1);
+    out_t[i] = (data << 1) ^ s;
+  }
+
+  // copy leftover bytes
+  if constexpr (sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    for (int i = 0; i < extra; i++) {
+      out[csize - extra + i] = in[csize - extra + i];
+    }
+  }
+  return true;
+}
+
+
+template <typename T>
+static inline void h_iTCMS(int& csize, byte in [CS], byte out [CS])
+{
+  T* const in_t = (T*)in;
+  T* const out_t = (T*)out;
+  const int size = csize / sizeof(T);
+
+  // convert from magnitude-sign to twos-complement format
+  for (int i = 0; i < size; i++) {
+    const T data = in_t[i];
+    const T s = ((std::make_signed_t<T>)(data << (sizeof(T) * 8 - 1))) >> (sizeof(T) * 8 - 1);
+    out_t[i] = (data >> 1) ^ s;
+  }
+
+  // copy leftover bytes
+  if constexpr(sizeof(T) > 1) {
+    const int extra = csize % sizeof(T);
+    for (int i = 0; i < extra; i++) {
+      out[csize - extra + i] = in[csize - extra + i];
+    }
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/h_TUPL.h
+++ b/include/lc/components/include/h_TUPL.h
@@ -1,0 +1,85 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef CPU_TUPL
+#define CPU_TUPL
+
+
+template <typename T, int dim>
+static inline bool h_TUPL(int& csize, byte in [CS], byte out [CS])
+{
+  assert(dim > 1);
+  const int tuples = csize / sizeof(T) / dim;  // tuples in chunk (rounded down)
+  const int size = tuples * dim;  // words in all tuples
+  const int extra = csize - sizeof(T) * size;  // leftover bytes
+  T* const buf_in = (T*)in;  // type cast
+  T* const buf_out = (T*)out;  // type cast
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) out[sizeof(T) * size + i] = in[sizeof(T) * size + i];
+
+  // distribute fields of structs
+  for (int i = 0; i < size; i++) {
+    buf_out[(i / dim) + (i % dim) * tuples] = buf_in[i];
+  }
+  return true;
+}
+
+
+template <typename T, int dim>
+static inline void h_iTUPL(int& csize, byte in [CS], byte out [CS])
+{
+  assert(dim > 1);
+  const int tuples = csize / sizeof(T) / dim;  // tuples in chunk (rounded down)
+  const int size = tuples * dim;  // words in all tuples
+  const int extra = csize - sizeof(T) * size;  // leftover bytes
+  T* const buf_in = (T*)in;  // type cast
+  T* const buf_out = (T*)out;  // type cast
+
+  // copy leftover bytes
+  for (int i = 0; i < extra; i++) out[sizeof(T) * size + i] = in[sizeof(T) * size + i];
+
+  // recombine fields of structs
+  for (int i = 0; i < size; i++) {
+    buf_out[i] = buf_in[(i / dim) + (i % dim) * tuples];
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/h_repetition_elimination.h
+++ b/include/lc/components/include/h_repetition_elimination.h
@@ -1,0 +1,120 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef repetition_elimination_host
+#define repetition_elimination_host
+
+
+template <typename T, bool check = false>
+static inline bool h_REencode(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout)  // all sizes in number of words
+{
+  const int bits = sizeof(T) * 8;  // bits per word
+  const int num = (insize + bits - 1) / bits;  // number of subchunks (rounded up)
+  int pos = 0;
+  int cnt = 0;
+  T prev = 0;
+  for (int i = 0; i < num - 1; i++) {
+    T bm = 0;
+    for (int j = 0; j < bits; j++) {
+      const T val = in[cnt++];
+      if (val != prev) {
+        if constexpr (check) {
+          if (pos >= datasize) return false;
+        }
+        bm |= (T)1 << j;
+        dataout[pos++] = val;
+      }
+      prev = val;
+    }
+    bmout[i] = bm;
+  }
+  const int i = num - 1;
+  {
+    T bm = 0;
+    for (int j = 0; j < bits; j++) {
+      if (cnt >= insize) break;
+      const T val = in[cnt++];
+      if (val != prev) {
+        if constexpr (check) {
+          if (pos >= datasize) return false;
+        }
+        bm |= (T)1 << j;
+        dataout[pos++] = val;
+      }
+      prev = val;
+    }
+    bmout[i] = bm;
+  }
+  datasize = pos;
+  return true;
+}
+
+
+template <typename T>
+static inline void h_REdecode(const int decsize, const T* const datain, const T* const bmin, T* const out)  // all sizes in number of words
+{
+  const int bits = sizeof(T) * 8;  // bits per word
+  const int num = (decsize + bits - 1) / bits;  // number of subchunks (rounded up)
+  int pos = 0;
+  int cnt = 0;
+  T val = 0;
+  for (int i = 0; i < num - 1; i++) {
+    const T bm = bmin[i];
+    for (int j = 0; j < bits; j++) {
+      if (((bm >> j) & 1) != 0) {
+        val = datain[pos++];
+      }
+      out[cnt++] = val;
+    }
+  }
+  const int i = num - 1;
+  {
+    const T bm = bmin[i];
+    for (int j = 0; j < bits; j++) {
+      if (((bm >> j) & 1) != 0) {
+        val = datain[pos++];
+      }
+      out[cnt++] = val;
+      if (cnt >= decsize) break;
+    }
+  }
+}
+
+
+#endif

--- a/include/lc/components/include/h_zero_elimination.h
+++ b/include/lc/components/include/h_zero_elimination.h
@@ -1,0 +1,118 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef zero_elimination_host
+#define zero_elimination_host
+
+
+template <typename T, bool check = false>
+static inline bool h_ZEencode(const T* const in, const int insize, T* const dataout, int& datasize, T* const bmout)  // all sizes in number of words
+{
+  const int bits = sizeof(T) * 8;  // bits per word
+  const int num = (insize + bits - 1) / bits;  // number of subchunks (rounded up)
+  int pos = 0;
+  int cnt = 0;
+  for (int i = 0; i < num - 1; i++) {
+    T bm = 0;
+    for (int j = 0; j < bits; j++) {
+      const T val = in[cnt++];
+      if (val != 0) {
+        if constexpr (check) {
+          if (pos >= datasize) return false;
+        }
+        bm |= (T)1 << j;
+        dataout[pos++] = val;
+      }
+    }
+    bmout[i] = bm;
+  }
+  const int i = num - 1;
+  {
+    T bm = 0;
+    for (int j = 0; j < bits; j++) {
+      if (cnt >= insize) break;
+      const T val = in[cnt++];
+      if (val != 0) {
+        if constexpr (check) {
+          if (pos >= datasize) return false;
+        }
+        bm |= (T)1 << j;
+        dataout[pos++] = val;
+      }
+    }
+    bmout[i] = bm;
+  }
+  datasize = pos;
+  return true;
+}
+
+
+template <typename T>
+static inline void h_ZEdecode(const int decsize, const T* const datain, const T* const bmin, T* const out)  // all sizes in number of words
+{
+  const int bits = sizeof(T) * 8;  // bits per word
+  const int num = (decsize + bits - 1) / bits;  // number of subchunks (rounded up)
+  int pos = 0;
+  int cnt = 0;
+  for (int i = 0; i < num - 1; i++) {
+    const T bm = bmin[i];
+    for (int j = 0; j < bits; j++) {
+      T val = 0;
+      if (((bm >> j) & 1) != 0) {
+        val = datain[pos++];
+      }
+      out[cnt++] = val;
+    }
+  }
+  const int i = num - 1;
+  {
+    const T bm = bmin[i];
+    for (int j = 0; j < bits; j++) {
+      T val = 0;
+      if (((bm >> j) & 1) != 0) {
+        val = datain[pos++];
+      }
+      out[cnt++] = val;
+      if (cnt >= decsize) break;
+    }
+  }
+}
+
+
+#endif

--- a/include/lc/lc.h
+++ b/include/lc/lc.h
@@ -1,0 +1,13 @@
+#pragma once
+
+void BITR_COMPRESS(uint8_t* input, size_t insize, uint8_t** output, size_t* outsize, float* time, void* stream);
+
+void TCMS_COMPRESS(uint8_t* input, size_t insize, uint8_t** output, size_t* outsize, float* time, void* stream);
+
+void RTR_COMPRESS(uint8_t* input, size_t insize, uint8_t** output, size_t* outsize, float* time, void* stream);
+
+void BITR_DECOMPRESS(uint8_t* input, void** output, float* time);
+
+void TCMS_DECOMPRESS(uint8_t* input, void** output, float* time);
+
+void RTR_DECOMPRESS(uint8_t* input, void** output, float* time);

--- a/include/lc/max_scan.h
+++ b/include/lc/max_scan.h
@@ -1,0 +1,107 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef max_scan
+#define max_scan
+
+template <typename T>
+static __device__ inline T block_max_scan(T val, void* buffer)  // returns inclusive maximum scan
+{
+  const int lane = threadIdx.x % WS;
+  const int warp = threadIdx.x / WS;
+  const int warps = TPB / WS;
+  T* const carry = (T*)buffer;
+  assert(WS >= warps);
+
+  T tmp = __shfl_up_sync(~0, val, 1);
+  if (lane >= 1) val = max(val, tmp);
+  tmp = __shfl_up_sync(~0, val, 2);
+  if (lane >= 2) val = max(val, tmp);
+  tmp = __shfl_up_sync(~0, val, 4);
+  if (lane >= 4) val = max(val, tmp);
+  tmp = __shfl_up_sync(~0, val, 8);
+  if (lane >= 8) val = max(val, tmp);
+  tmp = __shfl_up_sync(~0, val, 16);
+  if (lane >= 16) val = max(val, tmp);
+#if defined(WS) && (WS == 64)
+  tmp = __shfl_up_sync(~0, val, 32);
+  if (lane >= 32) val = max(val, tmp);
+#endif
+
+  if (lane == WS - 1) carry[warp] = val;
+  __syncthreads();  // carry written
+
+  if constexpr (warps > 1) {
+    if (warp == 0) {
+      T res = carry[lane];
+      T tmp = __shfl_up_sync(~0, res, 1);
+      if (lane >= 1) res = max(res, tmp);
+      if constexpr (warps > 2) {
+        tmp = __shfl_up_sync(~0, res, 2);
+        if (lane >= 2) res = max(res, tmp);
+        if constexpr (warps > 4) {
+          tmp = __shfl_up_sync(~0, res, 4);
+          if (lane >= 4) res = max(res, tmp);
+          if constexpr (warps > 8) {
+            tmp = __shfl_up_sync(~0, res, 8);
+            if (lane >= 8) res = max(res, tmp);
+            if constexpr (warps > 16) {
+              tmp = __shfl_up_sync(~0, res, 16);
+              if (lane >= 16) res = max(res, tmp);
+              #if defined(WS) && (WS == 64)
+              if constexpr (warps > 32) {
+                tmp = __shfl_up_sync(~0, res, 32);
+                if (lane >= 32) res = max(res, tmp);
+              }
+              #endif
+            }
+          }
+        }
+      }
+      carry[lane] = res;
+    }
+    __syncthreads();  // carry updated
+
+    if (warp > 0) val = max(val, carry[warp - 1]);
+  }
+
+  return val;
+}
+
+#endif

--- a/include/lc/prefix_sum.h
+++ b/include/lc/prefix_sum.h
@@ -1,0 +1,107 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef prefix_sum
+#define prefix_sum
+
+template <typename T>
+static __device__ inline T block_prefix_sum(T val, void* buffer)  // returns inclusive prefix sum
+{
+  const int lane = threadIdx.x % WS;
+  const int warp = threadIdx.x / WS;
+  const int warps = TPB / WS;
+  T* const carry = (T*)buffer;
+  assert(WS >= warps);
+
+  T tmp = __shfl_up_sync(~0, val, 1);
+  if (lane >= 1) val += tmp;
+  tmp = __shfl_up_sync(~0, val, 2);
+  if (lane >= 2) val += tmp;
+  tmp = __shfl_up_sync(~0, val, 4);
+  if (lane >= 4) val += tmp;
+  tmp = __shfl_up_sync(~0, val, 8);
+  if (lane >= 8) val += tmp;
+  tmp = __shfl_up_sync(~0, val, 16);
+  if (lane >= 16) val += tmp;
+#if defined(WS) && (WS == 64)
+  tmp = __shfl_up_sync(~0, val, 32);
+  if (lane >= 32) val += tmp;
+#endif
+
+  if (lane == WS - 1) carry[warp] = val;
+  __syncthreads();  // carry written
+
+  if constexpr (warps > 1) {
+    if (warp == 0) {
+      T sum = carry[lane];
+      T tmp = __shfl_up_sync(~0, sum, 1);
+      if (lane >= 1) sum += tmp;
+      if constexpr (warps > 2) {
+        tmp = __shfl_up_sync(~0, sum, 2);
+        if (lane >= 2) sum += tmp;
+        if constexpr (warps > 4) {
+          tmp = __shfl_up_sync(~0, sum, 4);
+          if (lane >= 4) sum += tmp;
+          if constexpr (warps > 8) {
+            tmp = __shfl_up_sync(~0, sum, 8);
+            if (lane >= 8) sum += tmp;
+            if constexpr (warps > 16) {
+              tmp = __shfl_up_sync(~0, sum, 16);
+              if (lane >= 16) sum += tmp;
+              #if defined(WS) && (WS == 64)
+              if constexpr (warps > 32) {
+                tmp = __shfl_up_sync(~0, sum, 32);
+                if (lane >= 32) sum += tmp;
+              }
+              #endif
+            }
+          }
+        }
+      }
+      carry[lane] = sum;
+    }
+    __syncthreads();  // carry updated
+
+    if (warp > 0) val += carry[warp - 1];
+  }
+
+  return val;
+}
+
+#endif

--- a/include/lc/sum_reduction.h
+++ b/include/lc/sum_reduction.h
@@ -1,0 +1,92 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef sum_reduction
+#define sum_reduction
+
+template <typename T>
+static __device__ inline T block_sum_reduction(T val, void* buffer)  // returns sum to all threads
+{
+  const int lane = threadIdx.x % WS;
+  const int warp = threadIdx.x / WS;
+  const int warps = TPB / WS;
+  T* const s_carry = (T*)buffer;
+  assert(WS >= warps);
+
+  val += __shfl_xor_sync(~0, val, 1);  // MB: use reduction on 8.6 CC
+  val += __shfl_xor_sync(~0, val, 2);
+  val += __shfl_xor_sync(~0, val, 4);
+  val += __shfl_xor_sync(~0, val, 8);
+  val += __shfl_xor_sync(~0, val, 16);
+#if defined(WS) && (WS == 64)
+  val += __shfl_xor_sync(~0, val, 32);
+#endif
+  if (lane == 0) s_carry[warp] = val;
+  __syncthreads();  // s_carry written
+
+  if constexpr (warps > 1) {
+    if (warp == 0) {
+      val = (lane < warps) ? s_carry[lane] : 0;
+      val += __shfl_xor_sync(~0, val, 1);  // MB: use reduction on 8.6 CC
+      if constexpr (warps > 2) {
+        val += __shfl_xor_sync(~0, val, 2);
+        if constexpr (warps > 4) {
+          val += __shfl_xor_sync(~0, val, 4);
+          if constexpr (warps > 8) {
+            val += __shfl_xor_sync(~0, val, 8);
+            if constexpr (warps > 16) {
+              val += __shfl_xor_sync(~0, val, 16);
+              #if defined(WS) && (WS == 64)
+              if constexpr (warps > 32) {
+                val += __shfl_xor_sync(~0, val, 32);
+              }
+              #endif
+            }
+          }
+        }
+      }
+      s_carry[lane] = val;
+    }
+    __syncthreads();  // s_carry updated
+  }
+
+  return s_carry[0];
+}
+
+#endif

--- a/include/mem/layout_cxx.hh
+++ b/include/mem/layout_cxx.hh
@@ -37,6 +37,7 @@ class pszmempool_cxx {
   Compact *compact;
 
   pszmem_cxx<B> *_compressed;  // compressed
+  B *_compressed_rre1;  // final compressed
 
   size_t len;
   int radius, bklen;
@@ -72,8 +73,9 @@ TPL POOL::pszmempool_cxx(u4 x, int _radius, u4 y, u4 z)
   auto pad = [&](auto _l, auto unit) { return unit * div(_l, unit); };
 
   // for spline
-  constexpr auto BLK = 8;
-  constexpr auto ERR_HISTO_LEN = 6;
+  constexpr auto BLK = 16;
+  //constexpr auto ERR_HISTO_LEN = 6;
+  constexpr auto ERR_HISTO_LEN = 36;
 
   _compressed = new pszmem_cxx<B>(len * 1.2, 1, 1, "compressed");
 

--- a/include/tehm.hh
+++ b/include/tehm.hh
@@ -40,7 +40,7 @@ struct TEHM {
    */
 
   using T = InDtype;
-  using E = ErrCtrlTrait<4, false>::type;  // predefined for mem. overlapping
+  using E = ErrCtrlTrait<1, false>::type;  // predefined for mem. overlapping
   using FP = typename FastLowPrecisionTrait<FastLowPrecision>::type;
   // using H = u4;
   // using Hfailsafe = u8;

--- a/include/utils/viewer/viewer.cu_hip.hh
+++ b/include/utils/viewer/viewer.cu_hip.hh
@@ -85,7 +85,7 @@ static void view(
 
   auto compare_on_cpu = [&]() {
     cmp->control({MallocHost})->file(compare.c_str(), FromFile);
-    cmp->control({D2H});
+    // cmp->control({D2H});
     eval_dataquality_cpu(xdata->hptr(), cmp->hptr(), len, compressd_bytes);
     // cmp->control({FreeHost});
   };

--- a/src/context.cc
+++ b/src/context.cc
@@ -181,15 +181,31 @@ void pszctx_parse_control_string(
     else if (optmatch({"beta"})) {
       ctx->intp_param.beta = psz_helper::str2fp(v);
     }
-    else if (optmatch({"intp_0"})) {
-      ctx->intp_param.interpolators[0] = psz_helper::str2int(v);
+    else if (optmatch({"md_0"})) {
+      ctx->intp_param.use_md[0] = psz_helper::str2int(v);
     }
-    else if (optmatch({"intp_1"})) {
-      ctx->intp_param.interpolators[1] = psz_helper::str2int(v);
+    else if (optmatch({"md_1"})) {
+      ctx->intp_param.use_md[1] = psz_helper::str2int(v);
     }
-    else if (optmatch({"intp_2"})) {
-      ctx->intp_param.interpolators[2] = psz_helper::str2int(v);
+    else if (optmatch({"md_2"})) {
+      ctx->intp_param.use_md[2] = psz_helper::str2int(v);
     }
+    else if (optmatch({"md_3"})) {
+      ctx->intp_param.use_md[3] = psz_helper::str2int(v);
+    }
+    else if (optmatch({"nat_0"})) {
+      ctx->intp_param.use_natural[0] = psz_helper::str2int(v);
+    }
+    else if (optmatch({"nat_1"})) {
+      ctx->intp_param.use_natural[1] = psz_helper::str2int(v);
+    }
+    else if (optmatch({"nat_2"})) {
+      ctx->intp_param.use_natural[2] = psz_helper::str2int(v);
+    }
+    else if (optmatch({"nat_3"})) {
+      ctx->intp_param.use_natural[3] = psz_helper::str2int(v);
+    }
+
     else if (optmatch({"rev_0"})) {
       ctx->intp_param.reverse[0] = psz_helper::str2int(v);
     }
@@ -198,6 +214,9 @@ void pszctx_parse_control_string(
     }
     else if (optmatch({"rev_2"})) {
       ctx->intp_param.reverse[2] = psz_helper::str2int(v);
+    }
+    else if (optmatch({"rev_3"})) {
+      ctx->intp_param.reverse[3] = psz_helper::str2int(v);
     }
   }
 }
@@ -357,6 +376,16 @@ void pszctx_parse_argv(pszctx* ctx, int const argc, char** const argv)
         check_next();
         auto _ = std::stoi(argv[++i]);
         ctx->intp_param.auto_tuning = (uint8_t)_;
+      }
+      else if (optmatch({"-s", "--scheme"})) {
+        check_next();
+        auto _ = std::string(argv[++i]);
+        if (_ == "tp") {
+          ctx->use_huffman = false;
+        }
+        else if (_ == "cr") {
+          ctx->use_huffman = true;
+        }
       }
 
       else if (optmatch({"--sycl-device"})) {

--- a/src/cusz_lib.cc
+++ b/src/cusz_lib.cc
@@ -20,7 +20,7 @@
 #include "tehm.hh"
 
 pszpredictor pszdefault_predictor() { return {Spline}; }
-pszquantizer pszdefault_quantizer() { return {512}; }
+pszquantizer pszdefault_quantizer() { return {128}; }
 pszhfrc pszdefault_hfcoder() { return {Sword, Coarse, 1024, 768}; }
 pszframe* pszdefault_framework()
 {
@@ -110,13 +110,13 @@ pszerror psz_decompress_init(pszcompressor* comp, pszheader* header)
 
 pszerror psz_decompress(
     pszcompressor* comp, pszout compressed, size_t const comp_len,
-    void* decompressed, pszlen const decomp_len, void* record, void* stream)
+    void* decompressed, void* outlier_tmp, pszlen const decomp_len, void* record, void* stream)
 {
   if (comp->type == F4) {
     auto cor = (cusz::CompressorF4*)(comp->compressor);
 
     cor->decompress(
-        comp->header, compressed, (f4*)(decompressed), (GpuStreamT)stream);
+        comp->header, compressed, (f4*)(decompressed), (f4*)(outlier_tmp), (GpuStreamT)stream);
     cor->export_timerecord((psz::TimeRecord*)record);
   }
   else {

--- a/src/kernel/detail/spline.inl
+++ b/src/kernel/detail/spline.inl
@@ -1,0 +1,2017 @@
+/**
+ * @file spline2.inl
+ * @author Jinyang Liu, Shixun Wu, Jiannan Tian
+ * @brief
+ * @version 0.2
+ * @date 2021-05-15
+ *
+ * (copyright to be updated)
+ * (C) 2021 by Washington State University, Argonne National Laboratory
+ *
+ */
+
+ #ifndef CUSZ_KERNEL_SPLINE3_CUH
+ #define CUSZ_KERNEL_SPLINE3_CUH
+ 
+ #include <stdint.h>
+ #include <stdio.h>
+ 
+ #include <type_traits>
+ 
+ #include "cusz/type.h"
+ #include "utils/err.hh"
+ #include "utils/timer.hh"
+ 
+ #define SPLINE3_COMPR true
+ #define SPLINE3_DECOMPR false
+ 
+ #if __cplusplus >= 201703L
+ #define CONSTEXPR constexpr
+ #else
+ #define CONSTEXPR
+ #endif
+ 
+ #define TIX threadIdx.x
+ #define TIY threadIdx.y
+ #define TIZ threadIdx.z
+ #define BIX blockIdx.x
+ #define BIY blockIdx.y
+ #define BIZ blockIdx.z
+ #define BDX blockDim.x
+ #define BDY blockDim.y
+ #define BDZ blockDim.z
+ #define GDX gridDim.x
+ #define GDY gridDim.y
+ #define GDZ gridDim.z
+ 
+ using DIM = u4;
+ using STRIDE = u4;
+ using DIM3 = dim3;
+ using STRIDE3 = dim3;
+ 
+ constexpr int DEFAULT_LINEAR_BLOCK_SIZE = 384;
+ 
+ #define SHM_ERROR s_ectrl
+ 
+ namespace cusz {
+ 
+ /********************************************************************************
+  * host API
+  ********************************************************************************/
+ 
+ template <
+     typename TITER, typename EITER, typename FP = float,
+     int SPLINE_DIM = 2,
+     int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8,
+     int AnchorBlockSizeZ = 1,
+     int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+     int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE,
+     typename CompactVal = TITER, typename CompactIdx = uint32_t*,
+     typename CompactNum = uint32_t*>
+ __global__ void c_spline_infprecis_data(
+     TITER data, DIM3 data_size, STRIDE3 data_leap, EITER ectrl,
+     DIM3 ectrl_size, STRIDE3 ectrl_leap, TITER anchor, STRIDE3 anchor_leap,
+     CompactVal cval, CompactIdx cidx, CompactNum cn, FP eb_r, FP ebx2,
+     int radius, INTERPOLATION_PARAMS intp_param, TITER errors);
+ 
+ template <
+     typename EITER, typename TITER, typename FP = float,
+     int SPLINE_DIM = 2, 
+     int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8,
+     int AnchorBlockSizeZ = 1,
+     int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+     int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __global__ void x_spline_infprecis_data(
+     EITER ectrl,          // input 1
+     DIM3 ectrl_size,      //
+     STRIDE3 ectrl_leap,   //
+     TITER anchor,         // input 2
+     DIM3 anchor_size,     //
+     STRIDE3 anchor_leap,  //
+     TITER data,           // output
+     DIM3 data_size,       //
+     STRIDE3 data_leap,    //
+     FP eb_r, FP ebx2, int radius, INTERPOLATION_PARAMS intp_param);
+ 
+ namespace device_api {
+ /********************************************************************************
+  * device API
+  ********************************************************************************/
+ 
+ template <
+     typename T1, typename T2, typename FP, int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+     int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+     int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+     int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE, bool WORKFLOW = SPLINE3_COMPR,
+     bool PROBE_PRED_ERROR = false>
+ __device__ void spline_layout_interpolate(
+     volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     DIM3 data_size, FP eb_r, FP ebx2, int radius,
+     INTERPOLATION_PARAMS intp_param);
+ }  // namespace device_api
+ 
+ }  // namespace cusz
+ 
+ /********************************************************************************
+  * helper function
+  ********************************************************************************/
+ 
+ namespace {
+ 
+ template <int SPLINE_DIM,
+     int AnchorBlockSizeX, int AnchorBlockSizeY, int AnchorBlockSizeZ,
+     int numAnchorBlockX,  // Number of Anchor blocks along X
+     int numAnchorBlockY,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ,  // Number of Anchor blocks along Z
+     bool INCLUSIVE = true>
+ __forceinline__ __device__ bool xyz_predicate(
+     unsigned int x, unsigned int y, unsigned int z, const DIM3& data_size)
+ {
+   if CONSTEXPR (INCLUSIVE) {
+     return (x <= (AnchorBlockSizeX * numAnchorBlockX) and
+             y <= (AnchorBlockSizeY * numAnchorBlockY) and
+             z <= (AnchorBlockSizeZ * numAnchorBlockZ)) and
+            BIX * (AnchorBlockSizeX * numAnchorBlockX) + x < data_size.x and
+            BIY * (AnchorBlockSizeY * numAnchorBlockY) + y < data_size.y and
+            BIZ * (AnchorBlockSizeZ * numAnchorBlockZ) + z < data_size.z;
+   }
+   else {
+     return x < (AnchorBlockSizeX * numAnchorBlockX) + (BIX == GDX - 1) * (SPLINE_DIM <= 1) and
+            y < (AnchorBlockSizeY * numAnchorBlockY) + (BIY == GDY - 1) * (SPLINE_DIM <= 2) and
+            z < (AnchorBlockSizeZ * numAnchorBlockZ) + (BIZ == GDZ - 1) * (SPLINE_DIM <= 3) and
+            BIX * (AnchorBlockSizeX * numAnchorBlockX) + x < data_size.x and
+            BIY * (AnchorBlockSizeY * numAnchorBlockY) + y < data_size.y and
+            BIZ * (AnchorBlockSizeZ * numAnchorBlockZ) + z < data_size.z;
+   }
+ }
+ 
+ template <
+     typename T1, typename T2, int SPLINE_DIM, int AnchorBlockSizeX, int AnchorBlockSizeY,
+     int AnchorBlockSizeZ,
+     int numAnchorBlockX,  // Number of Anchor blocks along X
+     int numAnchorBlockY,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void c_reset_scratch_data(
+     volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     int radius)
+ {
+   // alternatively, reinterprete cast volatile T?[][][] to 1D
+   for (auto _tix = TIX; _tix < (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) *
+                                    (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) * (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+        _tix += LINEAR_BLOCK_SIZE) {
+     auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+     auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+              (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+     auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+              (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+ 
+     s_data[z][y][x] = 0;
+     /*****************************************************************************
+      okay to use
+      ******************************************************************************/
+     if (x % AnchorBlockSizeX == 0 and y % AnchorBlockSizeY == 0 and
+         z % AnchorBlockSizeZ == 0)
+       s_ectrl[z][y][x] = radius;
+     /*****************************************************************************
+      alternatively
+      ******************************************************************************/
+     // s_ectrl[z][y][x] = radius;
+   }
+   __syncthreads();
+ }
+ 
+ template <
+     typename T1, int AnchorBlockSizeX, int AnchorBlockSizeY,
+     int AnchorBlockSizeZ,
+     int numAnchorBlockX,  // Number of Anchor blocks along X
+     int numAnchorBlockY,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void c_gather_anchor(
+     T1* data, DIM3 data_size, STRIDE3 data_leap, T1* anchor,
+     STRIDE3 anchor_leap)
+ {
+   auto x = (TIX % (AnchorBlockSizeX * numAnchorBlockX)) +
+            BIX * (AnchorBlockSizeX * numAnchorBlockX);
+   auto y = (TIX / (AnchorBlockSizeX * numAnchorBlockX)) %
+                (AnchorBlockSizeY * numAnchorBlockY) +
+            BIY * (AnchorBlockSizeY * numAnchorBlockY);
+   auto z = (TIX / (AnchorBlockSizeX * numAnchorBlockX)) /
+                (AnchorBlockSizeY * numAnchorBlockY) +
+            BIZ * (AnchorBlockSizeZ * numAnchorBlockZ);
+ 
+   bool pred1 = x % AnchorBlockSizeX == 0 and y % AnchorBlockSizeY == 0 and
+                z % AnchorBlockSizeZ == 0;
+   bool pred2 = x < data_size.x and y < data_size.y and z < data_size.z;
+ 
+   if (pred1 and pred2) {
+     auto data_id = x + y * data_leap.y + z * data_leap.z;
+     auto anchor_id = (x / AnchorBlockSizeX) +
+                      (y / AnchorBlockSizeY) * anchor_leap.y +
+                      (z / AnchorBlockSizeZ) * anchor_leap.z;
+     anchor[anchor_id] = data[data_id];
+   }
+   __syncthreads();
+ }
+ 
+ template <
+     typename T1, typename T2 = T1, int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+     int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+     int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+     int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void x_reset_scratch_data(
+     volatile T1 s_xdata[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     T1* anchor, DIM3 anchor_size, STRIDE3 anchor_leap)
+ {
+   for (auto _tix = TIX; _tix < (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) * (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) * (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+        _tix += LINEAR_BLOCK_SIZE) {
+     auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+     auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+              (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+     auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+              (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+ 
+     s_ectrl[z][y][x] = 0;  // TODO explicitly handle zero-padding
+     /*****************************************************************************
+      okay to use
+      ******************************************************************************/
+     // Todo 2d
+     // Here 8 is the interpolation block size, not the entire compression
+     // manipulated by a threadblock, need to dinstiguish with CompressionBlock.
+     if (x % AnchorBlockSizeX == 0 and y % AnchorBlockSizeY == 0 and
+         z % AnchorBlockSizeZ == 0) {
+       s_xdata[z][y][x] = 0;
+ 
+       auto ax = ((x / AnchorBlockSizeX) + BIX * numAnchorBlockX);
+       auto ay = ((y / AnchorBlockSizeY) + BIY * numAnchorBlockY);
+       auto az = ((z / AnchorBlockSizeZ) + BIZ * numAnchorBlockZ);
+ 
+       if (ax < anchor_size.x and ay < anchor_size.y and az < anchor_size.z)
+         s_xdata[z][y][x] =
+             anchor[ax + ay * anchor_leap.y + az * anchor_leap.z];
+     }
+     /*****************************************************************************
+      alternatively
+      ******************************************************************************/
+   }
+ 
+   __syncthreads();
+ }
+ 
+ template <
+     typename T1, typename T2, int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+     int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+     int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+     int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void global2shmem_data(
+     T1* data, DIM3 data_size, STRIDE3 data_leap,
+     volatile T2 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)])
+ {
+   constexpr auto TOTAL = (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) *
+                          (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) * 
+                          (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+   for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+     auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+     auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+              (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+     auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+              (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+     auto gx = (x + BIX * (AnchorBlockSizeX * numAnchorBlockX));
+     auto gy = (y + BIY * (AnchorBlockSizeY * numAnchorBlockY));
+     auto gz = (z + BIZ * (AnchorBlockSizeZ * numAnchorBlockZ));
+     auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+    
+     if (gx < data_size.x and gy < data_size.y and gz < data_size.z)
+       s_data[z][y][x] = data[gid];
+   }
+   __syncthreads();
+ }
+ 
+ 
+ template <
+     typename T = float, typename E = u4, int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+     int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+     int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+     int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void global2shmem_fuse(
+     E* ectrl, dim3 ectrl_size, dim3 ectrl_leap, T* scattered_outlier,
+     volatile T s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)])
+ {
+   constexpr auto TOTAL = (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) *
+                          (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) *
+                          (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+    unsigned int level_offsets[5] = { 0, 
+          (ectrl_size.x * ectrl_size.y * ectrl_size.z) / (16 * 16 * 16),
+          (ectrl_size.x * ectrl_size.y * ectrl_size.z) / (8 * 8 * 8),
+          (ectrl_size.x * ectrl_size.y * ectrl_size.z) / (4 * 4 * 4),
+          (ectrl_size.x * ectrl_size.y * ectrl_size.z) / (2 * 2 * 2),
+      };
+ 
+   for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+     auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+     auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+              (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+     auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+              (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+     auto gx = (x + BIX * (AnchorBlockSizeX * numAnchorBlockX));
+     auto gy = (y + BIY * (AnchorBlockSizeY * numAnchorBlockY));
+     auto gz = (z + BIZ * (AnchorBlockSizeZ * numAnchorBlockZ));
+     
+     auto gid = gx + gy * ectrl_leap.y + gz * ectrl_leap.z;
+    
+    //  unsigned int level = 0;
+    //  int level_size = AnchorBlockSizeX;
+    //  while(level_size > 1){
+    //   if ((gx % level_size == 0) && (gy % level_size == 0) && (gz % level_size == 0)) break;
+    //   level += 1;
+    //   level_size /= 2;
+    //  }
+    unsigned int level = 0;
+    // if ((gx % 16 == 0) && (gy % 16 == 0) && (gz % 16 == 0)) level = 0;
+    // else if ((gx % 8 == 0) && (gy % 8 == 0) && (gz % 8 == 0)) level = 1;
+    // else if ((gx % 4 == 0) && (gy % 4 == 0) && (gz % 4 == 0)) level = 2;
+    // else if ((gx % 2 == 0) && (gy % 2 == 0) && (gz % 2 == 0)) level = 3;
+    // else level = 4;
+    level = ((gx % 16 == 0) && (gy % 16 == 0) && (gz % 16 == 0)) ? 0 :
+    ((gx % 8 == 0) && (gy % 8 == 0) && (gz % 8 == 0)) ? 1 :
+    ((gx % 4 == 0) && (gy % 4 == 0) && (gz % 4 == 0)) ? 2 :
+    ((gx % 2 == 0) && (gy % 2 == 0) && (gz % 2 == 0)) ? 3 : 4;
+     unsigned int shift = 4 - level;
+
+     // Compute level index using integer division
+     unsigned int level_index_x = gx >> shift;
+     unsigned int level_index_y = gy >> shift;
+     unsigned int level_index_z = gz >> shift;
+
+     // Compute level dimensions
+     unsigned int level_dim_x = ectrl_size.x >> shift;
+     unsigned int level_dim_y = ectrl_size.y >> shift;
+     unsigned int level_dim_z = ectrl_size.z >> shift;
+
+     // Compute upper-level dimensions
+     unsigned int upper_level_dim_x = ectrl_size.x >> (shift + 1);
+     unsigned int upper_level_dim_y = ectrl_size.y >> (shift + 1);
+     unsigned int upper_level_dim_z = ectrl_size.z >> (shift + 1);
+
+     // Compute offset
+     unsigned int offset = (level == 0) ? 0 : (
+     ((level_index_x + 1) / 2) * upper_level_dim_y * upper_level_dim_z +
+     ((level_index_y + 1) / 2) * upper_level_dim_z * (1 - (level_index_x % 2)) +
+     ((level_index_z + 1) / 2) * (1 - (level_index_x % 2)) * (1 - (level_index_y % 2)));
+
+     // Compute index
+     unsigned int index = level_offsets[level] +
+         level_index_x * level_dim_y * level_dim_z +
+         level_index_y * level_dim_z +
+         level_index_z - offset;
+      
+     if (gx < ectrl_size.x and gy < ectrl_size.y and gz < ectrl_size.z)
+       s_ectrl[z][y][x] = static_cast<T>(ectrl[index]) + scattered_outlier[gid];
+   }
+   __syncthreads();
+ }
+ 
+ // dram_outlier should be the same in type with shared memory buf
+ template <
+     typename T1, typename T2, int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+     int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+     int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+     int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void shmem2global_data(
+     volatile T1 s_buf[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                      [AnchorBlockSizeY * numAnchorBlockY +  + (SPLINE_DIM >= 2)]
+                      [AnchorBlockSizeX * numAnchorBlockX +  + (SPLINE_DIM >= 1)],
+     T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap)
+ {
+   auto x_size = AnchorBlockSizeX * numAnchorBlockX + (BIX == GDX - 1) * (SPLINE_DIM >= 1);
+   auto y_size = AnchorBlockSizeY * numAnchorBlockY + (BIY == GDY - 1) * (SPLINE_DIM >= 2);
+   auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (BIZ == GDZ - 1) * (SPLINE_DIM >= 3);
+   auto TOTAL = x_size * y_size * z_size;
+ 
+   for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+     auto x = (_tix % x_size);
+     auto y = (_tix / x_size) % y_size;
+     auto z = (_tix / x_size) / y_size;
+     auto gx = (x + BIX * AnchorBlockSizeX * numAnchorBlockX);
+     auto gy = (y + BIY * AnchorBlockSizeY * numAnchorBlockY);
+     auto gz = (z + BIZ * AnchorBlockSizeZ * numAnchorBlockZ);
+     auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+ 
+     if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z)
+       dram_buf[gid] = s_buf[z][y][x];
+   }
+   __syncthreads();
+ }
+ 
+ // dram_outlier should be the same in type with shared memory buf
+ template <
+     typename T1, typename T2, int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+     int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+     int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+     int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void shmem2global_data_with_compaction(
+     volatile T1 s_buf[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                      [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                      [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap, int radius,
+     T1* dram_compactval = nullptr, uint32_t* dram_compactidx = nullptr,
+     uint32_t* dram_compactnum = nullptr)
+ {
+   auto x_size = AnchorBlockSizeX * numAnchorBlockX + (BIX == GDX - 1) * (SPLINE_DIM >= 1);
+   auto y_size = AnchorBlockSizeY * numAnchorBlockY + (BIY == GDY - 1) * (SPLINE_DIM >= 2);
+   auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (BIZ == GDZ - 1) * (SPLINE_DIM >= 3);
+   auto TOTAL = x_size * y_size * z_size;
+   unsigned int level_offsets[5] = { 0, 
+    (buf_size.x * buf_size.y * buf_size.z) / (16 * 16 * 16),
+    (buf_size.x * buf_size.y * buf_size.z) / (8 * 8 * 8),
+    (buf_size.x * buf_size.y * buf_size.z) / (4 * 4 * 4),
+    (buf_size.x * buf_size.y * buf_size.z) / (2 * 2 * 2),
+};
+ 
+   for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+     auto x = (_tix % x_size);
+     auto y = (_tix / x_size) % y_size;
+     auto z = (_tix / x_size) / y_size;
+     auto gx = (x + BIX * AnchorBlockSizeX * numAnchorBlockX);
+     auto gy = (y + BIY * AnchorBlockSizeY * numAnchorBlockY);
+     auto gz = (z + BIZ * AnchorBlockSizeZ * numAnchorBlockZ);
+     auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+
+     unsigned int level  =0;
+    //  if ((gx % 16 == 0) && (gy % 16 == 0) && (gz % 16 == 0)) level = 0;
+    //  else if ((gx % 8 == 0) && (gy % 8 == 0) && (gz % 8 == 0)) level = 1;
+    //  else if ((gx % 4 == 0) && (gy % 4 == 0) && (gz % 4 == 0)) level = 2;
+    //  else if ((gx % 2 == 0) && (gy % 2 == 0) && (gz % 2 == 0)) level = 3;
+    //  else level = 4;
+    level = ((gx % 16 == 0) && (gy % 16 == 0) && (gz % 16 == 0)) ? 0 :
+        ((gx % 8 == 0) && (gy % 8 == 0) && (gz % 8 == 0)) ? 1 :
+        ((gx % 4 == 0) && (gy % 4 == 0) && (gz % 4 == 0)) ? 2 :
+        ((gx % 2 == 0) && (gy % 2 == 0) && (gz % 2 == 0)) ? 3 : 4;
+ 
+     unsigned int shift = 4 - level;
+ 
+     // Compute level index using integer division
+     unsigned int level_index_x = gx >> shift;
+     unsigned int level_index_y = gy >> shift;
+     unsigned int level_index_z = gz >> shift;
+ 
+     // Compute level dimensions
+     unsigned int level_dim_x = buf_size.x >> shift;
+     unsigned int level_dim_y = buf_size.y >> shift;
+     unsigned int level_dim_z = buf_size.z >> shift;
+ 
+     // Compute upper-level dimensions
+     unsigned int upper_level_dim_x = buf_size.x >> (shift + 1);
+     unsigned int upper_level_dim_y = buf_size.y >> (shift + 1);
+     unsigned int upper_level_dim_z = buf_size.z >> (shift + 1);
+ 
+     // Compute offset
+     unsigned int offset = (level == 0) ? 0 : (
+     ((level_index_x + 1) / 2) * upper_level_dim_y * upper_level_dim_z +
+     ((level_index_y + 1) / 2) * upper_level_dim_z * (1 - (level_index_x % 2)) +
+     ((level_index_z + 1) / 2) * (1 - (level_index_x % 2)) * (1 -  (level_index_y % 2)));
+ 
+     // Compute index
+     unsigned int index = level_offsets[level] +
+         level_index_x * level_dim_y * level_dim_z +
+         level_index_y * level_dim_z +
+         level_index_z - offset;
+ 
+
+     auto candidate = s_buf[z][y][x];
+     bool quantizable = (candidate >= 0) and (candidate < 2 * radius);
+    
+     if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z) {
+       // TODO this is for algorithmic demo by reading from shmem
+       // For performance purpose, it can be inlined in quantization
+       dram_buf[index] = quantizable * static_cast<T2>(candidate);
+      //  dram_buf[gid] = quantizable * static_cast<T2>(candidate);
+ 
+       if (not quantizable) {
+         auto cur_idx = atomicAdd(dram_compactnum, 1);
+         dram_compactidx[cur_idx] = gid;
+         dram_compactval[cur_idx] = candidate;
+       }
+     }
+   }
+   __syncthreads();
+ }
+ 
+
+ template <
+     typename T1,
+     typename T2,
+     typename FP, int SPLINE_DIM, int AnchorBlockSizeX,
+     int AnchorBlockSizeY, int AnchorBlockSizeZ,
+     int numAnchorBlockX,  // Number of Anchor blocks along X
+     int numAnchorBlockY,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ,  // Number of Anchor blocks along Z
+     typename LAMBDA,
+     bool LINE,
+     bool FACE,
+     bool CUBE,
+     int  LINEAR_BLOCK_SIZE,
+     int NUM_ELE,
+     bool COARSEN,
+     bool BORDER_INCLUSIVE,
+     bool WORKFLOW,
+     typename INTERP>
+ __forceinline__ __device__ void interpolate_stage_md(
+     volatile T1 s_data[17][17][17],
+     volatile T2 s_ectrl[17][17][17],
+     DIM3    data_size,
+     LAMBDA xyzmap,
+     int         unit,
+     FP          eb_r,
+     FP          ebx2,
+     int         radius,
+     INTERP cubic_interpolator)
+ {
+     static_assert(COARSEN or (NUM_ELE <= 384), "block oversized");
+     static_assert((LINE or FACE or CUBE) == true, "must be one hot");
+     static_assert((LINE and FACE) == false, "must be only one hot (1)");
+     static_assert((LINE and CUBE) == false, "must be only one hot (2)");
+     static_assert((FACE and CUBE) == false, "must be only one hot (3)");
+ 
+     auto run = [&](auto x, auto y, auto z) {
+ 
+         
+ 
+         if (xyz_predicate<SPLINE_DIM,
+          AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+          numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ,
+          BORDER_INCLUSIVE>(x, y, z, data_size)) {
+             T1 pred = 0;
+             auto global_x=BIX*AnchorBlockSizeX + x, global_y=BIY*AnchorBlockSizeY+y, global_z=BIZ*AnchorBlockSizeZ+z;
+            
+             if CONSTEXPR (LINE) {  //
+                 //bool I_X = x&1; 
+                 bool I_Y = (y % (2*unit) )> 0; 
+                 bool I_Z = (z % (2*unit) )> 0; 
+                 if (I_Z){
+                     //assert(x&1==0 and y&1==0);
+ 
+                     if(BIZ!=GDZ-1){
+ 
+                         if(z>=3*unit and z+3*unit<=AnchorBlockSizeZ  )
+                             pred = cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x],s_data[z + unit][y][x],s_data[z + 3*unit][y][x]);
+                         else if (z+3*unit<=AnchorBlockSizeZ)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                         else if (z>=3*unit)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                         else
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(z>=3*unit){
+                             if(z+3*unit<=AnchorBlockSizeZ and global_z+3*unit<data_size.z)
+                                 pred = cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x] ,s_data[z + unit][y][x],s_data[z + 3*unit][y][x]);
+                             else if (global_z+unit<data_size.z)
+                                 pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+                             else
+                                 pred=s_data[z - unit][y][x];
+ 
+                         }
+                         else{
+                             if(z+3*unit<=AnchorBlockSizeZ and global_z+3*unit<data_size.z)
+                                 pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                             else if (global_z+unit<data_size.z)
+                                 pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                             else
+                                 pred=s_data[z - unit][y][x];
+                         } 
+                     }
+ 
+                 }
+                 else if (I_Y){
+                     //assert(x&1==0 and z&1==0);
+                     if(BIY!=GDY-1){
+                         if(y>=3*unit and y+3*unit<=AnchorBlockSizeY )
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]) ;
+                         else if (y+3*unit<=AnchorBlockSizeY)
+                             pred = (3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (y>=3*unit)
+                             pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                     }
+                     else{
+                         if(y>=3*unit){
+                             if(y+3*unit<=AnchorBlockSizeY and global_y+3*unit<data_size.y)
+                                 pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z][y - unit][x],s_data[z ][y+ unit][x],s_data[z ][y+ 3*unit][x]);
+                             else if (global_y+unit<data_size.y)
+                                 pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 8;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+ 
+                         }
+                         else{
+                             if(y+3*unit<=AnchorBlockSizeY and global_y+3*unit<data_size.y)
+                                 pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                             else if (global_y+unit<data_size.y)
+                                 pred = (s_data[z ][y- unit][x] + s_data[z][y + unit][x]) / 2;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+                         } 
+                     }
+                 }
+                 else{//I_X
+                     //assert(y&1==0 and z&1==0);
+                     if(BIX!=GDX-1){
+                         if(x>=3*unit and x+3*unit<=AnchorBlockSizeX )
+                             pred = cubic_interpolator(s_data[z ][y][x- 3*unit],s_data[z ][y][x- unit],s_data[z ][y][x+ unit],s_data[z ][y][x + 3*unit]);
+                         else if (x+3*unit<=AnchorBlockSizeX)
+                             pred = (3*s_data[z ][y][x- unit] + 6*s_data[z ][y][x + unit]-s_data[z][y][x + 3*unit]) / 8;
+                         else if (x>=3*unit)
+                             pred = (-s_data[z][y][x - 3*unit]+6*s_data[z][y][x - unit] + 3*s_data[z ][y][x + unit]) / 8;
+                         else
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                     }
+                     else{
+                         if(x>=3*unit){
+                             if(x+3*unit<=AnchorBlockSizeX and global_x+3*unit<data_size.x)
+                                 pred = cubic_interpolator(s_data[z ][y][x- 3*unit],s_data[z][y ][x- unit],s_data[z ][y][x+ unit],s_data[z ][y][x+ 3*unit]);
+                             else if (global_x+unit<data_size.x)
+                                 pred = (-s_data[z ][y][x- 3*unit]+6*s_data[z ][y][x- unit] + 3*s_data[z ][y][x+ unit]) / 8;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+ 
+                         }
+                         else{
+                             if(x+3*unit<=AnchorBlockSizeX and global_x+3*unit<data_size.x)
+                                 pred = (3*s_data[z][y ][x- unit] + 6*s_data[z ][y][x+ unit]-s_data[z][y ][x+ 3*unit]) / 8;
+                             else if (global_x+unit<data_size.x)
+                                 pred = (s_data[z ][y][x- unit] + s_data[z][y ][x+ unit]) / 2;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+                         } 
+                     }
+ 
+                 }
+             }
+             auto get_interp_order = [&](auto x, auto BI, auto GD, auto gx, auto gs, auto AnchorBlockSize){
+                 int b = x >= 3*unit ? 3 : 1;
+                 int f = 0;
+                 if(x+3*unit<=AnchorBlockSize and (BI != GD-1 or gx+3*unit < gs) )
+                     f = 3;
+                 else if (BI != GD-1 or gx+unit < gs)
+                     f = 1;
+                 if (b==3){
+                     if(f==3)
+                         return 4;
+                     else if (f==1)
+                         return 3;
+                     else
+                         return 0;
+                 }
+                 else{//b==1
+                     if(f==3)
+                         return 2;
+                     else if (f==1)
+                         return 1;
+                     else
+                         return 0;
+                 }
+             };
+             if CONSTEXPR (FACE) {  //
+ 
+                 bool I_YZ = (x % (2*unit) ) == 0;
+                 bool I_XZ = (y % (2*unit ) )== 0;
+
+                  
+                 if (I_YZ){
+ 
+ 
+                     auto interp_z = get_interp_order(z,BIZ,GDZ,global_z,data_size.z, AnchorBlockSizeZ);
+                     auto interp_y = get_interp_order(y,BIY,GDY,global_y,data_size.y, AnchorBlockSizeY);
+ 
+                     if(interp_z==4){
+                         if(interp_y==4){
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x],s_data[z + unit][y][x],s_data[z + 3*unit][y][x])+
+                                     cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]) ) / 2;
+                         }
+                         else
+                             pred = cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x],s_data[z + unit][y][x],s_data[z + 3*unit][y][x]);
+ 
+                     }
+                     else if (interp_z == 3){
+                         if(interp_y==4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x] - s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 16;
+                         else if (interp_y == 2)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x] + 3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 16;
+                         else
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                     }
+ 
+                     else if (interp_z == 2){
+                         if(interp_y==4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x] - s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 16;
+                         else if (interp_y == 2)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x] + 3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 16;
+                         else
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+ 
+                     }
+                     else if (interp_z == 1){
+                         if(interp_y == 4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (-s_data[z ][y- 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else if (interp_y == 2)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (interp_y == 1)
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x] + s_data[z ][y - unit][x] + s_data[z][y + unit][x]) / 4;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(interp_y == 4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (-s_data[z ][y- 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else if (interp_y == 2)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (interp_y == 1)
+                             pred = (s_data[z ][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z ][y - unit][x] - s_data[z - unit][y - unit][x]);
+ 
+                     }
+ 
+                 }
+                 else if (I_XZ){
+                     auto interp_z = get_interp_order(z,BIZ,GDZ,global_z,data_size.z, AnchorBlockSizeZ);
+                     auto interp_x = get_interp_order(x,BIX,GDX,global_x,data_size.x, AnchorBlockSizeX);
+ 
+                     //if(BIX == 10 and BIY == 12 and BIZ == 0 and x==13 and y==6 and z==9)
+                     //printf("ixz %d %d\n", interp_x,interp_z);
+ 
+                     if(interp_z==4){
+                         if(interp_x==4){
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z + 3*unit][y][x]) +
+                                     cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                          s_data[z][y][x - unit],
+                                                          s_data[z][y][x + unit],
+                                                          s_data[z][y][x + 3*unit])
+                                    ) / 2;
+                         }
+                         else
+                             pred = cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                       s_data[z - unit][y][x],
+                                                       s_data[z + unit][y][x],
+                                                       s_data[z + 3*unit][y][x]);
+ 
+                     }
+                     else if (interp_z == 3){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z - 3*unit][y][x] + 6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (-s_data[z - 3*unit][y][x] + 6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (-s_data[z - 3*unit][y][x] + 6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                     }
+                     else if (interp_z == 2){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x] - s_data[z + 3*unit][y][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x] - s_data[z + 3*unit][y][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x] - s_data[z + 3*unit][y][x]) / 8;
+ 
+                     }
+                     else if (interp_z == 1){
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]
+                                     + s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 4;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z][y][x - unit] - s_data[z - unit][y][x - unit]);
+                     }
+ 
+                 }
+                 else{//I_XY
+                     //assert(z&1==0);
+ 
+                     auto interp_y = get_interp_order(y,BIY,GDY,global_y,data_size.y,  AnchorBlockSizeY);
+                     auto interp_x = get_interp_order(x,BIX,GDX,global_x,data_size.x,  AnchorBlockSizeX);
+ 
+                     if(interp_y==4){
+                         if(interp_x==4){
+                             pred = (cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y + 3*unit][x]) +
+                                     cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                          s_data[z][y][x - unit],
+                                                          s_data[z][y][x + unit],
+                                                          s_data[z][y][x + 3*unit])
+                                    ) / 2;
+                         }
+                         else
+                             pred = cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                       s_data[z][y - unit][x],
+                                                       s_data[z][y + unit][x],
+                                                       s_data[z][y + 3*unit][x]);
+                     }
+                     else if (interp_y == 3){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y - 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (-s_data[z][y - 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (-s_data[z][y - 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                     }
+                     else if (interp_y == 2){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z][y + unit][x] - s_data[z][y + 3*unit][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z][y + unit][x] - s_data[z][y + 3*unit][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z][y + unit][x] - s_data[z][y + 3*unit][x]) / 8;
+                     }
+                     else if (interp_y == 1){
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]
+                                     + s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 4;
+                         else 
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                     }
+                     else{
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                         else 
+                             pred = (s_data[z][y - unit][x] + s_data[z][y][x - unit] - s_data[z][y - unit][x - unit]);
+                     }
+                 }
+             }
+ 
+             if CONSTEXPR (CUBE) {  //
+                 auto interp_z = get_interp_order(z,BIZ,GDZ,global_z,data_size.z, AnchorBlockSizeZ);
+                 auto interp_y = get_interp_order(y,BIY,GDY,global_y,data_size.y, AnchorBlockSizeY);
+                 auto interp_x = get_interp_order(x,BIX,GDX,global_x,data_size.x, AnchorBlockSizeX);
+ 
+                 if(interp_z == 4){
+                     if(interp_y == 4){
+                         if(interp_x == 4){
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]) +
+                                     cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y + 3*unit][x]) +
+                                     cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                          s_data[z][y][x - unit],
+                                                          s_data[z][y][x + unit],
+                                                          s_data[z][y][x + 3*unit])
+                                     ) / 3;
+                         }
+                         else{
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]) +
+                                     cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y + 3*unit][x])
+                                     ) / 2;
+                         }
+                     }
+                     else if(interp_x == 4){
+                         pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]) +
+                                 cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                      s_data[z][y][x - unit],
+                                                      s_data[z][y][x + unit],
+                                                      s_data[z][y][x + 3*unit])
+                                 ) / 2;
+ 
+                     }
+                     else{
+                         pred = cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]);
+                     }
+                 }
+ 
+                 else if(interp_y == 4){
+                     
+                     if(interp_x == 4){
+                         pred = (cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y+ 3*unit][x]) +
+                                 cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                      s_data[z][y][x - unit],
+                                                      s_data[z][y][x + unit],
+                                                      s_data[z][y][x + 3*unit])
+                                 ) / 2;
+ 
+                     }
+                     else{
+                         pred = cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y+ 3*unit][x]);
+                     }
+                 }
+                 else{
+                     if(interp_x == 4)
+                         pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                   s_data[z][y][x - unit],
+                                                   s_data[z][y][x + unit],
+                                                   s_data[z][y][x + 3*unit]);
+                     else if (interp_x == 3)
+                         pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                     else if (interp_x == 2)
+                         pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                     else if (interp_x == 1)
+                         pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                     else 
+                         pred = s_data[z][y][x - unit];///to revise;
+ 
+ 
+                 }
+ 
+             }
+ 
+ 
+                 
+             
+             
+ 
+             if CONSTEXPR (WORKFLOW == SPLINE3_COMPR) {
+                 
+                 auto          err = s_data[z][y][x] - pred;
+                 decltype(err) code;
+                 // TODO unsafe, did not deal with the out-of-cap case
+                 {
+                     code = fabs(err) * eb_r + 1;
+                     code = err < 0 ? -code : code;
+                     code = int(code / 2) + radius;
+                 }
+                 s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
+                 s_data[z][y][x]  = pred + (code - radius) * ebx2;
+                 
+ 
+             }
+             else {  // TODO == DECOMPRESSS and static_assert
+                 auto code       = s_ectrl[z][y][x];
+                 s_data[z][y][x] = pred + (code - radius) * ebx2;
+             }
+         }
+     };
+     // -------------------------------------------------------------------------------- //
+ 
+     if CONSTEXPR (COARSEN) {
+         constexpr auto TOTAL = NUM_ELE;
+             for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                 auto [x,y,z]    = xyzmap(_tix, unit);
+                 run(x, y, z);
+             }
+         
+     }
+     else {
+         auto [x,y,z]    = xyzmap(TIX, unit);
+         
+ 
+      //   printf("%d %d %d\n", x,y,z);
+         run(x, y, z);
+     }
+     __syncthreads();
+ }
+ 
+
+ template <
+     typename T1, typename T2, typename FP, int SPLINE_DIM, int AnchorBlockSizeX,
+     int AnchorBlockSizeY, int AnchorBlockSizeZ,
+     int numAnchorBlockX,  // Number of Anchor blocks along X
+     int numAnchorBlockY,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ,  // Number of Anchor blocks along Z
+     typename LAMBDAX, typename LAMBDAY, typename LAMBDAZ, bool BLUE,
+     bool YELLOW, bool HOLLOW, int LINEAR_BLOCK_SIZE, bool BORDER_INCLUSIVE,
+     bool WORKFLOW>
+ __forceinline__ __device__ void interpolate_stage(
+     volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     DIM3 data_size, LAMBDAX xmap, LAMBDAY ymap, LAMBDAZ zmap, int unit,
+     FP eb_r, FP ebx2, int radius, bool interpolator, int BLOCK_DIMX,
+     int BLOCK_DIMY, bool COARSEN, int BLOCK_DIMZ)
+ {
+   // static_assert(
+   //     BLOCK_DIMX * BLOCK_DIMY * (COARSEN ? 1 : BLOCK_DIMZ) <= 384,
+   //     "block oversized");
+   static_assert((BLUE or YELLOW or HOLLOW) == true, "must be one hot");
+   static_assert((BLUE and YELLOW) == false, "must be only one hot (1)");
+   static_assert((BLUE and YELLOW) == false, "must be only one hot (2)");
+   static_assert((YELLOW and HOLLOW) == false, "must be only one hot (3)");
+ 
+   auto run = [&](auto x, auto y, auto z) {
+     if (xyz_predicate<SPLINE_DIM,
+             AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+             numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ,
+             BORDER_INCLUSIVE>(x, y, z, data_size)) {
+       T1 pred = 0;
+       auto global_x = BIX * (AnchorBlockSizeX * numAnchorBlockX) + x;
+       auto global_y = BIY * (AnchorBlockSizeY * numAnchorBlockY) + y;
+       auto global_z = BIZ * (AnchorBlockSizeZ * numAnchorBlockZ) + z;
+       if (interpolator == 0) {
+         if CONSTEXPR (BLUE) {  //
+           if (BIZ != GDZ - 1) {
+             if (z >= 3 * unit and
+                 z + 3 * unit <= AnchorBlockSizeZ * numAnchorBlockZ)
+               pred =
+                   (-s_data[z - 3 * unit][y][x] + 9 * s_data[z - unit][y][x] +
+                    9 * s_data[z + unit][y][x] - s_data[z + 3 * unit][y][x]) /
+                   16;
+             else if (z + 3 * unit <= AnchorBlockSizeZ * numAnchorBlockZ)
+               pred = (3 * s_data[z - unit][y][x] + 6 * s_data[z + unit][y][x] -
+                       s_data[z + 3 * unit][y][x]) /
+                      8;
+             else if (z >= 3 * unit)
+               pred =
+                   (-s_data[z - 3 * unit][y][x] + 6 * s_data[z - unit][y][x] +
+                    3 * s_data[z + unit][y][x]) /
+                   8;
+ 
+             else
+               pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+           }
+           else {
+             if (z >= 3 * unit) {
+               if (z + 3 * unit <= AnchorBlockSizeZ * numAnchorBlockZ and
+                   global_z + 3 * unit < data_size.z)
+                 pred =
+                     (-s_data[z - 3 * unit][y][x] + 9 * s_data[z - unit][y][x] +
+                      9 * s_data[z + unit][y][x] - s_data[z + 3 * unit][y][x]) /
+                     16;
+               else if (global_z + unit < data_size.z)
+                 pred =
+                     (-s_data[z - 3 * unit][y][x] + 6 * s_data[z - unit][y][x] +
+                      3 * s_data[z + unit][y][x]) /
+                     8;
+               else
+                 pred = s_data[z - unit][y][x];
+             }
+             else {
+               if (z + 3 * unit <= AnchorBlockSizeZ * numAnchorBlockZ and
+                   global_z + 3 * unit < data_size.z)
+                 pred =
+                     (3 * s_data[z - unit][y][x] + 6 * s_data[z + unit][y][x] -
+                      s_data[z + 3 * unit][y][x]) /
+                     8;
+               else if (global_z + unit < data_size.z)
+                 pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+               else
+                 pred = s_data[z - unit][y][x];
+             }
+           }
+         }
+         if CONSTEXPR (YELLOW) {  //
+           if (BIY != GDY - 1) {
+             if (y >= 3 * unit and
+                 y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY)
+               pred =
+                   (-s_data[z][y - 3 * unit][x] + 9 * s_data[z][y - unit][x] +
+                    9 * s_data[z][y + unit][x] - s_data[z][y + 3 * unit][x]) /
+                   16;
+             else if (y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY)
+               pred = (3 * s_data[z][y - unit][x] + 6 * s_data[z][y + unit][x] -
+                       s_data[z][y + 3 * unit][x]) /
+                      8;
+             else if (y >= 3 * unit)
+               pred =
+                   (-s_data[z][y - 3 * unit][x] + 6 * s_data[z][y - unit][x] +
+                    3 * s_data[z][y + unit][x]) /
+                   8;
+             else
+               pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+           }
+           else {
+             if (y >= 3 * unit) {
+               if (y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY and
+                   global_y + 3 * unit < data_size.y)
+                 pred =
+                     (-s_data[z][y - 3 * unit][x] + 9 * s_data[z][y - unit][x] +
+                      9 * s_data[z][y + unit][x] - s_data[z][y + 3 * unit][x]) /
+                     16;
+               else if (global_y + unit < data_size.y)
+                 pred =
+                     (-s_data[z][y - 3 * unit][x] + 6 * s_data[z][y - unit][x] +
+                      3 * s_data[z][y + unit][x]) /
+                     8;
+               else
+                 pred = s_data[z][y - unit][x];
+             }
+             else {
+               if (y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY and
+                   global_y + 3 * unit < data_size.y)
+                 pred =
+                     (3 * s_data[z][y - unit][x] + 6 * s_data[z][y + unit][x] -
+                      s_data[z][y + 3 * unit][x]) /
+                     8;
+               else if (global_y + unit < data_size.y)
+                 pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+               else
+                 pred = s_data[z][y - unit][x];
+             }
+           }
+         }
+ 
+         if CONSTEXPR (HOLLOW) {  //
+           if (BIX != GDX - 1) {
+             if (x >= 3 * unit and
+                 x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX)
+               pred =
+                   (-s_data[z][y][x - 3 * unit] + 9 * s_data[z][y][x - unit] +
+                    9 * s_data[z][y][x + unit] - s_data[z][y][x + 3 * unit]) /
+                   16;
+             else if (x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX)
+               pred = (3 * s_data[z][y][x - unit] + 6 * s_data[z][y][x + unit] -
+                       s_data[z][y][x + 3 * unit]) /
+                      8;
+             else if (x >= 3 * unit)
+               pred =
+                   (-s_data[z][y][x - 3 * unit] + 6 * s_data[z][y][x - unit] +
+                    3 * s_data[z][y][x + unit]) /
+                   8;
+             else
+               pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+           }
+           else {
+             if (x >= 3 * unit) {
+               if (x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX and
+                   global_x + 3 * unit < data_size.x)
+                 pred =
+                     (-s_data[z][y][x - 3 * unit] + 9 * s_data[z][y][x - unit] +
+                      9 * s_data[z][y][x + unit] - s_data[z][y][x + 3 * unit]) /
+                     16;
+               else if (global_x + unit < data_size.x)
+                 pred =
+                     (-s_data[z][y][x - 3 * unit] + 6 * s_data[z][y][x - unit] +
+                      3 * s_data[z][y][x + unit]) /
+                     8;
+               else
+                 pred = s_data[z][y][x - unit];
+             }
+             else {
+               if (x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX and
+                   global_x + 3 * unit < data_size.x)
+                 pred =
+                     (3 * s_data[z][y][x - unit] + 6 * s_data[z][y][x + unit] -
+                      s_data[z][y][x + 3 * unit]) /
+                     8;
+               else if (global_x + unit < data_size.x)
+                 pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+               else
+                 pred = s_data[z][y][x - unit];
+             }
+           }
+         }
+       }
+       else {
+         if CONSTEXPR (BLUE) {  //
+ 
+           if (BIZ != GDZ - 1) {
+             if (z >= 3 * unit and
+                 z + 3 * unit <= AnchorBlockSizeZ * numAnchorBlockZ)
+               pred =
+                   (-3 * s_data[z - 3 * unit][y][x] +
+                    23 * s_data[z - unit][y][x] + 23 * s_data[z + unit][y][x] -
+                    3 * s_data[z + 3 * unit][y][x]) /
+                   40;
+             else if (z + 3 * unit <= AnchorBlockSizeZ * numAnchorBlockZ)
+               pred = (3 * s_data[z - unit][y][x] + 6 * s_data[z + unit][y][x] -
+                       s_data[z + 3 * unit][y][x]) /
+                      8;
+             else if (z >= 3 * unit)
+               pred =
+                   (-s_data[z - 3 * unit][y][x] + 6 * s_data[z - unit][y][x] +
+                    3 * s_data[z + unit][y][x]) /
+                   8;
+ 
+             else
+               pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+           }
+           else {
+             if (z >= 3 * unit) {
+               if (z + 3 * unit <= AnchorBlockSizeZ * numAnchorBlockZ and
+                   global_z + 3 * unit < data_size.z)
+                 pred = (-3 * s_data[z - 3 * unit][y][x] +
+                         23 * s_data[z - unit][y][x] +
+                         23 * s_data[z + unit][y][x] -
+                         3 * s_data[z + 3 * unit][y][x]) /
+                        40;
+               else if (global_z + unit < data_size.z)
+                 pred =
+                     (-s_data[z - 3 * unit][y][x] + 6 * s_data[z - unit][y][x] +
+                      3 * s_data[z + unit][y][x]) /
+                     8;
+               else
+                 pred = s_data[z - unit][y][x];
+             }
+             else {
+               if (z + 3 * unit <= AnchorBlockSizeZ * numAnchorBlockZ and
+                   global_z + 3 * unit < data_size.z)
+                 pred =
+                     (3 * s_data[z - unit][y][x] + 6 * s_data[z + unit][y][x] -
+                      s_data[z + 3 * unit][y][x]) /
+                     8;
+               else if (global_z + unit < data_size.z)
+                 pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+               else
+                 pred = s_data[z - unit][y][x];
+             }
+           }
+         }
+         if CONSTEXPR (YELLOW) {  //
+           if (BIY != GDY - 1) {
+             if (y >= 3 * unit and
+                 y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY)
+               pred =
+                   (-3 * s_data[z][y - 3 * unit][x] +
+                    23 * s_data[z][y - unit][x] + 23 * s_data[z][y + unit][x] -
+                    3 * s_data[z][y + 3 * unit][x]) /
+                   40;
+             else if (y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY)
+               pred = (3 * s_data[z][y - unit][x] + 6 * s_data[z][y + unit][x] -
+                       s_data[z][y + 3 * unit][x]) /
+                      8;
+             else if (y >= 3 * unit)
+               pred =
+                   (-s_data[z][y - 3 * unit][x] + 6 * s_data[z][y - unit][x] +
+                    3 * s_data[z][y + unit][x]) /
+                   8;
+             else
+               pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+           }
+           else {
+             if (y >= 3 * unit) {
+               if (y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY and
+                   global_y + 3 * unit < data_size.y)
+                 pred = (-3 * s_data[z][y - 3 * unit][x] +
+                         23 * s_data[z][y - unit][x] +
+                         23 * s_data[z][y + unit][x] -
+                         3 * s_data[z][y + 3 * unit][x]) /
+                        40;
+               else if (global_y + unit < data_size.y)
+                 pred =
+                     (-s_data[z][y - 3 * unit][x] + 6 * s_data[z][y - unit][x] +
+                      3 * s_data[z][y + unit][x]) /
+                     8;
+               else
+                 pred = s_data[z][y - unit][x];
+             }
+             else {
+               if (y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY and
+                   global_y + 3 * unit < data_size.y)
+                 pred =
+                     (3 * s_data[z][y - unit][x] + 6 * s_data[z][y + unit][x] -
+                      s_data[z][y + 3 * unit][x]) /
+                     8;
+               else if (global_y + unit < data_size.y)
+                 pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+               else
+                 pred = s_data[z][y - unit][x];
+             }
+           }
+         }
+ 
+         if CONSTEXPR (HOLLOW) {  //
+           if (BIX != GDX - 1) {
+             if (x >= 3 * unit and
+                 x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX)
+               pred =
+                   (-3 * s_data[z][y][x - 3 * unit] +
+                    23 * s_data[z][y][x - unit] + 23 * s_data[z][y][x + unit] -
+                    3 * s_data[z][y][x + 3 * unit]) /
+                   40;
+             else if (x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX)
+               pred = (3 * s_data[z][y][x - unit] + 6 * s_data[z][y][x + unit] -
+                       s_data[z][y][x + 3 * unit]) /
+                      8;
+             else if (x >= 3 * unit)
+               pred =
+                   (-s_data[z][y][x - 3 * unit] + 6 * s_data[z][y][x - unit] +
+                    3 * s_data[z][y][x + unit]) /
+                   8;
+             else
+               pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+           }
+           else {
+             if (x >= 3 * unit) {
+               if (x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX and
+                   global_x + 3 * unit < data_size.x)
+                 pred = (-3 * s_data[z][y][x - 3 * unit] +
+                         23 * s_data[z][y][x - unit] +
+                         23 * s_data[z][y][x + unit] -
+                         3 * s_data[z][y][x + 3 * unit]) /
+                        40;
+               else if (global_x + unit < data_size.x)
+                 pred =
+                     (-s_data[z][y][x - 3 * unit] + 6 * s_data[z][y][x - unit] +
+                      3 * s_data[z][y][x + unit]) /
+                     8;
+               else
+                 pred = s_data[z][y][x - unit];
+             }
+             else {
+               if (x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX and
+                   global_x + 3 * unit < data_size.x)
+                 pred =
+                     (3 * s_data[z][y][x - unit] + 6 * s_data[z][y][x + unit] -
+                      s_data[z][y][x + 3 * unit]) /
+                     8;
+               else if (global_x + unit < data_size.x)
+                 pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+               else
+                 pred = s_data[z][y][x - unit];
+             }
+           }
+         }
+       }
+       if CONSTEXPR (WORKFLOW == SPLINE3_COMPR) {
+         auto err = s_data[z][y][x] - pred;
+         decltype(err) code;
+         // TODO unsafe, did not deal with the out-of-cap case
+         {
+           code = fabs(err) * eb_r + 1;
+           code = err < 0 ? -code : code;
+           code = int(code / 2) + radius;
+         }
+         // if()
+         s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
+         s_data[z][y][x] = pred + (code - radius) * ebx2;
+       }
+       else {  // TODO == DECOMPRESSS and static_assert
+         auto code = s_ectrl[z][y][x];
+         s_data[z][y][x] = pred + (code - radius) * ebx2;
+         
+       }
+     }
+   };
+   int TOTAL = BLOCK_DIMX * BLOCK_DIMY * BLOCK_DIMZ;
+     for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+       auto itix = (_tix % BLOCK_DIMX);
+       auto itiy = (_tix / BLOCK_DIMX) % BLOCK_DIMY;
+       auto itiz = (_tix / BLOCK_DIMX) / BLOCK_DIMY;
+       auto x = xmap(itix, unit);
+       auto y = ymap(itiy, unit);
+       auto z = zmap(itiz, unit);
+       run(x, y, z);
+     }
+   __syncthreads();
+ }
+ 
+ }  // namespace
+
+ template <
+     typename T1, typename T2, typename FP, int SPLINE_DIM, int AnchorBlockSizeX,
+     int AnchorBlockSizeY, int AnchorBlockSizeZ,
+     int numAnchorBlockX,  // Number of Anchor blocks along X
+     int numAnchorBlockY,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE, bool WORKFLOW, bool PROBE_PRED_ERROR>
+ __device__ void cusz::device_api::spline_layout_interpolate(
+     volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     DIM3 data_size, FP eb_r, FP ebx2, int radius,
+     INTERPOLATION_PARAMS intp_param)
+ {
+   auto xblue = [] __device__(int _tix, int unit) -> int {
+     return unit * (_tix * 2);
+   };
+   auto yblue = [] __device__(int _tiy, int unit) -> int {
+     return unit * (_tiy * 2);
+   };
+   auto zblue = [] __device__(int _tiz, int unit) -> int {
+     return unit * (_tiz * 2 + 1);
+   };
+ 
+   auto xblue_reverse = [] __device__(int _tix, int unit) -> int {
+     return unit * (_tix);
+   };
+   auto yblue_reverse = [] __device__(int _tiy, int unit) -> int {
+     return unit * (_tiy);
+   };
+   auto zblue_reverse = [] __device__(int _tiz, int unit) -> int {
+     return unit * (_tiz * 2 + 1);
+   };
+ 
+   auto xyellow = [] __device__(int _tix, int unit) -> int {
+     return unit * (_tix * 2);
+   };
+   auto yyellow = [] __device__(int _tiy, int unit) -> int {
+     return unit * (_tiy * 2 + 1);
+   };
+   auto zyellow = [] __device__(int _tiz, int unit) -> int {
+     return unit * (_tiz);
+   };
+ 
+   auto xyellow_reverse = [] __device__(int _tix, int unit) -> int {
+     return unit * (_tix);
+   };
+   auto yyellow_reverse = [] __device__(int _tiy, int unit) -> int {
+     return unit * (_tiy * 2 + 1);
+   };
+   auto zyellow_reverse = [] __device__(int _tiz, int unit) -> int {
+     return unit * (_tiz * 2);
+   };
+ 
+   auto xhollow = [] __device__(int _tix, int unit) -> int {
+     return unit * (_tix * 2 + 1);
+   };
+   auto yhollow = [] __device__(int _tiy, int unit) -> int {
+     return unit * (_tiy);
+   };
+   auto zhollow = [] __device__(int _tiz, int unit) -> int {
+     return unit * (_tiz);
+   };
+ 
+   auto xhollow_reverse = [] __device__(int _tix, int unit) -> int {
+     return unit * (_tix * 2 + 1);
+   };
+   auto yhollow_reverse = [] __device__(int _tiy, int unit) -> int {
+     return unit * (_tiy * 2);
+   };
+   auto zhollow_reverse = [] __device__(int _tiz, int unit) -> int {
+     return unit * (_tiz * 2);
+   };
+   
+   auto xyzmap_line_16b_1u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+    constexpr auto N = 8;
+    constexpr auto L = N*(N+1)*(N+1); 
+    constexpr auto Q = (N+1)*(N+1); 
+    auto group = _tix / L ;
+    auto m = _tix % L ;
+    auto i = m / Q;
+    auto j = (m % Q) / (N+1);
+    auto k = (m % Q) % (N+1);
+    if(group==0)
+        return std::make_tuple(2*i+1,2*j,2*k);
+    else if (group==1)
+        return std::make_tuple(2*k,2*i+1,2*j);
+    else
+        return std::make_tuple(2*j,2*k,2*i+1);
+
+};
+
+auto xyzmap_face_16b_1u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+    constexpr auto N = 8;
+    constexpr auto L = N*N*(N+1);
+    constexpr auto Q = N*N; 
+    auto group = _tix / L ;
+    auto m = _tix % L ;
+    auto i = m / Q;
+    auto j = (m % Q) / N;
+    auto k = (m % Q) % N;
+    if(group==0)
+        return std::make_tuple(2*i,2*j+1,2*k+1);
+    else if (group==1)
+        return std::make_tuple(2*k+1,2*i,2*j+1);
+    else
+        return std::make_tuple(2*j+1,2*k+1,2*i);
+
+};
+
+ auto xyzmap_cube_16b_1u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+    constexpr auto N = 8;
+    constexpr auto Q = N * N; 
+    auto i = _tix / Q;
+    auto j = (_tix % Q) / N;
+    auto k = (_tix % Q) % N;
+    return std::make_tuple(2*i+1,2*j+1,2*k+1);
+
+};
+
+auto xyzmap_line_16b_2u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+    constexpr auto N = 4;
+    constexpr auto L = N*(N+1)*(N+1); 
+    constexpr auto Q = (N+1)*(N+1); 
+    auto group = _tix / L ;
+    auto m = _tix % L ;
+    auto i = m / Q;
+    auto j = (m % Q) / (N+1);
+    auto k = (m % Q) % (N+1);
+    if(group==0)
+        return std::make_tuple(4*i+2,4*j,4*k);
+    else if (group==1)
+        return std::make_tuple(4*k,4*i+2,4*j);
+    else
+        return std::make_tuple(4*j,4*k,4*i+2);
+
+};
+
+auto xyzmap_face_16b_2u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+    constexpr auto N = 4;
+    constexpr auto L = N*N*(N+1);
+    constexpr auto Q = N*N; 
+    auto group = _tix / L ;
+    auto m = _tix % L ;
+    auto i = m / Q;
+    auto j = (m % Q) / N;
+    auto k = (m % Q) % N;
+    if(group==0)
+        return std::make_tuple(4*i,4*j+2,4*k+2);
+    else if (group==1)
+        return std::make_tuple(4*k+2,4*i,4*j+2);
+    else
+        return std::make_tuple(4*j+2,4*k+2,4*i);
+
+};
+
+  auto xyzmap_cube_16b_2u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+    constexpr auto N = 4;
+    constexpr auto Q = N * N; 
+    auto i = _tix / Q;
+    auto j = (_tix % Q) / N;
+    auto k = (_tix % Q) % N;
+    return std::make_tuple(4*i+2,4*j+2,4*k+2);
+
+  };
+
+
+  auto nan_cubic_interp = [] __device__ (T1 a, T1 b, T1 c, T1 d) -> T1{
+      return (-a+9*b+9*c-9*d) / 16;
+  };
+
+  auto nat_cubic_interp = [] __device__ (T1 a, T1 b, T1 c, T1 d) -> T1{
+      return (-3*a+23*b+23*c-3*d) / 40;
+  };
+
+
+
+
+   constexpr auto COARSEN = true;
+   constexpr auto NO_COARSEN = false;
+   constexpr auto BORDER_INCLUSIVE = true;
+   constexpr auto BORDER_EXCLUSIVE = false;
+ 
+   FP cur_ebx2 = ebx2, cur_eb_r = eb_r;
+ 
+   auto calc_eb = [&](auto unit) {
+     cur_ebx2 = ebx2, cur_eb_r = eb_r;
+     int temp = 1;
+     while (temp < unit) {
+       temp *= 2;
+       cur_eb_r *= intp_param.alpha;
+       cur_ebx2 /= intp_param.alpha;
+     }
+     if (cur_ebx2 < ebx2 / intp_param.beta) {
+       cur_ebx2 = ebx2 / intp_param.beta;
+       cur_eb_r = eb_r * intp_param.beta;
+     }
+   };
+   
+
+    int max_unit = ((AnchorBlockSizeX >= AnchorBlockSizeY) ? AnchorBlockSizeX : AnchorBlockSizeY);
+    max_unit = ((max_unit >= AnchorBlockSizeZ) ? max_unit : AnchorBlockSizeZ);
+    max_unit /= 2;
+    int unit_x = AnchorBlockSizeX, unit_y = AnchorBlockSizeY, unit_z = AnchorBlockSizeZ;
+    
+    #pragma unroll
+    for(int unit = max_unit; unit > 2; unit /= 2){
+      // if(threadIdx.x == 0 && blockIdx.x + blockIdx.y + blockIdx.z == 0) printf("unit=%d\n", unit);
+      calc_eb(unit);
+     interpolate_stage<
+         T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+         numAnchorBlockX,  // Number of Anchor blocks along X
+         numAnchorBlockY,  // Number of Anchor blocks along Y
+         numAnchorBlockZ,  // Number of Anchor blocks along Z
+         decltype(xhollow_reverse), decltype(yhollow_reverse),
+         decltype(zhollow_reverse),  //
+         false, false, true, LINEAR_BLOCK_SIZE,
+         BORDER_INCLUSIVE, WORKFLOW>(
+         s_data, s_ectrl, data_size, xhollow_reverse, yhollow_reverse,
+         zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius,
+         intp_param.interpolators[0], numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), NO_COARSEN, numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+         unit_x /= 2;
+     interpolate_stage<
+         T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+         numAnchorBlockX,  // Number of Anchor blocks along X
+         numAnchorBlockY,  // Number of Anchor blocks along Y
+         numAnchorBlockZ,  // Number of Anchor blocks along Z
+         decltype(xyellow_reverse), decltype(yyellow_reverse),
+         decltype(zyellow_reverse),  //
+         false, true, false, LINEAR_BLOCK_SIZE,
+         BORDER_INCLUSIVE, WORKFLOW>(
+         s_data, s_ectrl, data_size, xyellow_reverse, yyellow_reverse,
+         zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius,
+         intp_param.interpolators[1], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y, NO_COARSEN, numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+          unit_y /= 2;
+    interpolate_stage<
+        T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+        numAnchorBlockX,  // Number of Anchor blocks along X
+        numAnchorBlockY,  // Number of Anchor blocks along Y
+        numAnchorBlockZ,  // Number of Anchor blocks along Z
+        decltype(xblue_reverse), decltype(yblue_reverse),
+        decltype(zblue_reverse),  //
+        true, false, false, LINEAR_BLOCK_SIZE,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xblue_reverse, yblue_reverse,
+        zblue_reverse, unit, cur_eb_r, cur_ebx2, radius,
+        intp_param.interpolators[2], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), NO_COARSEN, numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+      unit_z /= 2;
+    }
+      int unit = 2;
+      calc_eb(unit);
+         if(intp_param.interpolators[1]==0){
+ 
+          interpolate_stage_md<
+              T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_line_16b_2u), //
+              true, false, false, LINEAR_BLOCK_SIZE,300 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_line_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+  
+          interpolate_stage_md<
+              T1, T2, FP,
+              SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_face_16b_2u), //
+              false, true, false, LINEAR_BLOCK_SIZE,240 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_face_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+  
+          interpolate_stage_md<
+              T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_cube_16b_2u), //
+              false, false, true, LINEAR_BLOCK_SIZE,64 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_cube_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+  
+      }
+      else{
+          interpolate_stage_md<
+              T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_line_16b_2u), //
+              true, false, false, LINEAR_BLOCK_SIZE,300 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_line_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+  
+          interpolate_stage_md<
+              T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_face_16b_2u), //
+              false, true, false, LINEAR_BLOCK_SIZE,240 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_face_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+  
+          interpolate_stage_md<
+              T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_cube_16b_2u), //
+              false, false, true, LINEAR_BLOCK_SIZE,64 ,NO_COARSEN, BORDER_EXCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_cube_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+      }
+
+      unit = 1;
+      calc_eb(unit);
+      if(intp_param.interpolators[0]==0){
+          interpolate_stage_md<
+              T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_line_16b_1u), //
+              true, false, false, LINEAR_BLOCK_SIZE,1944 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_line_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+  
+          interpolate_stage_md<
+              T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_face_16b_1u), //
+              false, true, false, LINEAR_BLOCK_SIZE,1728 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_face_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+  
+          interpolate_stage_md<
+              T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_cube_16b_1u), //
+              false, false, true, LINEAR_BLOCK_SIZE,512 ,COARSEN, BORDER_EXCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_cube_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+  
+      }
+      else{
+          interpolate_stage_md<
+              T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_line_16b_1u), //
+              true, false, false, LINEAR_BLOCK_SIZE,1944 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_line_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+  
+          interpolate_stage_md<
+              T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_face_16b_1u), //
+              false, true, false, LINEAR_BLOCK_SIZE,1728 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_face_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+  
+          interpolate_stage_md<
+              T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+              numAnchorBlockX,  // Number of Anchor blocks along X
+              numAnchorBlockY,  // Number of Anchor blocks along Y
+              numAnchorBlockZ,  // Number of Anchor blocks along Z
+              decltype(xyzmap_cube_16b_1u), //
+              false, false, true, LINEAR_BLOCK_SIZE,512 ,COARSEN, BORDER_EXCLUSIVE, WORKFLOW>(
+              s_data, s_ectrl,data_size, xyzmap_cube_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+          
+  
+      }
+
+
+   
+  
+ }
+ 
+ template <
+     typename TITER, typename EITER, typename FP, int SPLINE_DIM, int AnchorBlockSizeX,
+     int AnchorBlockSizeY, int AnchorBlockSizeZ,
+     int numAnchorBlockX,  // Number of Anchor blocks along X
+     int numAnchorBlockY,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE, typename CompactVal, typename CompactIdx,
+     typename CompactNum>
+ __global__ void cusz::c_spline_infprecis_data(
+     TITER data, DIM3 data_size, STRIDE3 data_leap, EITER ectrl,
+     DIM3 ectrl_size, STRIDE3 ectrl_leap, TITER anchor, STRIDE3 anchor_leap,
+     CompactVal compact_val, CompactIdx compact_idx, CompactNum compact_num,
+     FP eb_r, FP ebx2, int radius,
+     INTERPOLATION_PARAMS intp_param  //,
+                                      // TITER errors
+ )
+ {
+   // compile time variables
+   using T = typename std::remove_pointer<TITER>::type;
+   using E = typename std::remove_pointer<EITER>::type;
+ 
+   {
+     __shared__ struct {
+       T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+             [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+             [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+       T ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+              [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+              [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+     } shmem;
+     c_reset_scratch_data<
+         T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+         numAnchorBlockX,  // Number of Anchor blocks along X
+         numAnchorBlockY,  // Number of Anchor blocks along Y
+         numAnchorBlockZ,  // Number of Anchor blocks along Z
+         LINEAR_BLOCK_SIZE>(shmem.data, shmem.ectrl, radius);
+ 
+     global2shmem_data<
+         T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+         numAnchorBlockX,  // Number of Anchor blocks along X
+         numAnchorBlockY,  // Number of Anchor blocks along Y
+         numAnchorBlockZ,  // Number of Anchor blocks along Z
+         LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data);
+     c_gather_anchor<
+         T, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+         numAnchorBlockX,  // Number of Anchor blocks along X
+         numAnchorBlockY,  // Number of Anchor blocks along Y
+         numAnchorBlockZ  // Number of Anchor blocks along Z
+         >(data, data_size, data_leap, anchor, anchor_leap);
+ 
+     cusz::device_api::spline_layout_interpolate<
+         T, T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+         numAnchorBlockX,  // Number of Anchor blocks along X
+         numAnchorBlockY,  // Number of Anchor blocks along Y
+         numAnchorBlockZ,  // Number of Anchor blocks along Z
+         LINEAR_BLOCK_SIZE, SPLINE3_COMPR, false>(
+         shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
+        //  if(threadIdx.x == 0 && blockIdx.x + blockIdx.y + blockIdx.z == 0) printf("Finish spline layout interpolate, start shmem2global_data_with_compaction\n");
+     shmem2global_data_with_compaction<
+         T, E, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+         numAnchorBlockX,  // Number of Anchor blocks along X
+         numAnchorBlockY,  // Number of Anchor blocks along Y
+         numAnchorBlockZ,  // Number of Anchor blocks along Z
+         LINEAR_BLOCK_SIZE>(
+         shmem.ectrl, ectrl, ectrl_size, ectrl_leap, radius, compact_val,
+         compact_idx, compact_num);
+   }
+ }
+ 
+ template <
+     typename EITER, typename TITER, typename FP, int SPLINE_DIM, int AnchorBlockSizeX,
+     int AnchorBlockSizeY, int AnchorBlockSizeZ,
+     int numAnchorBlockX,  // Number of Anchor blocks along X
+     int numAnchorBlockY,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE>
+ __global__ void cusz::x_spline_infprecis_data(
+     EITER ectrl,          // input 1
+     DIM3 ectrl_size,      //
+     STRIDE3 ectrl_leap,   //
+     TITER anchor,         // input 2
+     DIM3 anchor_size,     //
+     STRIDE3 anchor_leap,  //
+     TITER data,           // output
+     DIM3 data_size,       //
+     STRIDE3 data_leap,    //
+     TITER outlier_tmp,
+     FP eb_r, FP ebx2, int radius, INTERPOLATION_PARAMS intp_param)
+ {
+   // compile time variables
+   using E = typename std::remove_pointer<EITER>::type;
+   using T = typename std::remove_pointer<TITER>::type;
+ 
+   __shared__ struct {
+     T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+           [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+           [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+     T ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+            [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+            [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+   } shmem;
+   x_reset_scratch_data<
+       T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+       numAnchorBlockX,  // Number of Anchor blocks along X
+       numAnchorBlockY,  // Number of Anchor blocks along Y
+       numAnchorBlockZ,  // Number of Anchor blocks along Z
+       LINEAR_BLOCK_SIZE>(
+       shmem.data, shmem.ectrl, anchor, anchor_size, anchor_leap);
+   global2shmem_fuse<
+       T, E, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+       numAnchorBlockX,  // Number of Anchor blocks along X
+       numAnchorBlockY,  // Number of Anchor blocks along Y
+       numAnchorBlockZ,  // Number of Anchor blocks along Z
+      //  LINEAR_BLOCK_SIZE>(ectrl, ectrl_size, ectrl_leap, data, shmem.ectrl);
+       LINEAR_BLOCK_SIZE>(ectrl, ectrl_size, ectrl_leap, outlier_tmp, shmem.ectrl);
+ 
+   cusz::device_api::spline_layout_interpolate<
+       T, T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+       numAnchorBlockX,  // Number of Anchor blocks along X
+       numAnchorBlockY,  // Number of Anchor blocks along Y
+       numAnchorBlockZ,  // Number of Anchor blocks along Z
+       LINEAR_BLOCK_SIZE, SPLINE3_DECOMPR, false>(
+       shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
+   shmem2global_data<
+       T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+       numAnchorBlockX,  // Number of Anchor blocks along X
+       numAnchorBlockY,  // Number of Anchor blocks along Y
+       numAnchorBlockZ,  // Number of Anchor blocks along Z
+       LINEAR_BLOCK_SIZE>(shmem.data, data, data_size, data_leap);
+ }
+ 
+ #undef TIX
+ #undef TIY
+ #undef TIZ
+ #undef BIX
+ #undef BIY
+ #undef BIZ
+ #undef BDX
+ #undef BDY
+ #undef BDZ
+ #undef GDX
+ #undef GDY
+ #undef GDZ
+ 
+ #endif

--- a/src/kernel/detail/spline2_md.inl
+++ b/src/kernel/detail/spline2_md.inl
@@ -1,0 +1,2658 @@
+ /**
+ * @file spline3.inl
+ * @author Jinyang Liu, Shixun Wu, Jiannan Tian
+ * @brief
+ * @version 0.2
+ * @date 2021-05-15
+ *
+ * (copyright to be updated)
+ * (C) 2021 by Washington State University, Argonne National Laboratory
+ *
+ */
+
+#ifndef CUSZ_KERNEL_SPLINE3_CUH
+#define CUSZ_KERNEL_SPLINE3_CUH
+
+#include <stdint.h>
+#include <stdio.h>
+#include <type_traits>
+#include "cusz/type.h"
+#include "utils/err.hh"
+#include "utils/timer.hh"
+
+#define SPLINE3_COMPR true
+#define SPLINE3_DECOMPR false
+
+#define SPLINE3_PRED_ATT true
+#define SPLINE3_AB_ATT false
+
+#if __cplusplus >= 201703L
+#define CONSTEXPR constexpr
+#else
+#define CONSTEXPR
+#endif
+
+#define TIX threadIdx.x
+#define TIY threadIdx.y
+#define TIZ threadIdx.z
+#define BIX blockIdx.x
+#define BIY blockIdx.y
+#define BIZ blockIdx.z
+#define BDX blockDim.x
+#define BDY blockDim.y
+#define BDZ blockDim.z
+#define GDX gridDim.x
+#define GDY gridDim.y
+#define GDZ gridDim.z
+
+using DIM     = u4;
+using STRIDE  = u4;
+using DIM3    = dim3;
+using STRIDE3 = dim3;
+#define BLOCK_DIM_SIZE 384
+
+constexpr int BLOCK16 = 16;
+constexpr int BLOCK17 = 17;
+constexpr int DEFAULT_LINEAR_BLOCK_SIZE = BLOCK_DIM_SIZE;
+
+#define SHM_ERROR s_ectrl
+
+namespace cusz {
+
+/********************************************************************************
+ * host API
+ ********************************************************************************/
+template <typename TITER, int SPLINE_DIM,
+int PROFILE_BLOCK_SIZE_X,
+int PROFILE_BLOCK_SIZE_Y,
+int PROFILE_BLOCK_SIZE_Z,
+int PROFILE_NUM_BLOCK_X,
+int PROFILE_NUM_BLOCK_Y,
+int PROFILE_NUM_BLOCK_Z,
+int  LINEAR_BLOCK_SIZE>
+__global__ void c_spline_profiling_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    TITER errors);
+
+template <typename TITER, int SPLINE_DIM,
+int PROFILE_NUM_BLOCK_X,
+int PROFILE_NUM_BLOCK_Y,
+int PROFILE_NUM_BLOCK_Z,
+int  LINEAR_BLOCK_SIZE>
+__global__ void c_spline_profiling_data_2(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    TITER errors);
+
+template <
+    typename TITER,
+    typename EITER,
+    typename FP            = float,
+    int SPLINE_DIM = 2,
+    int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8,
+    int AnchorBlockSizeZ = 1,
+    int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+    int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+    int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+    int  LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE, 
+    typename CompactVal = TITER,
+    typename CompactIdx = uint32_t*,
+    typename CompactNum = uint32_t*>
+__global__ void c_spline_infprecis_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    EITER   ectrl,
+    DIM3    ectrl_size,
+    STRIDE3 ectrl_leap,
+    TITER   anchor,
+    STRIDE3 anchor_leap,
+    CompactVal cval,
+    CompactIdx cidx,
+    CompactNum cn,
+    FP      eb_r,
+    FP      ebx2,
+    int     radius,
+    INTERPOLATION_PARAMS intp_param,
+    TITER errors);
+
+template <
+    typename EITER,
+    typename TITER,
+    typename FP           = float,
+    int SPLINE_DIM = 2,
+    int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8,
+    int AnchorBlockSizeZ = 1,
+    int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+    int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+    int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__global__ void x_spline_infprecis_data(
+    EITER   ectrl,        // input 1
+    DIM3    ectrl_size,   //
+    STRIDE3 ectrl_leap,   //
+    TITER   anchor,       // input 2
+    DIM3    anchor_size,  //
+    STRIDE3 anchor_leap,  //
+    TITER   data,         // output
+    DIM3    data_size,    //
+    STRIDE3 data_leap,    //
+    FP      eb_r,
+    FP      ebx2,
+    int     radius,
+    INTERPOLATION_PARAMS intp_param);
+
+template <typename TITER>
+__global__ void reset_errors(TITER errors);
+
+template <typename TITER, typename FP, 
+int SPLINE_DIM = 2,
+int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8,
+int AnchorBlockSizeZ = 1,
+int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__global__ void pa_spline_infprecis_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    DIM3 sample_starts,
+    DIM3 sample_block_grid_sizes,
+    DIM3 sample_strides,
+    FP      eb_r,
+    FP      ebx2,
+    INTERPOLATION_PARAMS intp_param,
+    TITER errors,
+    bool workflow = SPLINE3_PRED_ATT
+    );
+
+
+namespace device_api {
+/********************************************************************************
+ * device API
+ ********************************************************************************/
+
+    template <typename T, 
+    int SPLINE_DIM = 3,
+int PROFILE_BLOCK_SIZE_X = 4,
+int PROFILE_BLOCK_SIZE_Y = 4,
+int PROFILE_BLOCK_SIZE_Z = 4,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void auto_tuning(
+    volatile T s_data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z]       
+                    [PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X],  volatile T local_errs[6], DIM3  data_size, volatile T* count);
+
+ template <typename T, 
+ int SPLINE_DIM = 3,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+ int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void auto_tuning_2(
+    volatile T s_data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z], volatile T s_nx[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T s_ny[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T s_nz[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4],  volatile T local_errs[6], DIM3  data_size, volatile T* count);
+
+template <
+    typename T1,
+    typename T2,
+    typename FP,
+    int SPLINE_DIM = 2,
+int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8,
+int AnchorBlockSizeZ = 1,
+int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE,
+    bool WORKFLOW         = SPLINE3_COMPR,
+    bool PROBE_PRED_ERROR = false>
+__device__ void
+spline_layout_interpolate(
+    volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]       
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)][AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)], 
+    volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]       
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)][AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],  DIM3  data_size,FP eb_r, FP ebx2, int radius, INTERPOLATION_PARAMS intp_param);
+
+template <typename T, typename FP, int SPLINE_DIM,
+int AnchorBlockSizeX, int AnchorBlockSizeY,
+int AnchorBlockSizeZ,
+int numAnchorBlockX,  // Number of Anchor blocks along X
+int numAnchorBlockY,  // Number of Anchor blocks along Y
+int numAnchorBlockZ,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE, bool WORKFLOW>
+__device__ void spline_layout_interpolate_att(
+    volatile T s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]       
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)][AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     DIM3    data_size,
+    DIM3 global_starts,FP eb_r, FP ebx2,uint8_t level,INTERPOLATION_PARAMS intp_param,volatile T *error);
+
+
+}  // namespace device_api
+
+
+
+
+}  // namespace cusz
+
+/********************************************************************************
+ * helper function
+ ********************************************************************************/
+
+namespace {
+
+template <int SPLINE_DIM, 
+int AnchorBlockSizeX,
+int AnchorBlockSizeY, 
+int AnchorBlockSizeZ,
+int numAnchorBlockX,  // Number of Anchor blocks along X
+int numAnchorBlockY,  // Number of Anchor blocks along Y
+int numAnchorBlockZ,  // Number of Anchor blocks along Z
+bool INCLUSIVE = true>
+__forceinline__ __device__ bool xyz_predicate(unsigned int x, unsigned int y, unsigned int z,const DIM3 &data_size)
+{
+    if CONSTEXPR (INCLUSIVE) {  //
+
+        
+            return (x <= (AnchorBlockSizeX * numAnchorBlockX) and y <= (AnchorBlockSizeY * numAnchorBlockY) and z <= (AnchorBlockSizeZ * numAnchorBlockZ)) and BIX * (AnchorBlockSizeX * numAnchorBlockX) + x < data_size.x and BIY *  (AnchorBlockSizeY * numAnchorBlockY) + y < data_size.y and BIZ * (AnchorBlockSizeZ * numAnchorBlockZ) + z < data_size.z;
+    }
+    else {
+        return x < (AnchorBlockSizeX * numAnchorBlockX) + (BIX == GDX - 1) * (SPLINE_DIM <= 1) and y < (AnchorBlockSizeY * numAnchorBlockY) + (BIY == GDY - 1) * (SPLINE_DIM <= 2) and z < (AnchorBlockSizeZ * numAnchorBlockZ) + (BIZ == GDZ - 1) * (SPLINE_DIM <= 3) and BIX * (AnchorBlockSizeX * numAnchorBlockX) + x < data_size.x and BIY * (AnchorBlockSizeY * numAnchorBlockY) + y < data_size.y and BIZ * (AnchorBlockSizeZ * numAnchorBlockZ) + z < data_size.z;
+    }
+}
+
+template <int SPLINE_DIM,
+int AnchorBlockSizeX,
+int AnchorBlockSizeY,
+int AnchorBlockSizeZ,
+int numAnchorBlockX, 
+int numAnchorBlockY, 
+int numAnchorBlockZ, 
+bool INCLUSIVE = true>
+__forceinline__ __device__ bool xyz_predicate_att(unsigned int x, unsigned int y, unsigned int z,const DIM3 &data_size, const DIM3 & global_starts)
+{
+    if CONSTEXPR (INCLUSIVE) {
+            return (x <= (AnchorBlockSizeX * numAnchorBlockX) and y <= (AnchorBlockSizeY * numAnchorBlockY) and z <= (AnchorBlockSizeZ * numAnchorBlockZ)) and global_starts.x + x < data_size.x and global_starts.y + y < data_size.y and global_starts.z + z < data_size.z;
+    }
+    else {
+        return x < (AnchorBlockSizeX * numAnchorBlockX) + (BIX == GDX - 1) and y < (AnchorBlockSizeY * numAnchorBlockY) + (BIY == GDY - 1) and z < (AnchorBlockSizeZ * numAnchorBlockZ) + (BIZ == GDZ - 1) and global_starts.x + x < data_size.x and global_starts.y + y < data_size.y and global_starts.z + z < data_size.z;
+    }
+}
+
+template <typename T1, typename T2,
+int SPLINE_DIM, 
+int AnchorBlockSizeX, 
+int AnchorBlockSizeY,
+int AnchorBlockSizeZ,
+int numAnchorBlockX,  // Number of Anchor blocks along X
+int numAnchorBlockY,  // Number of Anchor blocks along Y
+int numAnchorBlockZ,  // Number of Anchor blocks along Z 
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void c_reset_scratch_data(
+    volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    int radius)
+{
+    for (auto _tix = TIX; _tix < (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) *
+            (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) * (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+            _tix += LINEAR_BLOCK_SIZE) {
+        auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+        auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+                    (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+                    (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+
+        s_data[z][y][x] = 0;
+        if (x % AnchorBlockSizeX == 0 and y % AnchorBlockSizeY == 0 and
+            z % AnchorBlockSizeZ == 0)
+          s_ectrl[z][y][x] = radius;
+    }
+    __syncthreads();
+}
+
+
+template <typename T, 
+int SPLINE_DIM = 3,
+int PROFILE_BLOCK_SIZE_X = 4,
+int PROFILE_BLOCK_SIZE_Y = 4,
+int PROFILE_BLOCK_SIZE_Z = 4,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void c_reset_scratch_profiling_data(
+    volatile T s_data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z][PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X], T default_value)
+{
+    auto x_size = PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X;
+    auto y_size = PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y;
+    auto z_size = PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z;
+    for (auto _tix = TIX; _tix < x_size * y_size * z_size; _tix += LINEAR_BLOCK_SIZE) {
+        auto x = (_tix % x_size);
+        auto y = (_tix / x_size) % y_size;
+        auto z = (_tix / x_size) / y_size;
+        s_data[z][y][x] = default_value;
+
+    }
+}
+
+template <typename T,
+int SPLINE_DIM = 3,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4, 
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void c_reset_scratch_profiling_data_2(volatile T s_data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z], T nx[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], T ny[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], T nz[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4],T default_value)
+{
+    for (auto _tix = TIX; _tix < PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z * 4; _tix += LINEAR_BLOCK_SIZE) {
+        auto offset = (_tix % 4);
+        auto idx = _tix / 4;
+        nx[idx][offset] = ny[idx][offset] = nz[idx][offset] = default_value;
+        // s_data[TIX] = default_value;
+        s_data[idx] = default_value;
+
+    }
+}
+
+
+template <typename T1, 
+int AnchorBlockSizeX, int AnchorBlockSizeY,
+     int AnchorBlockSizeZ,
+     int numAnchorBlockX,  // Number of Anchor blocks along X
+     int numAnchorBlockY,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void c_gather_anchor(T1* data, DIM3 data_size, STRIDE3 data_leap, T1* anchor, STRIDE3 anchor_leap)
+{
+    auto ax = BIX ;//1 is block16 by anchor stride
+    auto ay = BIY ;
+    auto az = BIZ ;
+    // 2d bug may be here! 
+    auto x = (AnchorBlockSizeX * numAnchorBlockX) * ax;
+    auto y = (AnchorBlockSizeY * numAnchorBlockY) * ay;
+    auto z = (AnchorBlockSizeZ * numAnchorBlockZ) * az;
+
+    bool pred1 = TIX < 1;//1 is num of anchor
+    bool pred2 = x < data_size.x and y < data_size.y and z < data_size.z;
+
+    if (pred1 and pred2) {
+        auto data_id      = x + y * data_leap.y + z * data_leap.z;
+        auto anchor_id    = ax + ay * anchor_leap.y + az * anchor_leap.z;
+        anchor[anchor_id] = data[data_id];
+    }
+    __syncthreads();
+}
+
+
+
+template <typename T1, typename T2 = T1,
+int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+     int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+     int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+     int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+      int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void x_reset_scratch_data(
+    volatile T1 s_xdata[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    T1*         anchor,       //
+    DIM3        anchor_size,  //
+    STRIDE3     anchor_leap)
+{
+    for (auto _tix = TIX; _tix <  (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) * (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) * (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)); _tix += LINEAR_BLOCK_SIZE) {
+        auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+        auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+
+        s_ectrl[z][y][x] = 0;  // TODO explicitly handle zero-padding
+        /*****************************************************************************
+         okay to use
+         ******************************************************************************/
+        if (x % AnchorBlockSizeX == 0 and y % AnchorBlockSizeY == 0 and
+            z % AnchorBlockSizeZ == 0) {
+            s_xdata[z][y][x] = 0;
+
+            auto ax = ((x / AnchorBlockSizeX) + BIX * numAnchorBlockX);
+            auto ay = ((y / AnchorBlockSizeY) + BIY * numAnchorBlockY);
+            auto az = ((z / AnchorBlockSizeZ) + BIZ * numAnchorBlockZ);
+
+            if (ax < anchor_size.x and ay < anchor_size.y and az < anchor_size.z)
+                s_xdata[z][y][x] = anchor[ax + ay * anchor_leap.y + az * anchor_leap.z];
+
+        }
+
+    }
+
+    __syncthreads();
+}
+
+template <typename T1, typename T2, int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_data(T1* data, DIM3 data_size, STRIDE3 data_leap,
+    volatile T2 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)])
+{
+    constexpr auto TOTAL = (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) *
+                        (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) * 
+                        (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+        auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto gx  = (x + BIX * (AnchorBlockSizeX * numAnchorBlockX));
+        auto gy  = (y + BIY * (AnchorBlockSizeY * numAnchorBlockY));
+        auto gz  = (z + BIZ * (AnchorBlockSizeZ * numAnchorBlockZ));
+        auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+
+        if (gx < data_size.x and gy < data_size.y and gz < data_size.z) s_data[z][y][x] = data[gid];
+
+    }
+    __syncthreads();
+}
+
+template <typename T1, typename T2, 
+int SPLINE_DIM = 3,
+int PROFILE_BLOCK_SIZE_X = 4,
+int PROFILE_BLOCK_SIZE_Y = 4,
+int PROFILE_BLOCK_SIZE_Z = 4,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_profiling_data(T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z][PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X])
+{
+    constexpr auto x_size = PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X;
+    constexpr auto y_size = PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y;
+    constexpr auto z_size = PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z;
+    constexpr auto TOTAL = x_size * y_size * z_size;
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x   = (_tix % x_size);
+        auto y   = (_tix / x_size) % y_size;
+        auto z   = (_tix / x_size) / y_size;
+        auto gx_1 = x / PROFILE_BLOCK_SIZE_X;
+        auto gx_2 = x % PROFILE_BLOCK_SIZE_X;
+        auto gy_1 = y / PROFILE_BLOCK_SIZE_Y;
+        auto gy_2 = y % PROFILE_BLOCK_SIZE_Y;
+        auto gz_1 = z / PROFILE_BLOCK_SIZE_Z;
+        auto gz_2 = z % PROFILE_BLOCK_SIZE_Z;
+        auto gx = (data_size.x / PROFILE_NUM_BLOCK_X) * gx_1 + gx_2;
+        auto gy = (data_size.y / PROFILE_NUM_BLOCK_Y) * gy_1 + gy_2;
+        auto gz = (data_size.z / PROFILE_NUM_BLOCK_Z) * gz_1 + gz_2;
+
+        auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+
+        if (gx < data_size.x and gy < data_size.y and gz < data_size.z) s_data[z][y][x] = data[gid];
+
+    }
+    __syncthreads();
+}
+
+template <typename T1, typename T2,
+int SPLINE_DIM = 3,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_profiling_data_2(T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z], volatile T2 s_nx[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T2 s_ny[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T2 s_nz[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4])
+{
+    constexpr auto TOTAL = PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z * 4;
+    int factors[4] = {-3, -1, 1, 3};
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto offset   = (_tix % 4);
+        auto idx = _tix / 4;
+        auto x = idx % PROFILE_NUM_BLOCK_X;
+        auto y   = (idx / PROFILE_NUM_BLOCK_X) % PROFILE_NUM_BLOCK_Y;
+        auto z   = (idx / PROFILE_NUM_BLOCK_X) / PROFILE_NUM_BLOCK_Y;
+        auto gx=(data_size.x / PROFILE_NUM_BLOCK_X) * x + data_size.x / (PROFILE_NUM_BLOCK_X * 2);
+        auto gy=(data_size.y / PROFILE_NUM_BLOCK_Y) * y + data_size.y / (PROFILE_NUM_BLOCK_Y * 2);
+        auto gz=(data_size.z / PROFILE_NUM_BLOCK_Z) * z + data_size.z / (PROFILE_NUM_BLOCK_Z * 2);
+
+        auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+
+        if (gx >= 3 and gy >= 3 and gz >= 3 and gx + 3 < data_size.x and gy + 3 < data_size.y and gz + 3 < data_size.z) {
+            s_data[idx] = data[gid];
+            auto factor=factors[offset];
+            s_nx[idx][offset]=data[gid+factor];
+            s_ny[idx][offset]=data[gid+factor*data_leap.y];
+            s_nz[idx][offset]=data[gid+factor*data_leap.z];
+        }
+    }
+    __syncthreads();
+}
+
+template <typename T = float, typename E = u4, 
+int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_fuse(E* ectrl, dim3 ectrl_size, dim3 ectrl_leap, T* scattered_outlier, 
+    volatile T s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    volatile STRIDE3 grid_leaps[5],volatile size_t prefix_nums[5])
+{
+    
+    constexpr auto TOTAL = (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) *
+    (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) *
+    (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x   = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+        auto y   = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) % (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto z   = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) / (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto gx  = (x + BIX * (AnchorBlockSizeX * numAnchorBlockX));
+        auto gy  = (y + BIY * (AnchorBlockSizeY * numAnchorBlockY));
+        auto gz  = (z + BIZ * (AnchorBlockSizeZ * numAnchorBlockZ));
+        if (gx < ectrl_size.x and gy < ectrl_size.y and gz < ectrl_size.z) {
+            //todo: pre-compute the leaps and their halves
+
+            int level = 0;
+            auto data_gid = gx + gy * ectrl_leap.y + gz * ectrl_leap.z;
+            while(gx % 2 == 0 and gy % 2 == 0 and gz % 2 == 0 and level <= 3){
+                gx = gx >> 1;
+                gy = gy >> 1;
+                gz = gz >> 1;
+                level++;
+            }
+            auto gid = gx + gy*grid_leaps[level].y+gz*grid_leaps[level].z;
+
+            if(level < 4){//non-anchor
+                gid += prefix_nums[level]-((gz+1)>>1)*grid_leaps[level+1].z-(gz%2==0)*((gy+1)>>1)*grid_leaps[level+1].y-(gz%2==0 && gy%2==0)*((gx+1)>>1);
+            }
+
+            s_ectrl[z][y][x] = static_cast<T>(ectrl[gid]) + scattered_outlier[data_gid];
+        }
+    }
+    __syncthreads();
+}
+
+// dram_outlier should be the same in type with shared memory buf
+template <typename T1, typename T2,
+int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void
+shmem2global_data(volatile T1 s_buf[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+[AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+[AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)], T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap)
+{
+    auto x_size = AnchorBlockSizeX * numAnchorBlockX + (BIX == GDX - 1) * (SPLINE_DIM >= 1);
+    auto y_size = AnchorBlockSizeY * numAnchorBlockY + (BIY == GDY - 1) * (SPLINE_DIM >= 2);
+    auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (BIZ == GDZ - 1) * (SPLINE_DIM >= 3);
+    auto TOTAL = x_size * y_size * z_size;
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x   = (_tix % x_size);
+        auto y   = (_tix / x_size) % y_size;
+        auto z   = (_tix / x_size) / y_size;
+        auto gx  = (x + BIX * AnchorBlockSizeX * numAnchorBlockX);
+        auto gy  = (y + BIY * AnchorBlockSizeY * numAnchorBlockY);
+        auto gz  = (z + BIZ * AnchorBlockSizeZ * numAnchorBlockZ);
+        auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+
+        if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z) dram_buf[gid] = s_buf[z][y][x];
+    }
+    __syncthreads();
+}
+
+
+// dram_outlier should be the same in type with shared memory buf
+template <typename T1, typename T2,
+int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void
+shmem2global_data_with_compaction(volatile T1 s_buf[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+[AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+[AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)], T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap, int radius,volatile STRIDE3 grid_leaps[5],volatile size_t prefix_nums[5], T1* dram_compactval = nullptr, uint32_t* dram_compactidx = nullptr, uint32_t* dram_compactnum = nullptr)
+{
+    auto x_size = AnchorBlockSizeX * numAnchorBlockX + (BIX == GDX - 1) * (SPLINE_DIM >= 1);
+    auto y_size = AnchorBlockSizeY * numAnchorBlockY + (BIY == GDY - 1) * (SPLINE_DIM >= 2);
+    auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (BIZ == GDZ - 1) * (SPLINE_DIM >= 3);
+    auto TOTAL = x_size * y_size * z_size;
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x   = (_tix % x_size);
+        auto y   = (_tix / x_size) % y_size;
+        auto z   = (_tix / x_size) / y_size;
+        auto gx  = (x + BIX * AnchorBlockSizeX * numAnchorBlockX);
+        auto gy  = (y + BIY * AnchorBlockSizeY * numAnchorBlockY);
+        auto gz  = (z + BIZ * AnchorBlockSizeZ * numAnchorBlockZ);
+        //auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+
+        auto candidate = s_buf[z][y][x];
+        bool quantizable = (candidate >= 0) and (candidate < 2*radius);
+
+        if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z) {
+
+            
+
+            if (not quantizable) {
+                auto data_gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+                auto cur_idx = atomicAdd(dram_compactnum, 1);
+                dram_compactidx[cur_idx] = data_gid;
+                dram_compactval[cur_idx] = candidate;
+            }
+            int level = 0;
+            //todo: pre-compute the leaps and their halves
+            while(gx%2==0 and gy%2==0 and gz%2==0 and level <= 3){
+                
+                gx=gx>>1;
+                gy=gy>>1;
+                gz=gz>>1;
+                level ++;
+            }
+            auto gid = gx + gy*grid_leaps[level].y+gz*grid_leaps[level].z;
+
+            if(level < 4){//non-anchor
+                gid += prefix_nums[level]-((gz+1)>>1)*grid_leaps[level+1].z-(gz%2==0)*((gy+1)>>1)*grid_leaps[level+1].y-(gz%2==0 && gy%2==0)*((gx+1)>>1);
+            }
+
+            // TODO this is for algorithmic demo by reading from shmem
+            // For performance purpose, it can be inlined in quantization
+            dram_buf[gid] = quantizable * static_cast<T2>(candidate);
+        }
+    }
+}
+
+
+
+template <
+    typename T1,
+    typename T2,
+    typename FP,
+    int SPLINE_DIM, int AnchorBlockSizeX,
+    int AnchorBlockSizeY, int AnchorBlockSizeZ,
+    int numAnchorBlockX,
+    int numAnchorBlockY,
+    int numAnchorBlockZ,
+    typename LAMBDAX,
+    typename LAMBDAY,
+    typename LAMBDAZ,
+    bool BLUE,
+    bool YELLOW,
+    bool HOLLOW,
+    bool COARSEN,
+    int  LINEAR_BLOCK_SIZE,
+    bool BORDER_INCLUSIVE,
+    bool WORKFLOW>
+__forceinline__ __device__ void interpolate_stage(
+    volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    DIM3    data_size,
+    LAMBDAX     xmap,
+    LAMBDAY     ymap,
+    LAMBDAZ     zmap,
+    int         unit,
+    FP          eb_r,
+    FP          ebx2,
+    int         radius,
+    bool interpolator,
+    int  BLOCK_DIMX,
+    int  BLOCK_DIMY,
+    int  BLOCK_DIMZ)
+{
+    // static_assert(BLOCK_DIMX * BLOCK_DIMY * (COARSEN ? 1 : BLOCK_DIMZ) <= BLOCK_DIM_SIZE, "block oversized");
+    static_assert((BLUE or YELLOW or HOLLOW) == true, "must be one hot");
+    static_assert((BLUE and YELLOW) == false, "must be only one hot (1)");
+    static_assert((BLUE and YELLOW) == false, "must be only one hot (2)");
+    static_assert((YELLOW and HOLLOW) == false, "must be only one hot (3)");
+
+
+    auto run = [&](auto x, auto y, auto z) {
+        if (xyz_predicate<SPLINE_DIM,
+            AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+            numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ,
+            BORDER_INCLUSIVE>(x, y, z,data_size)) {
+            auto global_x = BIX * AnchorBlockSizeX * numAnchorBlockX + x;
+            auto global_y = BIY * AnchorBlockSizeY * numAnchorBlockY + y;
+            auto global_z = BIZ * AnchorBlockSizeZ * numAnchorBlockZ + z;  
+            
+            T1 pred = 0;
+            auto input_x = x;
+            auto input_BI = BIX;
+            auto input_GD = GDX;
+            auto input_gx = global_x;
+            auto input_gs = data_size.x;
+            auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+            auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+            auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+            auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+            int p1 = -1, p2 = 9, p3 = 9, p4 = -1, p5 = 16;
+            if(interpolator==0){
+                p1 = -3, p2 = 23, p3 = 23, p4 = -3, p5 = 40;
+            }
+            if CONSTEXPR (BLUE){
+                input_x = z;
+                input_BI = BIZ;
+                input_GD = GDZ;
+                input_gx = global_z;
+                input_gs = data_size.z;
+                right_bound = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+            }
+            if CONSTEXPR (YELLOW){
+                input_x = y;
+                input_BI = BIY;
+                input_GD = GDY;
+                input_gx = global_y;
+                input_gs = data_size.y;
+                right_bound = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+            }
+            
+            int id_[4], s_id[4];
+            id_[0] =  input_x - 3 * unit;
+            id_[0] =  id_[0] >= 0 ? id_[0] : 0;
+        
+            id_[1] = input_x - unit;
+            id_[1] = id_[1] >= 0 ? id_[1] : 0;
+        
+            id_[2] = input_x + unit;
+            id_[2] = id_[2] < right_bound ? id_[2] : 0;
+            
+            id_[3] = input_x + 3 * unit;
+            id_[3] = id_[3] < right_bound ? id_[3] : 0;
+            
+            s_id[0] = x_size * y_size * z + x_size * y + id_[0];
+            s_id[1] = x_size * y_size * z + x_size * y + id_[1];
+            s_id[2] = x_size * y_size * z + x_size * y + id_[2];
+            s_id[3] = x_size * y_size * z + x_size * y + id_[3];
+            if CONSTEXPR (BLUE){
+            s_id[0] = x_size * y_size * id_[0] + x_size * y + x;
+            s_id[1] = x_size * y_size * id_[1] + x_size * y + x;
+            s_id[2] = x_size * y_size * id_[2] + x_size * y + x;
+            s_id[3] = x_size * y_size * id_[3] + x_size * y + x;
+            }
+            if CONSTEXPR (YELLOW){
+                s_id[0] = x_size * y_size * z + x_size * id_[0] + x;
+                s_id[1] = x_size * y_size * z + x_size * id_[1] + x;
+                s_id[2] = x_size * y_size * z + x_size * id_[2] + x;
+                s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
+            }
+
+            T1 tmp_[4];
+        
+            bool case1 = (input_BI != input_GD - 1);
+            bool case2 = (input_x >= 3 * unit);
+            bool case3 = (input_x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX);
+            bool case4 = (input_gx + 3 * unit < input_gs);
+            bool case5 = (input_gx + unit < input_gs);
+            
+            // 预加载 shared memory 数据到寄存器
+            T1 tmp0 = *((T1*)s_data + s_id[0]); 
+            T1 tmp1 = *((T1*)s_data + s_id[1]); 
+            T1 tmp2 = *((T1*)s_data + s_id[2]); 
+            T1 tmp3 = *((T1*)s_data + s_id[3]); 
+
+            // 初始预测值
+            pred = tmp1;
+
+            // 计算不同 case 对应的 pred
+            if ((case1 && !case2 && !case3) || (!case1 && !case2 && !(case3 && case4) && case5)) {
+                pred = (tmp1 + tmp2) / 2;
+            }
+            else if ((case1 && !case2 && case3) || (!case1 && !case2 && case3 && case4)) {
+                pred = (3 * tmp1 + 6 * tmp2 - tmp3) / 8;
+            }
+            else if ((case1 && case2 && !case3) || (!case1 && case2 && !(case3 && case4) && case5)) {
+                pred = (-tmp0 + 6 * tmp1 + 3 * tmp2) / 8;
+            }
+            else if ((case1 && case2 && case3) || (!case1 && case2 && case3 && case4)) {
+                pred = (p1 * tmp0 + p2 * tmp1 + p3 * tmp2 + p4 * tmp3) / p5;
+            }
+                        
+            
+
+            if CONSTEXPR (WORKFLOW == SPLINE3_COMPR) {
+                
+                auto          err = s_data[z][y][x] - pred;
+                decltype(err) code;
+                // TODO unsafe, did not deal with the out-of-cap case
+                {
+                    code = fabs(err) * eb_r + 1;
+                    code = err < 0 ? -code : code;
+                    code = int(code / 2) + radius;
+                }
+                s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
+                s_data[z][y][x]  = pred + (code - radius) * ebx2;
+                
+
+            }
+            else {  // TODO == DECOMPRESSS and static_assert
+                auto code       = s_ectrl[z][y][x];
+                s_data[z][y][x] = pred + (code - radius) * ebx2;
+
+            }
+        }
+    };
+    // -------------------------------------------------------------------------------- //
+
+    if CONSTEXPR (COARSEN) {
+        constexpr auto TOTAL = BLOCK_DIMX * BLOCK_DIMY * BLOCK_DIMZ;
+        //if( BLOCK_DIMX *BLOCK_DIMY<= LINEAR_BLOCK_SIZE){
+            for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                auto itix = (_tix % BLOCK_DIMX);
+                auto itiy = (_tix / BLOCK_DIMX) % BLOCK_DIMY;
+                auto itiz = (_tix / BLOCK_DIMX) / BLOCK_DIMY;
+                auto x    = xmap(itix, unit);
+                auto y    = ymap(itiy, unit);
+                auto z    = zmap(itiz, unit);
+                
+                run(x, y, z);
+            }
+
+        
+    }
+    else {
+        auto itix = (TIX % BLOCK_DIMX);
+        auto itiy = (TIX / BLOCK_DIMX) % BLOCK_DIMY;
+        auto itiz = (TIX / BLOCK_DIMX) / BLOCK_DIMY;
+        auto x    = xmap(itix, unit);
+        auto y    = ymap(itiy, unit);
+        auto z    = zmap(itiz, unit);
+
+
+        run(x, y, z);
+    }
+    __syncthreads();
+}
+
+template <
+    typename T1,
+    typename T2,
+    typename FP,
+    int SPLINE_DIM, int AnchorBlockSizeX,
+    int AnchorBlockSizeY, int AnchorBlockSizeZ,
+    int numAnchorBlockX,
+    int numAnchorBlockY,
+    int numAnchorBlockZ,
+    typename LAMBDA,
+    bool LINE,
+    bool FACE,
+    bool CUBE,
+    int  LINEAR_BLOCK_SIZE,
+    bool COARSEN,
+    bool BORDER_INCLUSIVE,
+    bool WORKFLOW,
+    typename INTERP>
+__forceinline__ __device__ void interpolate_stage_md(
+    volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+ [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+ [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    DIM3    data_size,
+    LAMBDA xyzmap,
+    int         unit,
+    FP          eb_r,
+    FP          ebx2,
+    int         radius,
+    INTERP cubic_interpolator,
+    int NUM_ELE)
+{
+    // static_assert(COARSEN or (NUM_ELE <= BLOCK_DIM_SIZE), "block oversized");
+    static_assert((LINE or FACE or CUBE) == true, "must be one hot");
+    static_assert((LINE and FACE) == false, "must be only one hot (1)");
+    static_assert((LINE and CUBE) == false, "must be only one hot (2)");
+    static_assert((FACE and CUBE) == false, "must be only one hot (3)");
+
+    auto run = [&](auto x, auto y, auto z) {
+
+        if (xyz_predicate<SPLINE_DIM,
+            AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+            numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, BORDER_INCLUSIVE>(x, y, z,data_size)) {
+            T1 pred = 0;
+            auto global_x = BIX * AnchorBlockSizeX * numAnchorBlockX + x;
+            auto global_y = BIY * AnchorBlockSizeY * numAnchorBlockY + y;
+            auto global_z = BIZ * AnchorBlockSizeZ * numAnchorBlockZ + z;  
+
+           T1 tmp_z[4], tmp_y[4], tmp_x[4];
+           int id_z[4], id_y[4], id_x[4];
+           id_z[0] = (z - 3 * unit >= 0) ? z - 3 * unit : 0;
+           id_z[1] = (z - unit >= 0) ? z - unit : 0;
+           id_z[2] = (z + unit <= AnchorBlockSizeZ * numAnchorBlockZ) ? z + unit : 0;
+           id_z[3] = (z + 3 * unit <= AnchorBlockSizeZ * numAnchorBlockZ) ? z + 3 * unit : 0;
+           
+           id_y[0] = (y - 3 * unit >= 0) ? y - 3 * unit : 0;
+           id_y[1] = (y - unit >= 0) ? y - unit : 0;
+           id_y[2] = (y + unit <= AnchorBlockSizeY * numAnchorBlockY) ? y + unit : 0;
+           id_y[3] = (y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY) ? y + 3 * unit : 0;
+           
+           id_x[0] = (x - 3 * unit >= 0) ? x - 3 * unit : 0;
+           id_x[1] = (x - unit >= 0) ? x - unit : 0;
+           id_x[2] = (x + unit <= AnchorBlockSizeX * numAnchorBlockX) ? x + unit : 0;
+           id_x[3] = (x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX) ? x + 3 * unit : 0;
+           
+            if CONSTEXPR (LINE) {
+                bool I_Y = (y % (2*unit) )> 0; 
+                bool I_Z = (z % (2*unit) )> 0; 
+
+                pred = 0;
+                auto input_x = x;
+                auto input_BI = BIX;
+                auto input_GD = GDX;
+                auto input_gx = global_x;
+                auto input_gs = data_size.x;
+
+                auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                
+                if (I_Z){
+                    input_x = z;
+                    input_BI = BIZ;
+                    input_GD = GDZ;
+                    input_gx = global_z;
+                    input_gs = data_size.z;
+                    right_bound = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                }
+                else if (I_Y){
+                    input_x = y;
+                    input_BI = BIY;
+                    input_GD = GDY;
+                    input_gx = global_y;
+                    input_gs = data_size.y;
+                    right_bound = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                }
+                
+                int id_[4], s_id[4];
+                id_[0] =  input_x - 3 * unit;
+                id_[0] =  id_[0] >= 0 ? id_[0] : 0;
+            
+                id_[1] = input_x - unit;
+                id_[1] = id_[1] >= 0 ? id_[1] : 0;
+            
+                id_[2] = input_x + unit;
+                id_[2] = id_[2] < right_bound ? id_[2] : 0;
+                
+                id_[3] = input_x + 3 * unit;
+                id_[3] = id_[3] < right_bound ? id_[3] : 0;
+                
+                s_id[0] = x_size * y_size * z + x_size * y + id_[0];
+                s_id[1] = x_size * y_size * z + x_size * y + id_[1];
+                s_id[2] = x_size * y_size * z + x_size * y + id_[2];
+                s_id[3] = x_size * y_size * z + x_size * y + id_[3];
+                if (I_Z){
+                s_id[0] = x_size * y_size * id_[0] + x_size * y + x;
+                s_id[1] = x_size * y_size * id_[1] + x_size * y + x;
+                s_id[2] = x_size * y_size * id_[2] + x_size * y + x;
+                s_id[3] = x_size * y_size * id_[3] + x_size * y + x;
+                }
+                else if (I_Y){
+                    s_id[0] = x_size * y_size * z + x_size * id_[0] + x;
+                    s_id[1] = x_size * y_size * z + x_size * id_[1] + x;
+                    s_id[2] = x_size * y_size * z + x_size * id_[2] + x;
+                    s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
+                }
+
+                T1 tmp_[4];
+            
+                bool case1 = (input_BI != input_GD - 1);
+                bool case2 = (input_x >= 3 * unit);
+                bool case3 = (input_x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX);
+                bool case4 = (input_gx + 3 * unit < input_gs);
+                bool case5 = (input_gx + unit < input_gs);
+                
+                
+                // 预加载 shared memory 数据到寄存器
+                T1 tmp0 = *((T1*)s_data + s_id[0]); 
+                T1 tmp1 = *((T1*)s_data + s_id[1]); 
+                T1 tmp2 = *((T1*)s_data + s_id[2]); 
+                T1 tmp3 = *((T1*)s_data + s_id[3]); 
+    
+                // 初始预测值
+                pred = tmp1;
+    
+                // 计算不同 case 对应的 pred
+                if ( (case1 && case2 && case3) || (!case1 && case2 && case3 && case4)) {
+                    pred = cubic_interpolator(tmp0, tmp1, tmp2, tmp3);
+                    
+                }
+                else if ((case1 && case2 && !case3) || ( !case1 && case2 && !(case3 && case4) && case5)) {
+                    pred = (-tmp0 + 6 * tmp1 + 3 * tmp2) / 8;
+                }
+                else if ((case1 && !case2 && case3) || (!case1 && !case2 && case3 && case4 )){
+                    pred = (3 * tmp1 + 6 * tmp2 - tmp3) / 8;   
+                }
+                else if ((case1 && !case2 && !case3) || (!case1 && !case2 && !(case3 && case4) && case5)) {
+                    pred = (tmp1 + tmp2) / 2;
+                }
+
+            }
+            auto get_interp_order = [&](auto x, auto BI, auto GD, auto gx, auto gs){
+                int b = (x >= 3 * unit) ? 3 : 1;
+                int f = ((x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX) && ((BI != GD - 1) || (gx + 3 * unit < gs))) ? 3 :
+                (((BI != GD - 1) || (gx + unit < gs)) ? 1 : 0);
+
+                return (b == 3) ? ((f == 3) ? 4 : ((f == 1) ? 3 : 0)) 
+                                : ((f == 3) ? 2 : ((f == 1) ? 1 : 0));
+            };
+            if CONSTEXPR (FACE) {  //
+               // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and y==7 and z==0){
+               //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
+              //  }
+
+                bool I_YZ = (x % (2*unit) ) == 0;
+                bool I_XZ = (y % (2*unit ) )== 0;
+
+                //if(BIX == 10 and BIY == 12 and BIZ == 0 and x==13 and y==6 and z==9)
+               //     printf("face %d %d\n", I_YZ,I_XZ);
+                int x_1,BI_1,GD_1,gx_1,gs_1;
+                int x_2,BI_2,GD_2,gx_2,gs_2;
+                int s_id_1[4], s_id_2[4];
+                auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                if (I_YZ){
+                   
+                 x_1 = z,BI_1 = BIZ, GD_1 = GDZ, gx_1 = global_z,gs_1 = data_size.z;
+                 x_2 = y,BI_2 = BIY, GD_2 = GDY, gx_2 = global_y, gs_2 = data_size.y;
+                 s_id_1[0] = x_size * y_size * id_z[0] + x_size * y + x;
+                 s_id_1[1] = x_size * y_size * id_z[1] + x_size * y + x;
+                 s_id_1[2] = x_size * y_size * id_z[2] + x_size * y + x;
+                 s_id_1[3] = x_size * y_size * id_z[3] + x_size * y + x;
+                 s_id_2[0] = x_size * y_size * z + x_size * id_y[0] + x;
+                 s_id_2[1] = x_size * y_size * z + x_size * id_y[1] + x;
+                 s_id_2[2] = x_size * y_size * z + x_size * id_y[2] + x;
+                 s_id_2[3] = x_size * y_size * z + x_size * id_y[3] + x;
+                 pred = s_data[id_z[1]][id_y[1]][x];
+
+                }
+                else if (I_XZ){
+                    x_1 = z,BI_1 = BIZ, GD_1 = GDZ, gx_1 = global_z,gs_1 = data_size.z;
+                    x_2 = x,BI_2 = BIX, GD_2 = GDX, gx_2 = global_x, gs_2 = data_size.x;
+                    s_id_1[0] = x_size * y_size * id_z[0] + x_size * y + x;
+                    s_id_1[1] = x_size * y_size * id_z[1] + x_size * y + x;
+                    s_id_1[2] = x_size * y_size * id_z[2] + x_size * y + x;
+                    s_id_1[3] = x_size * y_size * id_z[3] + x_size * y + x;
+                    
+                    s_id_2[0] = x_size * y_size * z + x_size * y + id_x[0];
+                    s_id_2[1] = x_size * y_size * z + x_size * y + id_x[1];
+                    s_id_2[2] = x_size * y_size * z + x_size * y + id_x[2];
+                    s_id_2[3] = x_size * y_size * z + x_size * y + id_x[3];
+                    pred = s_data[id_z[1]][y][id_x[1]];
+                    
+                }
+                else{
+                    x_1 = y,BI_1 = BIY, GD_1 = GDY, gx_1 = global_y, gs_1 = data_size.y;
+                    x_2 = x,BI_2 = BIX, GD_2 = GDX, gx_2 = global_x, gs_2 = data_size.x;
+                    s_id_1[0] = x_size * y_size * z + x_size * id_y[0] + x;
+                    s_id_1[1] = x_size * y_size * z + x_size * id_y[1] + x;
+                    s_id_1[2] = x_size * y_size * z + x_size * id_y[2] + x;
+                    s_id_1[3] = x_size * y_size * z + x_size * id_y[3] + x;
+                    s_id_2[0] = x_size * y_size * z + x_size * y + id_x[0];
+                    s_id_2[1] = x_size * y_size * z + x_size * y + id_x[1];
+                    s_id_2[2] = x_size * y_size * z + x_size * y + id_x[2];
+                    s_id_2[3] = x_size * y_size * z + x_size * y + id_x[3];
+                    pred = s_data[z][id_y[1]][id_x[1]];
+                }
+
+                    auto interp_1 = get_interp_order(x_1,BI_1,GD_1,gx_1,gs_1);
+                    auto interp_2 = get_interp_order(x_2,BI_2,GD_2,gx_2,gs_2);
+
+                    int case_num = interp_1 + interp_2 * 5;
+
+
+                    if (interp_1 == 4 && interp_2 == 4) {
+                        pred = (cubic_interpolator(*((T1*)s_data + s_id_1[0]), 
+                        *((T1*)s_data + s_id_1[1]), 
+                        *((T1*)s_data + s_id_1[2]), 
+                        *((T1*)s_data + s_id_1[3])) +
+                         cubic_interpolator(*((T1*)s_data + s_id_2[0]), 
+                        *((T1*)s_data + s_id_2[1]), 
+                        *((T1*)s_data + s_id_2[2]), 
+                        *((T1*)s_data + s_id_2[3]))) / 2;
+                    } else if (interp_1 != 4 && interp_2 == 4) {
+                        pred = cubic_interpolator(*((T1*)s_data + s_id_2[0]), 
+                        *((T1*)s_data + s_id_2[1]), 
+                        *((T1*)s_data + s_id_2[2]), 
+                        *((T1*)s_data + s_id_2[3]));
+                    } else if (interp_1 == 4 && interp_2 != 4) {
+                        pred = cubic_interpolator(*((T1*)s_data + s_id_1[0]), 
+                        *((T1*)s_data + s_id_1[1]), 
+                        *((T1*)s_data + s_id_1[2]), 
+                        *((T1*)s_data + s_id_1[3]));
+                    } else if (interp_1 == 3 && interp_2 == 3) {
+                        pred = (-(*((T1*)s_data + s_id_2[0]))+6*(*((T1*)s_data + s_id_2[1])) + 3*(*((T1*)s_data + s_id_2[2]))) / 8;
+                        pred += (-(*((T1*)s_data + s_id_1[0]))+6*(*((T1*)s_data + s_id_1[1])) + 3*(*((T1*)s_data + s_id_1[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 3 && interp_2 == 2) {
+                        pred = (3*(*((T1*)s_data + s_id_2[1]))+6*(*((T1*)s_data + s_id_2[2])) - (*((T1*)s_data + s_id_2[3]))) / 8;
+                        pred += (-(*((T1*)s_data + s_id_1[0]))+6*(*((T1*)s_data + s_id_1[1])) + 3*(*((T1*)s_data + s_id_1[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 3 && interp_2 < 2) {
+                        pred = (-(*((T1*)s_data + s_id_1[0]))+6*(*((T1*)s_data + s_id_1[1])) + 3*(*((T1*)s_data + s_id_1[2]))) / 8;
+                    } else if (interp_1 == 2 && interp_2 == 3) {
+                        pred = (3*(*((T1*)s_data + s_id_1[1]))+6*(*((T1*)s_data + s_id_1[2])) - (*((T1*)s_data + s_id_1[3]))) / 8;
+                        pred += (-(*((T1*)s_data + s_id_2[0]))+6*(*((T1*)s_data + s_id_2[1])) + 3*(*((T1*)s_data + s_id_2[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 2 && interp_2 == 2) {
+                        pred = (3*(*((T1*)s_data + s_id_1[1]))+6*(*((T1*)s_data + s_id_1[2])) - (*((T1*)s_data + s_id_1[3]))) / 8;
+                        pred += (3*(*((T1*)s_data + s_id_2[1]))+6*(*((T1*)s_data + s_id_2[2])) - (*((T1*)s_data + s_id_2[3]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 2 && interp_2 < 2) {
+                        pred = (3*(*((T1*)s_data + s_id_1[1]))+6*(*((T1*)s_data + s_id_1[2])) - (*((T1*)s_data + s_id_1[3]))) / 8;
+                    } else if (interp_1 <= 1 && interp_2 == 3) {
+                        pred = (-(*((T1*)s_data + s_id_2[0]))+6*(*((T1*)s_data + s_id_2[1])) + 3*(*((T1*)s_data + s_id_2[2]))) / 8;
+                    } else if (interp_1 <= 1 && interp_2 == 2) {
+                        pred = (3*(*((T1*)s_data + s_id_2[1]))+6*(*((T1*)s_data + s_id_2[2])) - (*((T1*)s_data + s_id_2[3]))) / 8;
+                    } else if (interp_1 == 1 && interp_2 == 1) {
+                        pred = ((*((T1*)s_data + s_id_2[1]))+(*((T1*)s_data + s_id_2[2]))) / 2;
+                        pred += ((*((T1*)s_data + s_id_1[1]))+(*((T1*)s_data + s_id_1[2]))) / 2;
+                        pred /= 2;
+                    } else if (interp_1 == 1 && interp_2 < 1) {
+                        
+                        pred = ((*((T1*)s_data + s_id_1[1]))+(*((T1*)s_data + s_id_1[2]))) / 2;
+                    } else if (interp_1 == 0 && interp_2 == 1) {
+                        pred = ((*((T1*)s_data + s_id_2[1]))+(*((T1*)s_data + s_id_2[2]))) / 2;
+                    }
+                    else{
+                        pred = (*((T1*)s_data + s_id_1[1])) + (*((T1*)s_data + s_id_2[1])) - pred;
+                    }
+                    
+            }
+
+            if CONSTEXPR (CUBE) {  //
+                auto interp_z = get_interp_order(z,BIZ,GDZ,global_z,data_size.z);
+                auto interp_y = get_interp_order(y,BIY,GDY,global_y,data_size.y);
+                auto interp_x = get_interp_order(x,BIX,GDX,global_x,data_size.x);
+                
+                #pragma unroll
+                for(int id_itr = 0; id_itr < 4; ++id_itr){
+                 tmp_x[id_itr] = s_data[z][y][id_x[id_itr]]; 
+                }
+                if(interp_z == 4){
+                    #pragma unroll
+                    for(int id_itr = 0; id_itr < 4; ++id_itr){
+                        tmp_z[id_itr] = s_data[id_z[id_itr]][y][x];
+                       }
+                }
+                if(interp_y == 4){
+                    #pragma unroll
+                    for(int id_itr = 0; id_itr < 4; ++id_itr){
+                     tmp_y[id_itr] = s_data[z][id_y[id_itr]][x]; 
+                    }
+                }
+
+
+                T1 pred_z[5], pred_y[5], pred_x[5];
+                pred_x[0] = tmp_x[1];
+                pred_x[1] = cubic_interpolator(tmp_x[0],tmp_x[1],tmp_x[2],tmp_x[3]);
+                pred_x[2] = (-tmp_x[0]+6*tmp_x[1] + 3*tmp_x[2]) / 8;
+                pred_x[3] = (3*tmp_x[1] + 6*tmp_x[2]-tmp_x[3]) / 8;
+                pred_x[4] = (tmp_x[1] + tmp_x[2]) / 2;
+                
+                pred_y[1] = cubic_interpolator(tmp_y[0],tmp_y[1],tmp_y[2],tmp_y[3]);
+
+                
+                pred_z[1] = cubic_interpolator(tmp_z[0],tmp_z[1],tmp_z[2],tmp_z[3]);
+                
+                pred = pred_x[0];
+                pred = (interp_z == 4 && interp_y == 4 && interp_x == 4) ? (pred_x[1] +  pred_y[1] + pred_z[1]) / 3 : pred;
+                
+                pred = (interp_z == 4 && interp_y == 4 && interp_x != 4) ? (pred_z[1] + pred_y[1]) / 2 : pred;
+                pred = (interp_z == 4 && interp_y != 4 && interp_x == 4) ? (pred_z[1] + pred_x[1]) / 2 : pred;
+                pred = (interp_z != 4 && interp_y == 4 && interp_x == 4) ? (pred_y[1] + pred_x[1]) / 2 : pred;
+                
+                pred = (interp_z == 4 && interp_y != 4 && interp_x != 4) ? pred_z[1]: pred;
+                pred = (interp_z != 4 && interp_y == 4 && interp_x != 4) ? pred_y[1]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 4) ? pred_x[1]: pred;
+
+
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 3) ? pred_x[2]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 2) ? pred_x[3]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 1) ? pred_x[4]: pred;
+                // pred = (interp_z != 4 && interp_y != 4 && interp_x == 0) ? pred_x[0]: pred;
+            }
+
+
+                
+            
+            
+
+            if CONSTEXPR (WORKFLOW == SPLINE3_COMPR) {
+                
+                auto          err = s_data[z][y][x] - pred;
+                decltype(err) code;
+                // TODO unsafe, did not deal with the out-of-cap case
+                {
+                    code = fabs(err) * eb_r + 1;
+                    code = err < 0 ? -code : code;
+                    code = int(code / 2) + radius;
+                }
+                s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
+              
+                s_data[z][y][x]  = pred + (code - radius) * ebx2;
+                
+
+            }
+            else {  // TODO == DECOMPRESSS and static_assert
+
+                
+                auto code       = s_ectrl[z][y][x];
+                s_data[z][y][x] = pred + (code - radius) * ebx2;
+            }
+        }
+    };
+    // -------------------------------------------------------------------------------- //
+
+    if CONSTEXPR (COARSEN) {
+        constexpr auto TOTAL = NUM_ELE;
+        //if( BLOCK_DIMX *BLOCK_DIMY<= LINEAR_BLOCK_SIZE){
+            for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                auto [x,y,z]    = xyzmap(_tix, unit, AnchorBlockSizeX);
+                run(x, y, z);
+            }
+        
+    }
+    else {
+        if(TIX<NUM_ELE){
+            auto [x,y,z]    = xyzmap(TIX, unit, AnchorBlockSizeX);
+            run(x, y, z);
+        }
+    }
+    __syncthreads();
+}
+}  // namespace
+
+template <typename T, int SPLINE_DIM = 3,
+int PROFILE_BLOCK_SIZE_X = 4,
+int PROFILE_BLOCK_SIZE_Y = 4,
+int PROFILE_BLOCK_SIZE_Z = 4,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+int  LINEAR_BLOCK_SIZE>
+__device__ void cusz::device_api::auto_tuning(volatile T s_data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z]       
+    [PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X],  volatile T local_errs[2], DIM3  data_size,  T * errs){
+ 
+    if(TIX < 2)
+        local_errs[TIX] = 0;
+    __syncthreads(); 
+
+    auto local_idx = TIX % 2;
+    auto temp = TIX / 2;
+    
+
+    auto block_idx_x =  temp % PROFILE_NUM_BLOCK_X;
+    auto block_idx_y = ( temp / PROFILE_NUM_BLOCK_X) % PROFILE_NUM_BLOCK_Y;
+    auto block_idx_z = ( ( temp  / PROFILE_NUM_BLOCK_X) / PROFILE_NUM_BLOCK_Y) % PROFILE_NUM_BLOCK_Z;
+    auto dir = ( ( temp  / PROFILE_NUM_BLOCK_X) / PROFILE_NUM_BLOCK_Y) / PROFILE_NUM_BLOCK_Z;
+
+
+
+    bool predicate = dir < 2;
+
+    if(predicate){
+        auto x = PROFILE_BLOCK_SIZE_X * block_idx_x + 1 + local_idx;
+        auto y = PROFILE_BLOCK_SIZE_Y * block_idx_y + 1 + local_idx;
+        auto z = PROFILE_BLOCK_SIZE_Z * block_idx_z + 1 + local_idx;
+        T pred = 0;
+        switch(dir){
+            case 0:
+                pred = (s_data[z - 1][y][x] + s_data[z + 1][y][x]) / 2;
+                break;
+            case 1:
+                pred = (s_data[z][y][x - 1] + s_data[z][y][x + 1]) / 2;
+                break;
+            default:
+            break;
+        }
+        
+        T abs_error = fabs(pred - s_data[z][y][x]);
+        atomicAdd(const_cast<T*>(local_errs) + dir, abs_error);
+    } 
+    __syncthreads(); 
+    if(TIX < 2)
+        errs[TIX]=local_errs[TIX];
+    __syncthreads(); 
+       
+}
+
+template <typename T,
+int SPLINE_DIM = 3,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4, 
+int  LINEAR_BLOCK_SIZE>
+__device__ void cusz::device_api::auto_tuning_2(volatile T s_data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z], volatile T s_nx[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T s_ny[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T s_nz[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4],  volatile T local_errs[6], DIM3  data_size,  T * errs){
+ 
+    if(TIX<6)
+        local_errs[TIX]=0;
+    __syncthreads(); 
+
+    auto point_idx = TIX % (PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z);
+    auto c = TIX / (PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z);
+
+
+    bool predicate = c < 6;
+    if(predicate){
+
+        T pred=0;
+
+        //auto unit = 1;
+        switch(c){
+                case 0:
+                    pred = (-s_nz[point_idx][0] + 9 * s_nz[point_idx][1] + 9 * s_nz[point_idx][2] - s_nz[point_idx][3]) / 16;
+                    break;
+
+                case 1:
+                    pred = (-3 * s_nz[point_idx][0] + 23 * s_nz[point_idx][1] + 23* s_nz[point_idx][2] - 3 * s_nz[point_idx][3]) / 40;
+                    break;
+                case 2:
+                    pred = (-s_ny[point_idx][0] + 9 * s_ny[point_idx][1] + 9 * s_ny[point_idx][2] - s_ny[point_idx][3]) / 16;
+                    break;
+                case 3:
+                    pred = (-3 * s_ny[point_idx][0] + 23 * s_ny[point_idx][1] + 23 * s_ny[point_idx][2] - 3 * s_ny[point_idx][3]) / 40;
+                    break;
+
+                case 4:
+                    pred = (-s_nx[point_idx][0] + 9 * s_nx[point_idx][1] + 9 * s_nx[point_idx][2] - s_nx[point_idx][3]) / 16;
+                    break;
+                case 5:
+                    pred = (-3 * s_nx[point_idx][0] + 23 * s_nx[point_idx][1] + 23 * s_nx[point_idx][2] - 3 * s_nx[point_idx][3]) / 40;
+                    break;
+                default:
+                break;
+            }
+        T abs_error=fabs(pred-s_data[point_idx]);
+        atomicAdd(const_cast<T*>(local_errs) + c, abs_error);
+    } 
+    __syncthreads(); 
+    if(TIX<6)
+        errs[TIX]=local_errs[TIX];
+    __syncthreads(); 
+       
+}
+
+
+__device__ std::tuple<int, int, int> xyzmap_line(int _tix, const int UNIT, const int BLOCKSIZE) {
+    auto N = BLOCKSIZE / (UNIT * 2);
+    auto L = N * (N+1) * (N+1); 
+    auto Q = (N+1) * (N+1); 
+    auto group = _tix / L ;
+    auto m = _tix % L ;
+    auto i = m / Q;
+    auto j = (m % Q) / (N+1);
+    auto k = (m % Q) % (N+1);
+    if(group==0)
+        return std::make_tuple(2 * UNIT * i + UNIT, 2 * UNIT * j, 2 * UNIT * k);
+    else if (group==1)
+        return std::make_tuple(2 * UNIT * k, 2 * UNIT * i + UNIT, 2 * UNIT * j);
+    else
+        return std::make_tuple(2 * UNIT * j, 2 * UNIT * k, 2 * UNIT * i + UNIT);
+}
+
+__device__ std::tuple<int, int, int> xyzmap_face(int _tix, const int UNIT, const int BLOCKSIZE) {
+    auto N = BLOCKSIZE / (UNIT * 2);
+    auto L = N * N * (N+1);
+    auto Q = N * N; 
+    auto group = _tix / L ;
+    auto m = _tix % L ;
+    auto i = m / Q;
+    auto j = (m % Q) / N;
+    auto k = (m % Q) % N;
+    if(group==0)
+        return std::make_tuple(2 * UNIT * i, 2 * UNIT * j + UNIT, 2 * UNIT * k + UNIT);
+    else if (group==1)
+        return std::make_tuple(2 * UNIT * k + UNIT, 2 * UNIT * i, 2 * UNIT * j + UNIT);
+    else
+        return std::make_tuple(2 * UNIT * j + UNIT, 2 * UNIT * k + UNIT, 2 * UNIT * i);
+}
+
+
+__device__ std::tuple<int, int, int> xyzmap_cube(int _tix, const int UNIT, const int BLOCKSIZE) {
+    auto N = BLOCKSIZE / (UNIT * 2);
+    auto Q = N * N; 
+    auto i = _tix / Q;
+    auto j = (_tix % Q) / N;
+    auto k = (_tix % Q) % N;
+    return std::make_tuple(2 * UNIT * i + UNIT, 2 * UNIT * j + UNIT, 2 * UNIT * k + UNIT);
+}
+
+
+
+template <typename T1, typename T2, typename FP, int SPLINE_DIM, int AnchorBlockSizeX, int AnchorBlockSizeY, int AnchorBlockSizeZ, int numAnchorBlockX, int numAnchorBlockY, int numAnchorBlockZ, int LINEAR_BLOCK_SIZE, bool WORKFLOW, bool PROBE_PRED_ERROR>
+__device__ void cusz::device_api::spline_layout_interpolate(
+    volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    DIM3    data_size,
+    FP          eb_r,
+    FP          ebx2,
+    int         radius,
+    INTERPOLATION_PARAMS intp_param
+    )
+{
+    auto xblue = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+    auto yblue = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+    auto zblue = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+
+    auto xblue_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+    auto yblue_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy ); };
+    auto zblue_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+
+    auto xyellow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+    auto yyellow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
+    auto zyellow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+
+    auto xyellow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+    auto yyellow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
+    auto zyellow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2); };
+
+
+    auto xhollow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
+    auto yhollow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy); };
+    auto zhollow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+
+    auto xhollow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
+    auto yhollow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+    auto zhollow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz *2); };
+
+    auto nan_cubic_interp = [] __device__ (T1 a, T1 b, T1 c, T1 d) -> T1{
+        return (-a+9*b+9*c-d) / 16;
+    };
+
+    auto nat_cubic_interp = [] __device__ (T1 a, T1 b, T1 c, T1 d) -> T1{
+        return (-3*a+23*b+23*c-3*d) / 40;
+    };
+
+    constexpr auto COARSEN          = true;
+    constexpr auto NO_COARSEN       = false;
+    constexpr auto BORDER_INCLUSIVE = true;
+    constexpr auto BORDER_EXCLUSIVE = false;
+
+    
+    FP cur_ebx2=ebx2,cur_eb_r=eb_r;
+
+
+    auto calc_eb = [&](auto unit) {
+        cur_ebx2=ebx2,cur_eb_r=eb_r;
+        int temp=1;
+        while(temp<unit){
+            temp*=2;
+            cur_eb_r *= intp_param.alpha;
+            cur_ebx2 /= intp_param.alpha;
+
+        }
+        if(cur_ebx2 < ebx2 / intp_param.beta){
+            cur_ebx2 = ebx2 / intp_param.beta;
+            cur_eb_r = eb_r * intp_param.beta;
+
+        }
+    };
+    
+    int max_unit = ((AnchorBlockSizeX >= AnchorBlockSizeY) ? AnchorBlockSizeX : AnchorBlockSizeY);
+    max_unit = ((max_unit >= AnchorBlockSizeZ) ? max_unit : AnchorBlockSizeZ);
+    max_unit /= 2;
+    int unit_x = AnchorBlockSizeX, unit_y = AnchorBlockSizeY, unit_z = AnchorBlockSizeZ;
+    
+    #pragma unroll
+    for(int unit = max_unit; unit >= 1; unit /= 2){
+        calc_eb(unit);
+        if(intp_param.use_md[3]){
+            int N_x = AnchorBlockSizeX / (unit * 2);
+            int N_y = AnchorBlockSizeY / (unit * 2);
+            int N_z = AnchorBlockSizeZ / (unit * 2);
+            int N_line = N_x * (N_y + 1) * (N_z + 1) + (N_x + 1) * N_y * (N_z + 1) + (N_x + 1) * (N_y + 1) * N_z;
+            int N_face = N_x * N_y * (N_z + 1) + N_x * (N_y + 1) * N_z + (N_x + 1) * N_y * N_z; 
+            int N_cube = N_x * N_y * N_z;
+            if(intp_param.use_natural[3]==0){
+                interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line), true, false, false, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_line, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp, N_line);
+                interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face), false, true, false, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_face, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp, N_face);
+                interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube), false, false, true, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_cube, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp, N_cube);
+            }
+            else{
+                interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line), true, false, false, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_line, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp, N_line);
+
+                interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face), false, true, false, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_face, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp, N_face);
+
+                interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube), false, false, true, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_cube, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp, N_cube);
+            }
+        }
+        else{
+            if(intp_param.reverse[3]){
+                interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse), false, false, true, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3], numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                unit_x /= 2;
+                interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse), false, true, false, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y,numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                unit_y /= 2;
+                interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse), true, false, false, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xblue_reverse, yblue_reverse, zblue_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                unit_z /= 2;
+            }
+            else{
+                interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue), decltype(yblue), decltype(zblue), true, false, false, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xblue, yblue, zblue, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                unit_z /= 2;
+                interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow), decltype(yyellow), decltype(zyellow), false, true, false, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyellow, yyellow, zyellow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y, numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                unit_y /= 2;
+                interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow), decltype(yhollow), decltype(zhollow), false, false, true, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xhollow, yhollow, zhollow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3], numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                unit_x /= 2;
+            }
+        }
+    }
+
+}
+
+/********************************************************************************
+ * host API/kernel
+ ********************************************************************************/
+template <typename TITER, int SPLINE_DIM = 3,
+int PROFILE_BLOCK_SIZE_X = 4,
+int PROFILE_BLOCK_SIZE_Y = 4,
+int PROFILE_BLOCK_SIZE_Z = 4,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4, 
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__global__ void cusz::c_spline_profiling_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    TITER errors)
+{
+    // compile time variables
+    using T = typename std::remove_pointer<TITER>::type;
+ 
+
+    {
+        __shared__ struct {
+            T data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z][PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X];
+            T local_errs[2];
+           // T global_errs[6];
+        } shmem;
+        c_reset_scratch_profiling_data<T, SPLINE_DIM, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem.data, 0.0);
+        
+        global2shmem_profiling_data<T, T, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data);
+
+        cusz::device_api::auto_tuning<T, SPLINE_DIM, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem.data, shmem.local_errs, data_size, errors);
+
+    }
+}
+
+template <typename TITER, int SPLINE_DIM = 3, int PROFILE_NUM_BLOCK_X = 4, int PROFILE_NUM_BLOCK_Y = 4, int PROFILE_NUM_BLOCK_Z = 4, int  LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__global__ void cusz::c_spline_profiling_data_2(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    TITER errors)
+{
+    // compile time variables
+    using T = typename std::remove_pointer<TITER>::type;
+ 
+
+    {
+        __shared__ struct {
+            T data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z];
+            T neighbor_x [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+            T neighbor_y [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+            T neighbor_z [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+            T local_errs[6];
+           // T global_errs[6];
+        } shmem;
+
+
+        c_reset_scratch_profiling_data_2<T, SPLINE_DIM, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z,0.0);
+        global2shmem_profiling_data_2<T, T, SPLINE_DIM, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(data, data_size, data_leap,shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z);
+
+        if (TIX < 6 and BIX==0 and BIY==0 and BIZ==0) errors[TIX] = 0.0;//risky
+
+        cusz::device_api::auto_tuning_2<T, SPLINE_DIM, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(
+            shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z, shmem.local_errs, data_size, errors);
+
+        
+    }
+}
+
+
+__forceinline__ __device__ void pre_compute(DIM3 data_size, volatile STRIDE3 grid_leaps[5], volatile size_t prefix_nums[5]){
+    if(TIX==0){
+        auto d_size = data_size;
+        
+        int level = 0;
+        while(level <= 4){
+            grid_leaps[level].x = 1;
+            grid_leaps[level].y = d_size.x;
+            grid_leaps[level].z = d_size.x * d_size.y;
+            if(level < 4){
+                d_size.x = (d_size.x + 1) >> 1;
+                d_size.y = (d_size.y + 1) >> 1;
+                d_size.z = (d_size.z + 1) >> 1;
+                prefix_nums[level] = d_size.x * d_size.y * d_size.z;
+            }
+            level++;
+        }   
+        prefix_nums[4] = 0;
+    }
+    __syncthreads(); 
+}
+
+template <typename TITER, typename EITER, typename FP,  int SPLINE_DIM, int AnchorBlockSizeX, int AnchorBlockSizeY, int AnchorBlockSizeZ, int numAnchorBlockX, 
+int numAnchorBlockY, int numAnchorBlockZ, int LINEAR_BLOCK_SIZE, typename CompactVal, typename CompactIdx, typename CompactNum>
+__global__ void cusz::c_spline_infprecis_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    EITER   ectrl,
+    DIM3    ectrl_size,
+    STRIDE3 ectrl_leap,
+    TITER   anchor,
+    STRIDE3 anchor_leap,
+    CompactVal compact_val,
+    CompactIdx compact_idx,
+    CompactNum compact_num,
+    FP      eb_r,
+    FP      ebx2,
+    int     radius,
+    INTERPOLATION_PARAMS intp_param//,
+    )
+{
+    // compile time variables
+    using T = typename std::remove_pointer<TITER>::type;
+    using E = typename std::remove_pointer<EITER>::type;
+
+    {
+        __shared__ struct {
+            T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+             [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+             [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+            T ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+            STRIDE3 grid_leaps[5];
+            size_t prefix_nums[5];
+        } shmem;
+
+   
+        pre_compute(ectrl_size,shmem.grid_leaps,shmem.prefix_nums);
+
+        c_reset_scratch_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.data, shmem.ectrl, radius);
+
+        global2shmem_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data);
+
+        c_gather_anchor<T, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ>(data, data_size, data_leap, anchor, anchor_leap);
+        cusz::device_api::spline_layout_interpolate<T, T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_COMPR, false>(
+            shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
+
+        shmem2global_data_with_compaction<T, E,  SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY,  numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.ectrl, ectrl, ectrl_size, ectrl_leap, radius, shmem.grid_leaps,shmem.prefix_nums, compact_val, compact_idx, compact_num);
+    }
+}
+
+template <
+    typename EITER,
+    typename TITER,
+    typename FP, 
+    int SPLINE_DIM, int AnchorBlockSizeX,
+    int AnchorBlockSizeY, int AnchorBlockSizeZ,
+    int numAnchorBlockX,  // Number of Anchor blocks along X
+    int numAnchorBlockY,  // Number of Anchor blocks along Y
+    int numAnchorBlockZ,  // Number of Anchor blocks along Z
+    int LINEAR_BLOCK_SIZE>
+__global__ void cusz::x_spline_infprecis_data(
+    EITER   ectrl,        // input 1
+    DIM3    ectrl_size,   //
+    STRIDE3 ectrl_leap,   //
+    TITER   anchor,       // input 2
+    DIM3    anchor_size,  //
+    STRIDE3 anchor_leap,  //
+    TITER   data,         // output
+    DIM3    data_size,    //
+    STRIDE3 data_leap,    //
+    TITER outlier_tmp,
+    FP      eb_r,
+    FP      ebx2,
+    int     radius,
+    INTERPOLATION_PARAMS intp_param)
+{
+    // compile time variables
+    using E = typename std::remove_pointer<EITER>::type;
+    using T = typename std::remove_pointer<TITER>::type;
+
+    __shared__ struct {
+        T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+        T ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+        STRIDE3 grid_leaps[5];
+        size_t prefix_nums[5];
+    } shmem;
+
+    pre_compute(ectrl_size,shmem.grid_leaps,shmem.prefix_nums);
+
+    x_reset_scratch_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.data, shmem.ectrl, anchor, anchor_size, anchor_leap);
+    global2shmem_fuse<T, E, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(ectrl, ectrl_size, ectrl_leap, outlier_tmp, shmem.ectrl, shmem.grid_leaps,shmem.prefix_nums);
+
+    cusz::device_api::spline_layout_interpolate<T, T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_DECOMPR, false>(
+        shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
+    shmem2global_data<T, T,  AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.data, data, data_size, data_leap);
+}
+
+
+template <typename TITER>
+__global__ void cusz::reset_errors(TITER errors)
+{
+    if(TIX<18)
+        errors[TIX]=0;
+}
+
+template <typename T, int SPLINE_DIM, int nLevel>
+__forceinline__ __device__ void pre_compute_att(DIM3 sam_starts, DIM3 sam_bgs, DIM3 sam_strides, DIM3 &global_starts, INTERPOLATION_PARAMS &intp_param, uint8_t &level, uint8_t &unit, volatile T err[6], bool workflow);
+
+template <typename T>
+__forceinline__ __device__ void pre_compute_att<T, 2, 4>(DIM3 sam_starts, DIM3 sam_bgs, DIM3 sam_strides, DIM3 &global_starts, INTERPOLATION_PARAMS &intp_param, uint8_t &level, uint8_t &unit, volatile T err[6], bool workflow){
+
+    if(TIX < 6) err[TIX] = 0.0;
+
+    auto grid_idx_x = BIX % sam_bgs.x;
+    auto grid_idx_y = (BIX / sam_bgs.x) % sam_bgs.y;
+    auto grid_idx_z = (BIX / sam_bgs.x) / sam_bgs.y;
+    global_starts.x = sam_starts.x + grid_idx_x * sam_strides.x;
+    global_starts.y = sam_starts.y + grid_idx_y * sam_strides.y;
+    global_starts.z = sam_starts.z + grid_idx_z * sam_strides.z;
+    
+    if(workflow == SPLINE3_PRED_ATT){
+        bool use_natural = false, use_md = false, reverse = false;
+        if (BIY == 0){
+            level = 2;
+        }
+        else if (BIY < 3){
+            level = 1;
+            use_natural = (BIY == 2);
+        }
+        else{
+            level = 0;
+            use_natural = BIY > 5;
+            use_md = (BIY == 5 or BIY == 8);
+            reverse = BIY % 3;
+        }       
+        intp_param.use_natural[level] = use_natural;
+        intp_param.use_md[level] = use_md;
+        intp_param.reverse[level] = reverse;
+    }
+    else{
+        level = 0;
+        if(BIY == 0){
+            intp_param.alpha = 1.0;
+            intp_param.beta = 2.0;
+        }
+        else if (BIY == 1){
+            intp_param.alpha = 1.25;
+            intp_param.beta = 2.0;
+        }
+        else{
+            intp_param.alpha = 1.5 + 0.25 * ((BIY - 2) / 3);
+            intp_param.beta = 2.0 + ((BIY - 2) % 3);
+        }
+    }
+    unit = 1 << level;
+    __syncthreads();
+}
+
+template <typename T1, typename T2, int SPLINE_DIM = 2, int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8, int numAnchorBlockX = 4, int numAnchorBlockY = 1,  int numAnchorBlockZ = 1, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_data_att(T1* data, DIM3 data_size, STRIDE3 data_leap,   volatile T2 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+[AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+[AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)], DIM3 global_starts, uint8_t unit)
+{
+    constexpr auto TOTAL = (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) *
+    (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) * 
+    (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+        auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto gx  = (x + global_starts.x);
+        auto gy  = (y + global_starts.y);
+        auto gz  = (z + global_starts.z);
+        auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+
+        if (gx < data_size.x and gy < data_size.y and gz < data_size.z  ) s_data[z][y][x] = data[gid];
+    }
+    __syncthreads();
+}
+
+
+template <
+    typename T,
+    typename FP,
+    int SPLINE_DIM, int AnchorBlockSizeX,
+    int AnchorBlockSizeY, int AnchorBlockSizeZ,
+    int numAnchorBlockX,
+    int numAnchorBlockY,
+    int numAnchorBlockZ,
+    typename LAMBDAX,
+    typename LAMBDAY,
+    typename LAMBDAZ,
+    bool BLUE,
+    bool YELLOW,
+    bool HOLLOW,
+    bool COARSEN,
+    int  LINEAR_BLOCK_SIZE,
+    bool BORDER_INCLUSIVE,
+    bool WORKFLOW
+    >
+__forceinline__ __device__ void interpolate_stage_att(
+    volatile T s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)][AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)][AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    DIM3    data_size,
+     DIM3    global_starts,
+    LAMBDAX     xmap,
+    LAMBDAY     ymap,
+    LAMBDAZ     zmap,
+    int         unit,
+    FP eb_r,
+    FP ebx2,
+    bool interpolator,
+    volatile T* error,
+    int  BLOCK_DIMX,
+    int  BLOCK_DIMY,
+    int  BLOCK_DIMZ)
+{
+    // static_assert(BLOCK_DIMX * BLOCK_DIMY * (COARSEN ? 1 : BLOCK_DIMZ) <= BLOCK_DIM_SIZE, "block oversized");
+    static_assert((BLUE or YELLOW or HOLLOW) == true, "must be one hot");
+    static_assert((BLUE and YELLOW) == false, "must be only one hot (1)");
+    static_assert((BLUE and YELLOW) == false, "must be only one hot (2)");
+    static_assert((YELLOW and HOLLOW) == false, "must be only one hot (3)");
+    //DIM3 global_starts (global_starts_v.x,global_starts_v.y, global_starts_v.z);
+    auto run = [&](auto x, auto y, auto z) {
+        if (xyz_predicate_att<SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, BORDER_INCLUSIVE>(x, y, z,data_size, global_starts)) {
+            T pred = 0;
+
+            auto global_x=global_starts.x+x, global_y=global_starts.y+y, global_z=global_starts.z+z;
+            auto input_x = x;
+            auto input_BI = BIX;
+            auto input_GD = GDX;
+            auto input_gx = global_x;
+            auto input_gs = data_size.x;
+            auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+            auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+            auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+            auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+            int global_start_ = global_starts.x;
+            int p1 = -1, p2 = 9, p3 = 9, p4 = -1, p5 = 16;
+            if(interpolator==0){
+               p1 = -3, p2 = 23, p3 = 23, p4 = -3, p5 = 40;
+           }
+           if CONSTEXPR (BLUE){
+               input_x = z;
+               input_BI = BIZ;
+               input_GD = GDZ;
+               input_gx = global_z;
+               input_gs = data_size.z;
+               global_start_ = global_starts.z;
+               right_bound = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+           }
+           if CONSTEXPR (YELLOW){
+               input_x = y;
+               input_BI = BIY;
+               input_GD = GDY;
+               input_gx = global_y;
+               input_gs = data_size.y;
+               global_start_ = global_starts.y;
+               right_bound = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+           }
+           
+           int id_[4], s_id[4];
+           id_[0] =  input_x - 3 * unit;
+           id_[0] =  id_[0] >= 0 ? id_[0] : 0;
+           
+           id_[1] = input_x - unit;
+           id_[1] = id_[1] >= 0 ? id_[1] : 0;
+           
+           id_[2] = input_x + unit;
+           id_[2] = id_[2] < right_bound ? id_[2] : 0;
+           
+           id_[3] = input_x + 3 * unit;
+           id_[3] = id_[3] < right_bound ? id_[3] : 0;
+           
+           s_id[0] = x_size * y_size * z + x_size * y + id_[0];
+           s_id[1] = x_size * y_size * z + x_size * y + id_[1];
+           s_id[2] = x_size * y_size * z + x_size * y + id_[2];
+           s_id[3] = x_size * y_size * z + x_size * y + id_[3];
+           if CONSTEXPR (BLUE){
+            s_id[0] = x_size * y_size * id_[0] + x_size * y + x;
+            s_id[1] = x_size * y_size * id_[1] + x_size * y + x;
+            s_id[2] = x_size * y_size * id_[2] + x_size * y + x;
+            s_id[3] = x_size * y_size * id_[3] + x_size * y + x;
+           }
+           if CONSTEXPR (YELLOW){
+            s_id[0] = x_size * y_size * z + x_size * id_[0] + x;
+            s_id[1] = x_size * y_size * z + x_size * id_[1] + x;
+            s_id[2] = x_size * y_size * z + x_size * id_[2] + x;
+            s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
+           }
+           
+           T tmp_[4];
+           
+           bool case1 = (global_start_ + AnchorBlockSizeX * numAnchorBlockX < input_gs);
+           bool case2 = (input_x >= 3 * unit);
+           bool case3 = (input_x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX);
+           bool case4 = (input_gx + 3 * unit < input_gs);
+           bool case5 = (input_gx + unit < input_gs);
+           
+           
+           // 预加载 shared memory 数据到寄存器
+           T tmp0 = *((T*)s_data + s_id[0]); 
+           T tmp1 = *((T*)s_data + s_id[1]); 
+           T tmp2 = *((T*)s_data + s_id[2]); 
+           T tmp3 = *((T*)s_data + s_id[3]); 
+           
+           // 初始预测值
+           pred = tmp1;
+           
+           // 计算不同 case 对应的 pred
+           if ((case1 && !case2 && !case3) || (!case1 && !case2 && !(case3 && case4) && case5)) {
+               pred = (tmp1 + tmp2) / 2;
+           }
+           else if ((case1 && !case2 && case3) || (!case1 && !case2 && case3 && case4)) {
+               pred = (3 * tmp1 + 6 * tmp2 - tmp3) / 8;
+           }
+           else if ((case1 && case2 && !case3) || (!case1 && case2 && !(case3 && case4) && case5)) {
+               pred = (-tmp0 + 6 * tmp1 + 3 * tmp2) / 8;
+           }
+           else if ((case1 && case2 && case3) || (!case1 && case2 && case3 && case4)) {
+               pred = (p1 * tmp0 + p2 * tmp1 + p3 * tmp2 + p4 * tmp3) / p5;
+           }
+
+             if CONSTEXPR (WORKFLOW == SPLINE3_AB_ATT) {
+                
+                auto          err = s_data[z][y][x] - pred;
+                decltype(err) code;
+                // TODO unsafe, did not deal with the out-of-cap case
+                {
+                    code = fabs(err) * eb_r + 1;
+                    code = err < 0 ? -code : code;
+                    code = int(code / 2) ;
+                }
+                
+                s_data[z][y][x]  = pred + code * ebx2;
+                atomicAdd(const_cast<T*>(error),code!=0);
+                
+
+            }
+            else{
+                atomicAdd(const_cast<T*>(error),fabs(s_data[z][y][x]-pred));
+            }
+        }
+    };
+    // -------------------------------------------------------------------------------- //
+
+    if CONSTEXPR (COARSEN) {
+        constexpr auto TOTAL = BLOCK_DIMX * BLOCK_DIMY * BLOCK_DIMZ;
+        //if( BLOCK_DIMX *BLOCK_DIMY<= LINEAR_BLOCK_SIZE){
+            for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                auto itix = (_tix % BLOCK_DIMX);
+                auto itiy = (_tix / BLOCK_DIMX) % BLOCK_DIMY;
+                auto itiz = (_tix / BLOCK_DIMX) / BLOCK_DIMY;
+                auto x    = xmap(itix, unit);
+                auto y    = ymap(itiy, unit);
+                auto z    = zmap(itiz, unit);
+                
+                run(x, y, z);
+            }
+    }
+    else {
+        auto itix = (TIX % BLOCK_DIMX);
+        auto itiy = (TIX / BLOCK_DIMX) % BLOCK_DIMY;
+        auto itiz = (TIX / BLOCK_DIMX) / BLOCK_DIMY;
+        auto x    = xmap(itix, unit);
+        auto y    = ymap(itiy, unit);
+        auto z    = zmap(itiz, unit);
+        run(x, y, z);
+    }
+    __syncthreads();
+}
+
+template <
+    typename T,
+    typename FP,
+    int SPLINE_DIM, int AnchorBlockSizeX,
+    int AnchorBlockSizeY, int AnchorBlockSizeZ,
+    int numAnchorBlockX,
+    int numAnchorBlockY,
+    int numAnchorBlockZ,
+    typename LAMBDA,
+    bool LINE,
+    bool FACE,
+    bool CUBE,
+    int  LINEAR_BLOCK_SIZE,
+    bool COARSEN,
+    bool BORDER_INCLUSIVE,
+    bool WORKFLOW,
+    typename INTERP>
+__forceinline__ __device__ void interpolate_stage_md_att(
+    volatile T s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)][AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)][AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    DIM3    data_size,
+    DIM3    global_starts,
+    LAMBDA xyzmap,
+    int         unit,
+    FP eb_r,
+    FP ebx2,
+    INTERP cubic_interpolator,
+    volatile T* error,
+    int NUM_ELE)
+{
+    // static_assert(COARSEN or (NUM_ELE <= BLOCK_DIM_SIZE), "block oversized");
+    static_assert((LINE or FACE or CUBE) == true, "must be one hot");
+    static_assert((LINE and FACE) == false, "must be only one hot (1)");
+    static_assert((LINE and CUBE) == false, "must be only one hot (2)");
+    static_assert((FACE and CUBE) == false, "must be only one hot (3)");
+    //DIM3 global_starts (global_starts_v.x,global_starts_v.y, global_starts_v.z);
+    auto run = [&](auto x, auto y, auto z) {
+
+        
+
+        if (xyz_predicate_att<SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, BORDER_INCLUSIVE>(x, y, z, data_size, global_starts)) {
+            T pred = 0;
+
+            auto global_x=global_starts.x+x, global_y=global_starts.y+y, global_z=global_starts.z+z;
+           T tmp_z[4], tmp_y[4], tmp_x[4];
+           int id_z[4], id_y[4], id_x[4];
+           id_z[0] = (z - 3 * unit >= 0) ? z - 3 * unit : 0;
+           id_z[1] = (z - unit >= 0) ? z - unit : 0;
+           id_z[2] = (z + unit <=  AnchorBlockSizeZ * numAnchorBlockZ) ? z + unit : 0;
+           id_z[3] = (z + 3 * unit <=  AnchorBlockSizeZ * numAnchorBlockZ) ? z + 3 * unit : 0;
+           
+           id_y[0] = (y - 3 * unit >= 0) ? y - 3 * unit : 0;
+           id_y[1] = (y - unit >= 0) ? y - unit : 0;
+           id_y[2] = (y + unit <= AnchorBlockSizeY * numAnchorBlockY) ? y + unit : 0;
+           id_y[3] = (y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY) ? y + 3 * unit : 0;
+           
+           id_x[0] = (x - 3 * unit >= 0) ? x - 3 * unit : 0;
+           id_x[1] = (x - unit >= 0) ? x - unit : 0;
+           id_x[2] = (x + unit <= AnchorBlockSizeX * numAnchorBlockX) ? x + unit : 0;
+           id_x[3] = (x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX) ? x + 3 * unit : 0;
+           
+            if CONSTEXPR (LINE) {
+                bool I_Y = (y % (2*unit) )> 0; 
+                bool I_Z = (z % (2*unit) )> 0; 
+
+                pred = 0;
+                auto input_x = x;
+                auto input_BI = BIX;
+                auto input_GD = GDX;
+                auto input_gx = global_x;
+                auto input_gs = data_size.x;
+                auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                int global_start_ = global_starts.x;
+                if (I_Z){
+                    input_x = z;
+                    input_BI = BIZ;
+                    input_GD = GDZ;
+                    input_gx = global_z;
+                    input_gs = data_size.z;
+                    global_start_ = global_starts.z;
+                    right_bound = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                }
+                else if (I_Y){
+                    input_x = y;
+                    input_BI = BIY;
+                    input_GD = GDY;
+                    input_gx = global_y;
+                    input_gs = data_size.y;
+                    global_start_ = global_starts.y;
+                    right_bound = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                }
+                
+                int id_[4], s_id[4];
+                id_[0] =  input_x - 3 * unit;
+                id_[0] =  id_[0] >= 0 ? id_[0] : 0;
+            
+                id_[1] = input_x - unit;
+                id_[1] = id_[1] >= 0 ? id_[1] : 0;
+            
+                id_[2] = input_x + unit;
+                id_[2] = id_[2] < right_bound ? id_[2] : 0;
+                
+                id_[3] = input_x + 3 * unit;
+                id_[3] = id_[3] < right_bound ? id_[3] : 0;
+                
+                s_id[0] = x_size * y_size * z + x_size * y + id_[0];
+                s_id[1] = x_size * y_size * z + x_size * y + id_[1];
+                s_id[2] = x_size * y_size * z + x_size * y + id_[2];
+                s_id[3] = x_size * y_size * z + x_size * y + id_[3];
+                if (I_Z){
+                    s_id[0] = x_size * y_size * id_[0] + x_size * y + x;
+                    s_id[1] = x_size * y_size * id_[1] + x_size * y + x;
+                    s_id[2] = x_size * y_size * id_[2] + x_size * y + x;
+                    s_id[3] = x_size * y_size * id_[3] + x_size * y + x;
+                }
+                else if (I_Y){
+                    s_id[0] = x_size * y_size * z + x_size * id_[0] + x;
+                    s_id[1] = x_size * y_size * z + x_size * id_[1] + x;
+                    s_id[2] = x_size * y_size * z + x_size * id_[2] + x;
+                    s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
+                }
+
+                T tmp_[4];
+            
+                bool case1 = (global_start_ + AnchorBlockSizeX * numAnchorBlockX < input_gs);
+                bool case2 = (input_x >= 3 * unit);
+                bool case3 = (input_x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX);
+                bool case4 = (input_gx + 3 * unit < input_gs);
+                bool case5 = (input_gx + unit < input_gs);
+                
+                
+                // 预加载 shared memory 数据到寄存器
+                T tmp0 = *((T*)s_data + s_id[0]); 
+                T tmp1 = *((T*)s_data + s_id[1]); 
+                T tmp2 = *((T*)s_data + s_id[2]); 
+                T tmp3 = *((T*)s_data + s_id[3]); 
+    
+                // 初始预测值
+                pred = tmp1;
+    
+                // 计算不同 case 对应的 pred
+                if ( (case1 && case2 && case3) || (!case1 && case2 && case3 && case4)) {
+                    pred = cubic_interpolator(tmp0, tmp1, tmp2, tmp3);
+                    
+                }
+                else if ((case1 && case2 && !case3) || ( !case1 && case2 && !(case3 && case4) && case5)) {
+                    pred = (-tmp0 + 6 * tmp1 + 3 * tmp2) / 8;
+                }
+                else if ((case1 && !case2 && case3) || (!case1 && !case2 && case3 && case4 )){
+                    pred = (3 * tmp1 + 6 * tmp2 - tmp3) / 8;   
+                }
+                else if ((case1 && !case2 && !case3) || (!case1 && !case2 && !(case3 && case4) && case5)) {
+                    pred = (tmp1 + tmp2) / 2;
+                }
+
+            }
+            auto get_interp_order = [&](auto x, auto gx, auto gs){
+                int b = (x >= 3 * unit) ? 3 : 1;
+                int f = ((x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX) && ((gx + 3 * unit < gs))) ? 3 :
+                (((gx + unit < gs)) ? 1 : 0);
+
+                return (b == 3) ? ((f == 3) ? 4 : ((f == 1) ? 3 : 0)) 
+                                : ((f == 3) ? 2 : ((f == 1) ? 1 : 0));
+            };
+            if CONSTEXPR (FACE) {  //
+
+                bool I_YZ = (x % (2*unit) ) == 0;
+                bool I_XZ = (y % (2*unit ) )== 0;
+                int x_1,BI_1,GD_1,gx_1,gs_1;
+                int x_2,BI_2,GD_2,gx_2,gs_2;
+                int s_id_1[4], s_id_2[4];
+                auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                if (I_YZ){
+                   
+                 x_1 = z,BI_1 = BIZ, GD_1 = GDZ, gx_1 = global_z,gs_1 = data_size.z;
+                 x_2 = y,BI_2 = BIY, GD_2 = GDY, gx_2 = global_y, gs_2 = data_size.y;
+                 s_id_1[0] = x_size * y_size * id_z[0] + x_size * y + x;
+                 s_id_1[1] = x_size * y_size * id_z[1] + x_size * y + x;
+                 s_id_1[2] = x_size * y_size * id_z[2] + x_size * y + x;
+                 s_id_1[3] = x_size * y_size * id_z[3] + x_size * y + x;
+                 s_id_2[0] = x_size * y_size * z + x_size * id_y[0] + x;
+                 s_id_2[1] = x_size * y_size * z + x_size * id_y[1] + x;
+                 s_id_2[2] = x_size * y_size * z + x_size * id_y[2] + x;
+                 s_id_2[3] = x_size * y_size * z + x_size * id_y[3] + x;
+                 pred = s_data[id_z[1]][id_y[1]][x];
+
+                }
+                else if (I_XZ){
+                    x_1 = z,BI_1 = BIZ, GD_1 = GDZ, gx_1 = global_z,gs_1 = data_size.z;
+                    x_2 = x,BI_2 = BIX, GD_2 = GDX, gx_2 = global_x, gs_2 = data_size.x;
+                    s_id_1[0] = x_size * y_size * id_z[0] + x_size * y + x;
+                    s_id_1[1] = x_size * y_size * id_z[1] + x_size * y + x;
+                    s_id_1[2] = x_size * y_size * id_z[2] + x_size * y + x;
+                    s_id_1[3] = x_size * y_size * id_z[3] + x_size * y + x;
+                    
+                    s_id_2[0] = x_size * y_size * z + x_size * y + id_x[0];
+                    s_id_2[1] = x_size * y_size * z + x_size * y + id_x[1];
+                    s_id_2[2] = x_size * y_size * z + x_size * y + id_x[2];
+                    s_id_2[3] = x_size * y_size * z + x_size * y + id_x[3];
+                    pred = s_data[id_z[1]][y][id_x[1]];
+                    
+                }
+                else{
+                    x_1 = y,BI_1 = BIY, GD_1 = GDY, gx_1 = global_y, gs_1 = data_size.y;
+                    x_2 = x,BI_2 = BIX, GD_2 = GDX, gx_2 = global_x, gs_2 = data_size.x;
+                    s_id_1[0] = x_size * y_size * z + x_size * id_y[0] + x;
+                    s_id_1[1] = x_size * y_size * z + x_size * id_y[1] + x;
+                    s_id_1[2] = x_size * y_size * z + x_size * id_y[2] + x;
+                    s_id_1[3] = x_size * y_size * z + x_size * id_y[3] + x;
+                    s_id_2[0] = x_size * y_size * z + x_size * y + id_x[0];
+                    s_id_2[1] = x_size * y_size * z + x_size * y + id_x[1];
+                    s_id_2[2] = x_size * y_size * z + x_size * y + id_x[2];
+                    s_id_2[3] = x_size * y_size * z + x_size * y + id_x[3];
+                    pred = s_data[z][id_y[1]][id_x[1]];
+                }
+
+                    auto interp_1 = get_interp_order(x_1,gx_1,gs_1);
+                    auto interp_2 = get_interp_order(x_2,gx_2,gs_2);
+
+                    int case_num = interp_1 + interp_2 * 5;
+
+                    if (interp_1 == 4 && interp_2 == 4) {
+                        pred = (cubic_interpolator(*((T*)s_data + s_id_1[0]), 
+                        *((T*)s_data + s_id_1[1]), 
+                        *((T*)s_data + s_id_1[2]), 
+                        *((T*)s_data + s_id_1[3])) +
+                         cubic_interpolator(*((T*)s_data + s_id_2[0]), 
+                        *((T*)s_data + s_id_2[1]), 
+                        *((T*)s_data + s_id_2[2]), 
+                        *((T*)s_data + s_id_2[3]))) / 2;
+                    } else if (interp_1 != 4 && interp_2 == 4) {
+                        pred = cubic_interpolator(*((T*)s_data + s_id_2[0]), 
+                        *((T*)s_data + s_id_2[1]), 
+                        *((T*)s_data + s_id_2[2]), 
+                        *((T*)s_data + s_id_2[3]));
+                    } else if (interp_1 == 4 && interp_2 != 4) {
+                        pred = cubic_interpolator(*((T*)s_data + s_id_1[0]), 
+                        *((T*)s_data + s_id_1[1]), 
+                        *((T*)s_data + s_id_1[2]), 
+                        *((T*)s_data + s_id_1[3]));
+                    } else if (interp_1 == 3 && interp_2 == 3) {
+                        pred = (-(*((T*)s_data + s_id_2[0]))+6*(*((T*)s_data + s_id_2[1])) + 3*(*((T*)s_data + s_id_2[2]))) / 8;
+                        pred += (-(*((T*)s_data + s_id_1[0]))+6*(*((T*)s_data + s_id_1[1])) + 3*(*((T*)s_data + s_id_1[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 3 && interp_2 == 2) {
+                        pred = (3*(*((T*)s_data + s_id_2[1]))+6*(*((T*)s_data + s_id_2[2])) - (*((T*)s_data + s_id_2[3]))) / 8;
+                        pred += (-(*((T*)s_data + s_id_1[0]))+6*(*((T*)s_data + s_id_1[1])) + 3*(*((T*)s_data + s_id_1[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 3 && interp_2 < 2) {
+                        pred = (-(*((T*)s_data + s_id_1[0]))+6*(*((T*)s_data + s_id_1[1])) + 3*(*((T*)s_data + s_id_1[2]))) / 8;
+                    } else if (interp_1 == 2 && interp_2 == 3) {
+                        pred = (3*(*((T*)s_data + s_id_1[1]))+6*(*((T*)s_data + s_id_1[2])) - (*((T*)s_data + s_id_1[3]))) / 8;
+                        pred += (-(*((T*)s_data + s_id_2[0]))+6*(*((T*)s_data + s_id_2[1])) + 3*(*((T*)s_data + s_id_2[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 2 && interp_2 == 2) {
+                        pred = (3*(*((T*)s_data + s_id_1[1]))+6*(*((T*)s_data + s_id_1[2])) - (*((T*)s_data + s_id_1[3]))) / 8;
+                        pred += (3*(*((T*)s_data + s_id_2[1]))+6*(*((T*)s_data + s_id_2[2])) - (*((T*)s_data + s_id_2[3]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 2 && interp_2 < 2) {
+                        pred = (3*(*((T*)s_data + s_id_1[1]))+6*(*((T*)s_data + s_id_1[2])) - (*((T*)s_data + s_id_1[3]))) / 8;
+                    } else if (interp_1 <= 1 && interp_2 == 3) {
+                        pred = (-(*((T*)s_data + s_id_2[0]))+6*(*((T*)s_data + s_id_2[1])) + 3*(*((T*)s_data + s_id_2[2]))) / 8;
+                    } else if (interp_1 <= 1 && interp_2 == 2) {
+                        pred = (3*(*((T*)s_data + s_id_2[1]))+6*(*((T*)s_data + s_id_2[2])) - (*((T*)s_data + s_id_2[3]))) / 8;
+                    } else if (interp_1 == 1 && interp_2 == 1) {
+                        pred = ((*((T*)s_data + s_id_2[1]))+(*((T*)s_data + s_id_2[2]))) / 2;
+                        pred += ((*((T*)s_data + s_id_1[1]))+(*((T*)s_data + s_id_1[2]))) / 2;
+                        pred /= 2;
+                    } else if (interp_1 == 1 && interp_2 < 1) {
+                        
+                        pred = ((*((T*)s_data + s_id_1[1]))+(*((T*)s_data + s_id_1[2]))) / 2;
+                    } else if (interp_1 == 0 && interp_2 == 1) {
+                        pred = ((*((T*)s_data + s_id_2[1]))+(*((T*)s_data + s_id_2[2]))) / 2;
+                    }
+                    else{
+                        pred = (*((T*)s_data + s_id_1[1])) + (*((T*)s_data + s_id_2[1])) - pred;
+                    }
+                    
+            }
+
+            if CONSTEXPR (CUBE) {  //
+                auto interp_z = get_interp_order(z,global_z,data_size.z);
+                auto interp_y = get_interp_order(y,global_y,data_size.y);
+                auto interp_x = get_interp_order(x,global_x,data_size.x);
+                
+                #pragma unroll
+                for(int id_itr = 0; id_itr < 4; ++id_itr){
+                 tmp_x[id_itr] = s_data[z][y][id_x[id_itr]]; 
+                }
+                if(interp_z == 4){
+                    #pragma unroll
+                    for(int id_itr = 0; id_itr < 4; ++id_itr){
+                        tmp_z[id_itr] = s_data[id_z[id_itr]][y][x];
+                       }
+                }
+                if(interp_y == 4){
+                    #pragma unroll
+                    for(int id_itr = 0; id_itr < 4; ++id_itr){
+                     tmp_y[id_itr] = s_data[z][id_y[id_itr]][x]; 
+                    }
+                }
+
+
+                T pred_z[5], pred_y[5], pred_x[5];
+                pred_x[0] = tmp_x[1];
+                pred_x[1] = cubic_interpolator(tmp_x[0],tmp_x[1],tmp_x[2],tmp_x[3]);
+                pred_x[2] = (-tmp_x[0]+6*tmp_x[1] + 3*tmp_x[2]) / 8;
+                pred_x[3] = (3*tmp_x[1] + 6*tmp_x[2]-tmp_x[3]) / 8;
+                pred_x[4] = (tmp_x[1] + tmp_x[2]) / 2;
+                
+                pred_y[1] = cubic_interpolator(tmp_y[0],tmp_y[1],tmp_y[2],tmp_y[3]);
+
+                
+                pred_z[1] = cubic_interpolator(tmp_z[0],tmp_z[1],tmp_z[2],tmp_z[3]);
+                
+            
+                
+                pred = pred_x[0];
+                pred = (interp_z == 4 && interp_y == 4 && interp_x == 4) ? (pred_x[1] +  pred_y[1] + pred_z[1]) / 3 : pred;
+                
+                pred = (interp_z == 4 && interp_y == 4 && interp_x != 4) ? (pred_z[1] + pred_y[1]) / 2 : pred;
+                pred = (interp_z == 4 && interp_y != 4 && interp_x == 4) ? (pred_z[1] + pred_x[1]) / 2 : pred;
+                pred = (interp_z != 4 && interp_y == 4 && interp_x == 4) ? (pred_y[1] + pred_x[1]) / 2 : pred;
+                
+                pred = (interp_z == 4 && interp_y != 4 && interp_x != 4) ? pred_z[1]: pred;
+                pred = (interp_z != 4 && interp_y == 4 && interp_x != 4) ? pred_y[1]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 4) ? pred_x[1]: pred;
+
+
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 3) ? pred_x[2]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 2) ? pred_x[3]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 1) ? pred_x[4]: pred;
+                // pred = (interp_z != 4 && interp_y != 4 && interp_x == 0) ? pred_x[0]: pred;
+            }
+
+
+  
+            if CONSTEXPR (WORKFLOW == SPLINE3_AB_ATT) {
+                
+                auto          err = s_data[z][y][x] - pred;
+                decltype(err) code;
+                // TODO unsafe, did not deal with the out-of-cap case
+                {
+                    code = fabs(err) * eb_r + 1;
+                    code = err < 0 ? -code : code;
+                    code = int(code / 2) ;
+                }
+              
+                s_data[z][y][x]  = pred + code * ebx2;
+                atomicAdd(const_cast<T*>(error),code!=0);
+                
+
+            }
+
+
+            else{
+
+                atomicAdd(const_cast<T*>(error),fabs(s_data[z][y][x]-pred));
+                
+            }
+        }
+    };
+    // -------------------------------------------------------------------------------- //
+
+    if CONSTEXPR (COARSEN) {
+        constexpr auto TOTAL = NUM_ELE;
+            for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                auto [x,y,z]    = xyzmap(_tix, unit, AnchorBlockSizeX);
+                run(x, y, z);
+            }   
+    }
+    else {
+        if(TIX<NUM_ELE){
+            auto [x,y,z]    = xyzmap(TIX, unit, AnchorBlockSizeX);
+            run(x, y, z);
+        }
+    }
+    __syncthreads();
+}
+
+
+template <typename T, typename FP, int SPLINE_DIM, int AnchorBlockSizeX, int AnchorBlockSizeY, int AnchorBlockSizeZ, int numAnchorBlockX, int numAnchorBlockY, int numAnchorBlockZ, int LINEAR_BLOCK_SIZE, bool WORKFLOW>
+__device__ void cusz::device_api::spline_layout_interpolate_att(
+    volatile T s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     DIM3    data_size,
+    DIM3 global_starts,FP eb_r, FP ebx2,uint8_t level,INTERPOLATION_PARAMS intp_param,volatile T *error)
+{
+    auto xblue = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+    auto yblue = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+    auto zblue = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+
+    auto xblue_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+    auto yblue_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy ); };
+    auto zblue_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+
+    auto xyellow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+    auto yyellow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
+    auto zyellow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+
+    auto xyellow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+    auto yyellow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
+    auto zyellow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2); };
+
+
+    auto xhollow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
+    auto yhollow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy); };
+    auto zhollow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+
+    auto xhollow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
+    auto yhollow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+    auto zhollow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz *2); };
+
+    auto nan_cubic_interp = [] __device__ (T a, T b, T c, T d) -> T{
+        return (-a+9*b+9*c-d) / 16;
+    };
+
+    auto nat_cubic_interp = [] __device__ (T a, T b, T c, T d) -> T{
+        return (-3*a+23*b+23*c-3*d) / 40;
+    };
+    constexpr auto COARSEN          = true;
+    constexpr auto NO_COARSEN       = false;
+    constexpr auto BORDER_INCLUSIVE = true;
+    constexpr auto BORDER_EXCLUSIVE = false;
+
+
+    int unit;
+
+    FP cur_ebx2=ebx2,cur_eb_r=eb_r;
+
+
+    auto calc_eb = [&](auto unit) {
+        cur_ebx2=ebx2,cur_eb_r=eb_r;
+        int temp=1;
+        while(temp<unit){
+            temp*=2;
+            cur_eb_r *= intp_param.alpha;
+            cur_ebx2 /= intp_param.alpha;
+
+        }
+        if(cur_ebx2 < ebx2 / intp_param.beta){
+            cur_ebx2 = ebx2 / intp_param.beta;
+            cur_eb_r = eb_r * intp_param.beta;
+
+        }
+    };
+
+    int max_unit = ((AnchorBlockSizeX >= AnchorBlockSizeY) ? AnchorBlockSizeX : AnchorBlockSizeY);
+    max_unit = ((max_unit >= AnchorBlockSizeZ) ? max_unit : AnchorBlockSizeZ);
+    max_unit /= 2;
+    int unit_x = AnchorBlockSizeX, unit_y = AnchorBlockSizeY, unit_z = AnchorBlockSizeZ;
+    
+    #pragma unroll
+    for(int unit = max_unit; unit >= 1; unit /= 2){
+        if(WORKFLOW==SPLINE3_AB_ATT or (1 << level) == unit){
+            if(WORKFLOW==SPLINE3_AB_ATT)
+                calc_eb(unit);
+            if(intp_param.use_md[3]){
+                int N_x = AnchorBlockSizeX / (unit * 2);
+                int N_y = AnchorBlockSizeY / (unit * 2);
+                int N_z = AnchorBlockSizeZ / (unit * 2);
+                int N_line = N_x * (N_y + 1) * (N_z + 1) + (N_x + 1) * N_y * (N_z + 1) + (N_x + 1) * (N_y + 1) * N_z;
+                int N_face = N_x * N_y * (N_z + 1) + N_x * (N_y + 1) * N_z + (N_x + 1) * N_y * N_z; 
+                int N_cube = N_x * N_y * N_z;
+                if(intp_param.use_natural[3]==0){
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line), true, false, false, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(s_data,data_size,global_starts, xyzmap_line, unit, cur_eb_r,cur_ebx2, nan_cubic_interp,error, N_line);
+
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face), false, true, false, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(s_data, data_size,global_starts, xyzmap_face, unit, cur_eb_r,cur_ebx2, nan_cubic_interp,error, N_face);
+
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube), false, false, true, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(s_data,data_size,global_starts, xyzmap_cube, unit, cur_eb_r,cur_ebx2, nan_cubic_interp, error, N_cube);
+                }
+                else{
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line), true, false, false, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(s_data, data_size,global_starts, xyzmap_line, unit, cur_eb_r,cur_ebx2, nat_cubic_interp, error, N_line);
+
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face), false, true, false, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(s_data, data_size,global_starts, xyzmap_face, unit, cur_eb_r, cur_ebx2, nat_cubic_interp, error, N_face);
+
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube), false, false, true, LINEAR_BLOCK_SIZE, NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(s_data, data_size,global_starts, xyzmap_cube, unit, cur_eb_r, cur_ebx2, nat_cubic_interp, error, N_cube);
+                }
+
+            }
+            else{
+
+                if(intp_param.reverse[3]){
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  false, false, true, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size, global_starts, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r,cur_ebx2, intp_param.use_natural[3], error, numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_x /= 2;
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse), false, true, false, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE,WORKFLOW>(s_data, data_size, global_starts, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r,cur_ebx2, intp_param.use_natural[3], error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y, numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_y /= 2;
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse), true, false, false, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE,WORKFLOW>(s_data,data_size,global_starts, xblue_reverse, yblue_reverse, zblue_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[3],error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                    unit_z /= 2;
+                }
+                else{
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue), decltype(yblue), decltype(zblue),  true, false, false, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE,WORKFLOW>(s_data,data_size,global_starts, xblue, yblue, zblue, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[3], error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                    unit_z /= 2;
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow), decltype(yyellow), decltype(zyellow), false, true, false, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE,WORKFLOW>(s_data,data_size,global_starts, xyellow, yyellow, zyellow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[3],error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y, numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_y /= 2;
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow), decltype(yhollow), decltype(zhollow), false, false, true, NO_COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE,WORKFLOW>(s_data,data_size,global_starts, xhollow, yhollow, zhollow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[3],error,  numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_x /= 2;
+                }
+            }
+        }
+    }
+}
+
+
+template <typename TITER, typename FP, int SPLINE_DIM, int AnchorBlockSizeX, int AnchorBlockSizeY, int AnchorBlockSizeZ, int numAnchorBlockX, int numAnchorBlockY, int numAnchorBlockZ, int LINEAR_BLOCK_SIZE>
+__global__ void cusz::pa_spline_infprecis_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    DIM3 sample_starts,
+    DIM3 sample_block_grid_sizes,
+    DIM3 sample_strides,
+    FP eb_r,
+    FP eb_x2,
+    INTERPOLATION_PARAMS intp_param,
+    TITER errors,
+    bool workflow
+    )
+{
+    // compile time variables
+    using T = typename std::remove_pointer<TITER>::type;
+
+    {
+        __shared__ struct {
+            T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+            [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+            [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+            T err[6];
+        } shmem;
+
+        DIM3 global_starts;
+        uint8_t level = 0;
+        uint8_t unit = 1;
+        pre_compute_att<T>(sample_starts, sample_block_grid_sizes, sample_strides, global_starts, intp_param, level, unit, shmem.err, workflow);
+        
+        global2shmem_data_att<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ,LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data,global_starts,unit);
+       
+        if(workflow){
+
+            if(level==2){
+                uint8_t level3 = 3;
+                intp_param.use_natural[3] = false;
+                intp_param.use_natural[2] = false;
+                intp_param.use_md[3] = false;
+                intp_param.reverse[3] = false;
+                cusz::device_api::spline_layout_interpolate_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err);
+                intp_param.reverse[3] = true;
+                cusz::device_api::spline_layout_interpolate_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err+1);
+                intp_param.use_md[3] = true;
+                cusz::device_api::spline_layout_interpolate_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err+2);
+
+
+                intp_param.use_md[2] = false;
+                intp_param.reverse[2] = false;
+                cusz::device_api::spline_layout_interpolate_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+3);
+                intp_param.reverse[2] = true;
+                cusz::device_api::spline_layout_interpolate_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+4);
+                intp_param.use_md[2] = true;
+                cusz::device_api::spline_layout_interpolate_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+5);
+                if(TIX<6){
+                    atomicAdd(const_cast<T*>(errors+TIX),shmem.err[TIX]);
+                }
+            }
+            else if (level == 1){
+                intp_param.use_md[1] = false;
+                intp_param.reverse[1] = false;
+                cusz::device_api::spline_layout_interpolate_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+                intp_param.reverse[1] = true;
+                cusz::device_api::spline_layout_interpolate_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+1);
+                intp_param.use_md[1] = true;
+                cusz::device_api::spline_layout_interpolate_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+2);
+
+                if(TIX<3){
+                   atomicAdd(const_cast<T*>(errors + 3 + BIY * 3 + TIX),shmem.err[TIX]);
+                }
+            }
+            else{
+                cusz::device_api::spline_layout_interpolate_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+                if(TIX==0){
+                    atomicAdd(const_cast<T*>(errors + 9 + BIY), shmem.err[0]);
+                }
+            }
+            
+        }
+        else{
+            cusz::device_api::spline_layout_interpolate_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_AB_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+            if(TIX==0)
+                atomicAdd(const_cast<T*>(errors+BIY),shmem.err[0]);
+        
+        }
+    }
+}
+
+
+
+#undef TIX
+#undef TIY
+#undef TIZ
+#undef BIX
+#undef BIY
+#undef BIZ
+#undef BDX
+#undef BDY
+#undef BDZ
+#undef GDX
+#undef GDY
+#undef GDZ
+
+#endif

--- a/src/kernel/detail/spline3.inl
+++ b/src/kernel/detail/spline3.inl
@@ -1,4 +1,4 @@
-/**
+ /**
  * @file spline3.inl
  * @author Jinyang Liu, Shixun Wu, Jiannan Tian
  * @brief
@@ -15,7 +15,9 @@
 
 #include <stdint.h>
 #include <stdio.h>
+
 #include <type_traits>
+
 #include "cusz/type.h"
 #include "utils/err.hh"
 #include "utils/timer.hh"
@@ -42,12 +44,12 @@
 #define GDY gridDim.y
 #define GDZ gridDim.z
 
-using DIM     = u4;
-using STRIDE  = u4;
-using DIM3    = dim3;
+using DIM = u4;
+using STRIDE = u4;
+using DIM3 = dim3;
 using STRIDE3 = dim3;
 
-constexpr int BLOCK8  = 8;
+constexpr int BLOCK8 = 8;
 constexpr int BLOCK32 = 32;
 constexpr int DEFAULT_LINEAR_BLOCK_SIZE = 384;
 
@@ -60,84 +62,60 @@ namespace cusz {
  ********************************************************************************/
 template <typename TITER, int LINEAR_BLOCK_SIZE>
 __global__ void c_spline3d_profiling_16x16x16data(
-    TITER   data,
-    DIM3    data_size,
-    STRIDE3 data_leap,
-    TITER errors);
+    TITER data, DIM3 data_size, STRIDE3 data_leap, TITER errors);
 
 template <typename TITER, int LINEAR_BLOCK_SIZE>
 __global__ void c_spline3d_profiling_data_2(
-    TITER   data,
-    DIM3    data_size,
-    STRIDE3 data_leap,
-    TITER errors);
+    TITER data, DIM3 data_size, STRIDE3 data_leap, TITER errors);
 
 template <
-    typename TITER,
-    typename EITER,
-    typename FP            = float,
-    int  LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE, 
-    typename CompactVal = TITER,
-    typename CompactIdx = uint32_t*,
+    typename TITER, typename EITER, typename FP = float,
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE,
+    typename CompactVal = TITER, typename CompactIdx = uint32_t*,
     typename CompactNum = uint32_t*>
 __global__ void c_spline3d_infprecis_32x8x8data(
-    TITER   data,
-    DIM3    data_size,
-    STRIDE3 data_leap,
-    EITER   ectrl,
-    DIM3    ectrl_size,
-    STRIDE3 ectrl_leap,
-    TITER   anchor,
-    STRIDE3 anchor_leap,
-    CompactVal cval,
-    CompactIdx cidx,
-    CompactNum cn,
-    FP      eb_r,
-    FP      ebx2,
-    int     radius,
-    INTERPOLATION_PARAMS intp_param,
-    TITER errors);
+    TITER data, DIM3 data_size, STRIDE3 data_leap, EITER ectrl,
+    DIM3 ectrl_size, STRIDE3 ectrl_leap, TITER anchor, STRIDE3 anchor_leap,
+    CompactVal cval, CompactIdx cidx, CompactNum cn, FP eb_r, FP ebx2,
+    int radius, INTERPOLATION_PARAMS intp_param, TITER errors);
 
 template <
-    typename EITER,
-    typename TITER,
-    typename FP           = float,
+    typename EITER, typename TITER, typename FP = float,
     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
 __global__ void x_spline3d_infprecis_32x8x8data(
-    EITER   ectrl,        // input 1
-    DIM3    ectrl_size,   //
+    EITER ectrl,          // input 1
+    DIM3 ectrl_size,      //
     STRIDE3 ectrl_leap,   //
-    TITER   anchor,       // input 2
-    DIM3    anchor_size,  //
+    TITER anchor,         // input 2
+    DIM3 anchor_size,     //
     STRIDE3 anchor_leap,  //
-    TITER   data,         // output
-    DIM3    data_size,    //
+    TITER data,           // output
+    DIM3 data_size,       //
     STRIDE3 data_leap,    //
-    FP      eb_r,
-    FP      ebx2,
-    int     radius,
-    INTERPOLATION_PARAMS intp_param);
+    FP eb_r, FP ebx2, int radius, INTERPOLATION_PARAMS intp_param);
 
 namespace device_api {
 /********************************************************************************
  * device API
  ********************************************************************************/
 
-    template <typename T,int  LINEAR_BLOCK_SIZE>
-__device__ void auto_tuning(volatile T s_data[9][9][33],  volatile T local_errs[6], DIM3  data_size, volatile T* count);
+template <typename T, int LINEAR_BLOCK_SIZE>
+__device__ void auto_tuning(
+    volatile T s_data[9][9][33], volatile T local_errs[6], DIM3 data_size,
+    volatile T* count);
 
- template <typename T,int  LINEAR_BLOCK_SIZE>
-__device__ void auto_tuning_2(volatile T s_data[9][9][33],  volatile T local_errs[6], DIM3  data_size, volatile T* count);
+template <typename T, int LINEAR_BLOCK_SIZE>
+__device__ void auto_tuning_2(
+    volatile T s_data[9][9][33], volatile T local_errs[6], DIM3 data_size,
+    volatile T* count);
 
 template <
-    typename T1,
-    typename T2,
-    typename FP,
-    int  LINEAR_BLOCK_SIZE,
-    bool WORKFLOW         = SPLINE3_COMPR,
-    bool PROBE_PRED_ERROR = false>
-__device__ void
-spline3d_layout2_interpolate(volatile T1 s_data[9][9][33], volatile T2 s_ectrl[9][9][33],  DIM3  data_size,FP eb_r, FP ebx2, int radius, INTERPOLATION_PARAMS intp_param);
+    typename T1, typename T2, typename FP, int LINEAR_BLOCK_SIZE,
+    bool WORKFLOW = SPLINE3_COMPR, bool PROBE_PRED_ERROR = false>
+__device__ void spline3d_layout2_interpolate(
+    volatile T1 s_data[9][9][33], volatile T2 s_ectrl[9][9][33],
+    DIM3 data_size, FP eb_r, FP ebx2, int radius,
+    INTERPOLATION_PARAMS intp_param);
 }  // namespace device_api
 
 }  // namespace cusz
@@ -149,138 +127,180 @@ spline3d_layout2_interpolate(volatile T1 s_data[9][9][33], volatile T2 s_ectrl[9
 namespace {
 
 template <bool INCLUSIVE = true>
-__forceinline__ __device__ bool xyz33x9x9_predicate(unsigned int x, unsigned int y, unsigned int z,const DIM3 &data_size)
+__forceinline__ __device__ bool xyz33x9x9_predicate(
+    unsigned int x, unsigned int y, unsigned int z, const DIM3& data_size)
 {
-    if CONSTEXPR (INCLUSIVE) {  //
+  if CONSTEXPR (INCLUSIVE) {  //
 
-        
-            return (x <= 32 and y <= 8 and z <= 8) and BIX*BLOCK32+x<data_size.x and BIY*BLOCK8+y<data_size.y and BIZ*BLOCK8+z<data_size.z;
-    }
-    else {
-        return x < 32+(BIX==GDX-1) and y < 8+(BIY==GDY-1) and z < 8+(BIZ==GDZ-1) and BIX*BLOCK32+x<data_size.x and BIY*BLOCK8+y<data_size.y and BIZ*BLOCK8+z<data_size.z;
-    }
+    return (x <= 32 and y <= 8 and z <= 8) and
+           BIX * BLOCK32 + x < data_size.x and
+           BIY * BLOCK8 + y < data_size.y and BIZ * BLOCK8 + z < data_size.z;
+  }
+  else {
+    return x < 32 + (BIX == GDX - 1) and y < 8 + (BIY == GDY - 1) and
+           z < 8 + (BIZ == GDZ - 1) and BIX * BLOCK32 + x < data_size.x and
+           BIY * BLOCK8 + y < data_size.y and BIZ * BLOCK8 + z < data_size.z;
+  }
 }
 
 // control block_id3 in function call
-template <typename T, bool PRINT_FP = true, int XEND = 33, int YEND = 9, int ZEND = 9>
-__device__ void
-spline3d_print_block_from_GPU(T volatile a[9][9][33], int radius = 512, bool compress = true, bool print_ectrl = true)
+template <
+    typename T, bool PRINT_FP = true, int XEND = 33, int YEND = 9,
+    int ZEND = 9>
+__device__ void spline3d_print_block_from_GPU(
+    T volatile a[9][9][33], int radius = 512, bool compress = true,
+    bool print_ectrl = true)
 {
-    for (auto z = 0; z < ZEND; z++) {
-        printf("\nprint from GPU, z=%d\n", z);
-        printf("    ");
-        for (auto i = 0; i < 33; i++) printf("%3d", i);
-        printf("\n");
+  for (auto z = 0; z < ZEND; z++) {
+    printf("\nprint from GPU, z=%d\n", z);
+    printf("    ");
+    for (auto i = 0; i < 33; i++) printf("%3d", i);
+    printf("\n");
 
-        for (auto y = 0; y < YEND; y++) {
-            printf("y=%d ", y);
-            for (auto x = 0; x < XEND; x++) {  //
-                if CONSTEXPR (PRINT_FP) { printf("%.2e\t", (float)a[z][y][x]); }
+    for (auto y = 0; y < YEND; y++) {
+      printf("y=%d ", y);
+      for (auto x = 0; x < XEND; x++) {  //
+        if CONSTEXPR (PRINT_FP) { printf("%.2e\t", (float)a[z][y][x]); }
+        else {
+          T c = print_ectrl ? a[z][y][x] - radius : a[z][y][x];
+          if (compress) {
+            if (c == 0) { printf("%3c", '.'); }
+            else {
+              if (abs(c) >= 10) { printf("%3c", '*'); }
+              else {
+                if (print_ectrl) { printf("%3d", c); }
                 else {
-                    T c = print_ectrl ? a[z][y][x] - radius : a[z][y][x];
-                    if (compress) {
-                        if (c == 0) { printf("%3c", '.'); }
-                        else {
-                            if (abs(c) >= 10) { printf("%3c", '*'); }
-                            else {
-                                if (print_ectrl) { printf("%3d", c); }
-                                else {
-                                    printf("%4.2f", c);
-                                }
-                            }
-                        }
-                    }
-                    else {
-                        if (print_ectrl) { printf("%3d", c); }
-                        else {
-                            printf("%4.2f", c);
-                        }
-                    }
+                  printf("%4.2f", c);
                 }
+              }
             }
-            printf("\n");
+          }
+          else {
+            if (print_ectrl) { printf("%3d", c); }
+            else {
+              printf("%4.2f", c);
+            }
+          }
         }
+      }
+      printf("\n");
     }
-    printf("\nGPU print end\n\n");
+  }
+  printf("\nGPU print end\n\n");
 }
 
-template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
-__device__ void c_reset_scratch_33x9x9data(volatile T1 s_data[9][9][33], volatile T2 s_ectrl[9][9][33], int radius)
+template <
+    typename T1, typename T2,
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void c_reset_scratch_33x9x9data(
+    volatile T1 s_data[9][9][33], volatile T2 s_ectrl[9][9][33], int radius)
 {
-    // alternatively, reinterprete cast volatile T?[][][] to 1D
-    for (auto _tix = TIX; _tix < 33 * 9 * 9; _tix += LINEAR_BLOCK_SIZE) {
-        auto x = (_tix % 33);
-        auto y = (_tix / 33) % 9;
-        auto z = (_tix / 33) / 9;
+  // alternatively, reinterprete cast volatile T?[][][] to 1D
+  for (auto _tix = TIX; _tix < 33 * 9 * 9; _tix += LINEAR_BLOCK_SIZE) {
+    auto x = (_tix % 33);
+    auto y = (_tix / 33) % 9;
+    auto z = (_tix / 33) / 9;
 
-        s_data[z][y][x] = 0;
-        /*****************************************************************************
-         okay to use
-         ******************************************************************************/
-        if (x % 8 == 0 and y % 8 == 0 and z % 8 == 0) s_ectrl[z][y][x] = radius;
-        /*****************************************************************************
-         alternatively
-         ******************************************************************************/
-        // s_ectrl[z][y][x] = radius;
-    }
-    __syncthreads();
-}
-
-
-template <typename T, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
-__device__ void c_reset_scratch_profiling_16x16x16data(volatile T s_data[16][16][16], T default_value)
-{
-    for (auto _tix = TIX; _tix < 16 * 16 * 16; _tix += LINEAR_BLOCK_SIZE) {
-        auto x = (_tix % 16);
-        auto y = (_tix / 16) % 16;
-        auto z = (_tix / 16) / 16;
-
-        s_data[z][y][x] = default_value;
-
-    }
+    s_data[z][y][x] = 0;
+    /*****************************************************************************
+     okay to use
+     ******************************************************************************/
+    if (x % 8 == 0 and y % 8 == 0 and z % 8 == 0) s_ectrl[z][y][x] = radius;
+    /*****************************************************************************
+     alternatively
+     ******************************************************************************/
+    // s_ectrl[z][y][x] = radius;
+  }
+  __syncthreads();
 }
 
 template <typename T, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
-__device__ void c_reset_scratch_profiling_data_2(volatile T s_data[64], T nx[64][4], T ny[64][4], T nz[64][4],T default_value)
+__device__ void c_reset_scratch_profiling_16x16x16data(
+    volatile T s_data[16][16][16], T default_value)
 {
-    for (auto _tix = TIX; _tix < 64 * 4; _tix += LINEAR_BLOCK_SIZE) {
-        auto x = (_tix % 4);
-        auto yz=_tix/4;
+  for (auto _tix = TIX; _tix < 16 * 16 * 16; _tix += LINEAR_BLOCK_SIZE) {
+    auto x = (_tix % 16);
+    auto y = (_tix / 16) % 16;
+    auto z = (_tix / 16) / 16;
 
-        
+    s_data[z][y][x] = default_value;
+  }
+}
 
-        nx[yz][x]=ny[yz][x]=nz[yz][x]=default_value;
-        s_data[TIX] = default_value;
+template <typename T, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void c_reset_scratch_profiling_data_2(
+    volatile T s_data[64], T nx[64][4], T ny[64][4], T nz[64][4],
+    T default_value)
+{
+  for (auto _tix = TIX; _tix < 64 * 4; _tix += LINEAR_BLOCK_SIZE) {
+    auto x = (_tix % 4);
+    auto yz = _tix / 4;
 
-    }
+    nx[yz][x] = ny[yz][x] = nz[yz][x] = default_value;
+    s_data[TIX] = default_value;
+  }
+}
+
+template <typename T1, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void c_gather_anchor(
+    T1* data, DIM3 data_size, STRIDE3 data_leap, T1* anchor,
+    STRIDE3 anchor_leap)
+{
+  auto x = (TIX % 32) + BIX * 32;
+  auto y = (TIX / 32) % 8 + BIY * 8;
+  auto z = (TIX / 32) / 8 + BIZ * 8;
+
+  bool pred1 = x % 8 == 0 and y % 8 == 0 and z % 8 == 0;
+  bool pred2 = x < data_size.x and y < data_size.y and z < data_size.z;
+
+  if (pred1 and pred2) {
+    auto data_id = x + y * data_leap.y + z * data_leap.z;
+    auto anchor_id =
+        (x / 8) + (y / 8) * anchor_leap.y + (z / 8) * anchor_leap.z;
+    anchor[anchor_id] = data[data_id];
+  }
+  __syncthreads();
 }
 
 template <typename T1, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
 __device__ void c_gather_anchor(T1* data, DIM3 data_size, STRIDE3 data_leap, T1* anchor, STRIDE3 anchor_leap)
 {
-    auto x = (TIX % 32) + BIX * 32;
-    auto y = (TIX / 32) % 8 + BIY * 8;
-    auto z = (TIX / 32) / 8 + BIZ * 8;
+    auto ax =  BIX;//1 is block16 by anchor stride
+    auto ay = BIY ;
+    auto az = BIZ ;
 
-    bool pred1 = x % 8 == 0 and y % 8 == 0 and z % 8 == 0;
+    auto x = 16*ax;
+    auto y = 16*ay;
+    auto z = 16*az;
+
+    bool pred1 = TIX < 1;//1 is num of anchor
     bool pred2 = x < data_size.x and y < data_size.y and z < data_size.z;
 
     if (pred1 and pred2) {
         auto data_id      = x + y * data_leap.y + z * data_leap.z;
-        auto anchor_id    = (x / 8) + (y / 8) * anchor_leap.y + (z / 8) * anchor_leap.z;
+        auto anchor_id    = ax + ay * anchor_leap.y + az * anchor_leap.z;
         anchor[anchor_id] = data[data_id];
+        /*
+        if(TIX == 7 and BIX == 12 and BIY == 12 and BIZ == 8){
+            printf("anchor: %d, %d, %.2e, %.2e,%d,%d,%d,%d\n", anchor_id,data_id,anchor[anchor_id],data[data_id],data_leap.y,data_leap.z,anchor_leap.y,anchor_leap.z);
+        }
+        if(TIX == 0 and BIX == 13 and BIY == 13 and BIZ == 9){
+            printf("13139anchor: %d, %d, %.2e, %.2e\n", anchor_id,data_id,anchor[anchor_id],data[data_id]);
+        }*/
     }
     __syncthreads();
 }
 
+
 /*
  * use shmem, erroneous
 template <typename T1, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
-__device__ void c_gather_anchor(volatile T1 s_data[9][9][33], T1* anchor, STRIDE3 anchor_leap)
+__device__ void c_gather_anchor(volatile T1 s_data[9][9][33], T1* anchor,
+STRIDE3 anchor_leap)
 {
-    constexpr auto NUM_ITERS = 33 * 9 * 9 / LINEAR_BLOCK_SIZE + 1;  // 11 iterations
-    for (auto i = 0; i < NUM_ITERS; i++) {
-        auto _tix = i * LINEAR_BLOCK_SIZE + TIX;
+    constexpr auto NUM_ITERS = 33 * 9 * 9 / LINEAR_BLOCK_SIZE + 1;  // 11
+iterations for (auto i = 0; i < NUM_ITERS; i++) { auto _tix = i *
+LINEAR_BLOCK_SIZE + TIX;
 
         if (_tix < 33 * 9 * 9) {
             auto x = (_tix % 33);
@@ -299,595 +319,718 @@ __device__ void c_gather_anchor(volatile T1 s_data[9][9][33], T1* anchor, STRIDE
 }
 */
 
-template <typename T1, typename T2 = T1, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+template <
+    typename T1, typename T2 = T1,
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
 __device__ void x_reset_scratch_33x9x9data(
-    volatile T1 s_xdata[9][9][33],
-    volatile T2 s_ectrl[9][9][33],
-    T1*         anchor,       //
-    DIM3        anchor_size,  //
-    STRIDE3     anchor_leap)
+    volatile T1 s_xdata[9][9][33], volatile T2 s_ectrl[9][9][33],
+    T1* anchor,        //
+    DIM3 anchor_size,  //
+    STRIDE3 anchor_leap)
 {
-    for (auto _tix = TIX; _tix < 33 * 9 * 9; _tix += LINEAR_BLOCK_SIZE) {
-        auto x = (_tix % 33);
-        auto y = (_tix / 33) % 9;
-        auto z = (_tix / 33) / 9;
+  for (auto _tix = TIX; _tix < 33 * 9 * 9; _tix += LINEAR_BLOCK_SIZE) {
+    auto x = (_tix % 33);
+    auto y = (_tix / 33) % 9;
+    auto z = (_tix / 33) / 9;
 
-        s_ectrl[z][y][x] = 0;  // TODO explicitly handle zero-padding
-        /*****************************************************************************
-         okay to use
-         ******************************************************************************/
-        if (x % 8 == 0 and y % 8 == 0 and z % 8 == 0) {
-            s_xdata[z][y][x] = 0;
+    s_ectrl[z][y][x] = 0;  // TODO explicitly handle zero-padding
+    /*****************************************************************************
+     okay to use
+     ******************************************************************************/
+    if (x % 8 == 0 and y % 8 == 0 and z % 8 == 0) {
+      s_xdata[z][y][x] = 0;
 
-            auto ax = ((x / 8) + BIX * 4);
-            auto ay = ((y / 8) + BIY);
-            auto az = ((z / 8) + BIZ);
+      auto ax = ((x / 8) + BIX * 4);
+      auto ay = ((y / 8) + BIY);
+      auto az = ((z / 8) + BIZ);
 
-            if (ax < anchor_size.x and ay < anchor_size.y and az < anchor_size.z)
-                s_xdata[z][y][x] = anchor[ax + ay * anchor_leap.y + az * anchor_leap.z];
-        }
-        /*****************************************************************************
-         alternatively
-         ******************************************************************************/
-        // s_ectrl[z][y][x] = radius;
+      if (ax < anchor_size.x and ay < anchor_size.y and az < anchor_size.z)
+        s_xdata[z][y][x] =
+            anchor[ax + ay * anchor_leap.y + az * anchor_leap.z];
     }
+    /*****************************************************************************
+     alternatively
+     ******************************************************************************/
+    // s_ectrl[z][y][x] = radius;
+  }
 
-    __syncthreads();
-}
-
-template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
-__device__ void global2shmem_33x9x9data(T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[9][9][33])
-{
-    constexpr auto TOTAL = 33 * 9 * 9;
-
-    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
-        auto x   = (_tix % 33);
-        auto y   = (_tix / 33) % 9;
-        auto z   = (_tix / 33) / 9;
-        auto gx  = (x + BIX * BLOCK32);
-        auto gy  = (y + BIY * BLOCK8);
-        auto gz  = (z + BIZ * BLOCK8);
-        auto gid = gx + gy * data_leap.y + gz * data_leap.z;
-
-        if (gx < data_size.x and gy < data_size.y and gz < data_size.z) s_data[z][y][x] = data[gid];
-/*
-        if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and z==4){
-            printf("g2s1084 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
-        }
-
-        if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and z==8){
-            printf("g2s1048 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
-        }*/
-    }
-    __syncthreads();
-}
-
-template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
-__device__ void global2shmem_profiling_16x16x16data(T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[16][16][16])
-{
-    constexpr auto TOTAL = 16 * 16 * 16;
-
-    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
-        auto x   = (_tix % 16);
-        auto y   = (_tix / 16) % 16;
-        auto z   = (_tix / 16) / 16;
-        auto gx_1=x/4;
-        auto gx_2=x%4;
-        auto gy_1=y/4;
-        auto gy_2=y%4;
-        auto gz_1=z/4;
-        auto gz_2=z%4;
-        auto gx=(data_size.x/4)*gx_1+gx_2;
-        auto gy=(data_size.y/4)*gy_1+gy_2;
-        auto gz=(data_size.z/4)*gz_1+gz_2;
-
-        auto gid = gx + gy * data_leap.y + gz * data_leap.z;
-
-        if (gx < data_size.x and gy < data_size.y and gz < data_size.z) s_data[z][y][x] = data[gid];
-/*
-        if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and z==4){
-            printf("g2s1084 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
-        }
-
-        if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and z==8){
-            printf("g2s1048 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
-        }*/
-    }
-    __syncthreads();
-}
-
-template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
-__device__ void global2shmem_profiling_data_2(T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[64], volatile T2 s_nx[64][4], volatile T2 s_ny[64][4], volatile T2 s_nz[64][4])
-{
-    constexpr auto TOTAL = 64 * 4;
-    int factors[4]={-3,-1,1,3};
-    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
-        auto offset   = (_tix % 4);
-        auto idx = _tix /4;
-        auto x = idx%4;
-        auto y   = (idx / 4) % 4;
-        auto z   = (idx / 4) / 4;
-        auto gx=(data_size.x/4)*x+data_size.x/8;
-        auto gy=(data_size.y/4)*y+data_size.y/8;
-        auto gz=(data_size.z/4)*z+data_size.z/8;
-
-        auto gid = gx + gy * data_leap.y + gz * data_leap.z;
-
-        if (gx>=3 and gy>=3 and gz>=3 and gx+3 < data_size.x and gy+3 < data_size.y and gz+3 < data_size.z) {
-            s_data[idx] = data[gid];
-            
-            auto factor=factors[offset];
-            s_nx[idx][offset]=data[gid+factor];
-            s_ny[idx][offset]=data[gid+factor*data_leap.y];
-            s_nz[idx][offset]=data[gid+factor*data_leap.z];
-           
-        }
-/*
-        if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and z==4){
-            printf("g2s1084 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
-        }
-
-        if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and z==8){
-            printf("g2s1048 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
-        }*/
-    }
-    __syncthreads();
-}
-
-template <typename T = float, typename E = u4, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
-__device__ void global2shmem_fuse(E* ectrl, dim3 ectrl_size, dim3 ectrl_leap, T* scattered_outlier, volatile T s_ectrl[9][9][33])
-{
-    constexpr auto TOTAL = 33 * 9 * 9;
-
-    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
-        auto x   = (_tix % 33);
-        auto y   = (_tix / 33) % 9;
-        auto z   = (_tix / 33) / 9;
-        auto gx  = (x + BIX * BLOCK32);
-        auto gy  = (y + BIY * BLOCK8);
-        auto gz  = (z + BIZ * BLOCK8);
-        auto gid = gx + gy * ectrl_leap.y + gz * ectrl_leap.z;
-
-        if (gx < ectrl_size.x and gy < ectrl_size.y and gz < ectrl_size.z) s_ectrl[z][y][x] = static_cast<T>(ectrl[gid]) + scattered_outlier[gid];
-    }
-    __syncthreads();
-}
-
-// dram_outlier should be the same in type with shared memory buf
-template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
-__device__ void
-shmem2global_32x8x8data(volatile T1 s_buf[9][9][33], T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap)
-{
-    auto x_size=BLOCK32+(BIX==GDX-1);
-    auto y_size=BLOCK8+(BIY==GDY-1);
-    auto z_size=BLOCK8+(BIZ==GDZ-1);
-    //constexpr auto TOTAL = 32 * 8 * 8;
-    auto TOTAL = x_size * y_size * z_size;
-
-    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
-        auto x   = (_tix % x_size);
-        auto y   = (_tix / x_size) % y_size;
-        auto z   = (_tix / x_size) / y_size;
-        auto gx  = (x + BIX * BLOCK32);
-        auto gy  = (y + BIY * BLOCK8);
-        auto gz  = (z + BIZ * BLOCK8);
-        auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
-
-        if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z) dram_buf[gid] = s_buf[z][y][x];
-        /*
-        if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and z==4){
-            printf("s2g1084 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_buf[z][y][x],dram_buf[gid]);
-        }
-
-        if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and z==8){
-            printf("s2g1048 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_buf[z][y][x],dram_buf[gid]);
-        }*/
-    }
-    __syncthreads();
-}
-
-
-// dram_outlier should be the same in type with shared memory buf
-template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
-__device__ void
-shmem2global_32x8x8data_with_compaction(volatile T1 s_buf[9][9][33], T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap, int radius, T1* dram_compactval = nullptr, uint32_t* dram_compactidx = nullptr, uint32_t* dram_compactnum = nullptr)
-{
-    auto x_size = BLOCK32 + (BIX == GDX-1);
-    auto y_size = BLOCK8 + (BIY == GDY-1);
-    auto z_size = BLOCK8 + (BIZ == GDZ-1);
-    auto TOTAL = x_size * y_size * z_size;
-
-    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
-        auto x   = (_tix % x_size);
-        auto y   = (_tix / x_size) % y_size;
-        auto z   = (_tix / x_size) / y_size;
-        auto gx  = (x + BIX * BLOCK32);
-        auto gy  = (y + BIY * BLOCK8);
-        auto gz  = (z + BIZ * BLOCK8);
-        auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
-
-        auto candidate = s_buf[z][y][x];
-        bool quantizable = (candidate >= 0) and (candidate < 2*radius);
-
-        if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z) {
-            // TODO this is for algorithmic demo by reading from shmem
-            // For performance purpose, it can be inlined in quantization
-            dram_buf[gid] = quantizable * static_cast<T2>(candidate);
-
-            if (not quantizable) {
-                auto cur_idx = atomicAdd(dram_compactnum, 1);
-                dram_compactidx[cur_idx] = gid;
-                dram_compactval[cur_idx] = candidate;
-            }
-        }
-    }
-    __syncthreads();
+  __syncthreads();
 }
 
 template <
-    typename T1,
-    typename T2,
-    typename FP,
-    typename LAMBDAX,
-    typename LAMBDAY,
-    typename LAMBDAZ,
-    bool BLUE,
-    bool YELLOW,
-    bool HOLLOW,
-    int  LINEAR_BLOCK_SIZE,
-    int  BLOCK_DIMX,
-    int  BLOCK_DIMY,
-    bool COARSEN,
-    int  BLOCK_DIMZ,
-    bool BORDER_INCLUSIVE,
-    bool WORKFLOW>
-__forceinline__ __device__ void interpolate_stage(
-    volatile T1 s_data[9][9][33],
-    volatile T2 s_ectrl[9][9][33],
-    DIM3    data_size,
-    LAMBDAX     xmap,
-    LAMBDAY     ymap,
-    LAMBDAZ     zmap,
-    int         unit,
-    FP          eb_r,
-    FP          ebx2,
-    int         radius,
-    bool interpolator)
+    typename T1, typename T2,
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_33x9x9data(
+    T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[9][9][33])
 {
-    static_assert(BLOCK_DIMX * BLOCK_DIMY * (COARSEN ? 1 : BLOCK_DIMZ) <= 384, "block oversized");
-    static_assert((BLUE or YELLOW or HOLLOW) == true, "must be one hot");
-    static_assert((BLUE and YELLOW) == false, "must be only one hot (1)");
-    static_assert((BLUE and YELLOW) == false, "must be only one hot (2)");
-    static_assert((YELLOW and HOLLOW) == false, "must be only one hot (3)");
+  constexpr auto TOTAL = 33 * 9 * 9;
 
-    auto run = [&](auto x, auto y, auto z) {
+  for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+    auto x = (_tix % 33);
+    auto y = (_tix / 33) % 9;
+    auto z = (_tix / 33) / 9;
+    auto gx = (x + BIX * BLOCK32);
+    auto gy = (y + BIY * BLOCK8);
+    auto gz = (z + BIZ * BLOCK8);
+    auto gid = gx + gy * data_leap.y + gz * data_leap.z;
 
-        
-
-        if (xyz33x9x9_predicate<BORDER_INCLUSIVE>(x, y, z,data_size)) {
-            T1 pred = 0;
-
-            //if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and (CONSTEXPR (YELLOW)) )
-            //    printf("%d %d %d\n",x,y,z);
-            /*
-             if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==4)
-                        printf("444 %.2e %.2e \n",s_data[z - unit][y][x],s_data[z + unit][y][x]);
-
-            if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==0)
-                        printf("440 %.2e %.2e \n",s_data[z][y - unit][x],s_data[z][y + unit][x]);
-            if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==8 and z==0)
-                        printf("480 %.2e %.2e \n",s_data[z][y ][x- unit],s_data[z][y ][x+ unit]);*/
-                  //  }
-            auto global_x=BIX*BLOCK32+x, global_y=BIY*BLOCK8+y, global_z=BIZ*BLOCK8+z;
-            /*
-            int interpolation_coeff_set1[2]={-1,-3};
-            int interpolation_coeff_set2[2]={9,23};
-            int interpolation_coeff_set3[2]={16,40};
-            auto a=interpolation_coeff_set1[interpolator];
-            auto b=interpolation_coeff_set2[interpolator];
-            auto c=interpolation_coeff_set3[interpolator];
-            */
-            if(interpolator==0){
-                if CONSTEXPR (BLUE) {  //
-
-                    if(BIZ!=GDZ-1){
-
-                        if(z>=3*unit and z+3*unit<=BLOCK8  )
-                            pred = (-s_data[z - 3*unit][y][x]+9*s_data[z - unit][y][x] + 9*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 16;
-                        else if (z+3*unit<=BLOCK8)
-                            pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
-                        else if (z>=3*unit)
-                            pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
-
-                        else
-                            pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
-                    }
-                    else{
-                        if(z>=3*unit){
-                            if(z+3*unit<=BLOCK8 and global_z+3*unit<data_size.z)
-                                pred = (-s_data[z - 3*unit][y][x]+9*s_data[z - unit][y][x] + 9*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 16;
-                            else if (global_z+unit<data_size.z)
-                                pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
-                            else
-                                pred=s_data[z - unit][y][x];
-
-                        }
-                        else{
-                            if(z+3*unit<=BLOCK8 and global_z+3*unit<data_size.z)
-                                pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
-                            else if (global_z+unit<data_size.z)
-                                pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
-                            else
-                                pred=s_data[z - unit][y][x];
-                        } 
-                    }
-                }
-                if CONSTEXPR (YELLOW) {  //
-                   // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and y==7 and z==0){
-                   //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
-                  //  }
-                    if(BIY!=GDY-1){
-                        if(y>=3*unit and y+3*unit<=BLOCK8 )
-                            pred = (-s_data[z ][y- 3*unit][x]+9*s_data[z ][y- unit][x] + 9*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 16;
-                        else if (y+3*unit<=BLOCK8)
-                            pred = (3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 8;
-                        else if (y>=3*unit)
-                            pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
-                        else
-                            pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
-                    }
-                    else{
-                        if(y>=3*unit){
-                            if(y+3*unit<=BLOCK8 and global_y+3*unit<data_size.y)
-                                pred = (-s_data[z ][y- 3*unit][x]+9*s_data[z][y - unit][x] + 9*s_data[z ][y+ unit][x]-s_data[z ][y+ 3*unit][x]) / 16;
-                            else if (global_y+unit<data_size.y)
-                                pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 8;
-                            else
-                                pred=s_data[z ][y- unit][x];
-
-                        }
-                        else{
-                            if(y+3*unit<=BLOCK8 and global_y+3*unit<data_size.y)
-                                pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
-                            else if (global_y+unit<data_size.y)
-                                pred = (s_data[z ][y- unit][x] + s_data[z][y + unit][x]) / 2;
-                            else
-                                pred=s_data[z ][y- unit][x];
-                        } 
-                    }
-                }
-
-                if CONSTEXPR (HOLLOW) {  //
-                    //if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1)
-                    //    printf("%d %d %d\n",x,y,z);
-                    if(BIX!=GDX-1){
-                        if(x>=3*unit and x+3*unit<=BLOCK32 )
-                            pred = (-s_data[z ][y][x- 3*unit]+9*s_data[z ][y][x- unit] + 9*s_data[z ][y][x+ unit]-s_data[z ][y][x + 3*unit]) / 16;
-                        else if (x+3*unit<=BLOCK32)
-                            pred = (3*s_data[z ][y][x- unit] + 6*s_data[z ][y][x + unit]-s_data[z][y][x + 3*unit]) / 8;
-                        else if (x>=3*unit)
-                            pred = (-s_data[z][y][x - 3*unit]+6*s_data[z][y][x - unit] + 3*s_data[z ][y][x + unit]) / 8;
-                        else
-                            pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
-                    }
-                    else{
-                        if(x>=3*unit){
-                            if(x+3*unit<=BLOCK32 and global_x+3*unit<data_size.x)
-                                pred = (-s_data[z ][y][x- 3*unit]+9*s_data[z][y ][x- unit] + 9*s_data[z ][y][x+ unit]-s_data[z ][y][x+ 3*unit]) / 16;
-                            else if (global_x+unit<data_size.x)
-                                pred = (-s_data[z ][y][x- 3*unit]+6*s_data[z ][y][x- unit] + 3*s_data[z ][y][x+ unit]) / 8;
-                            else
-                                pred=s_data[z ][y][x- unit];
-
-                        }
-                        else{
-                            if(x+3*unit<=BLOCK32 and global_x+3*unit<data_size.x)
-                                pred = (3*s_data[z][y ][x- unit] + 6*s_data[z ][y][x+ unit]-s_data[z][y ][x+ 3*unit]) / 8;
-                            else if (global_x+unit<data_size.x)
-                                pred = (s_data[z ][y][x- unit] + s_data[z][y ][x+ unit]) / 2;
-                            else
-                                pred=s_data[z ][y][x- unit];
-                        } 
-                    }
-                }
-
+    if (gx < data_size.x and gy < data_size.y and gz < data_size.z)
+      s_data[z][y][x] = data[gid];
+    /*
+            if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and
+       z==4){ printf("g2s1084 %d %d %d %d %.2e %.2e
+       \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
             }
-            else{
-                if CONSTEXPR (BLUE) {  //
 
-                    if(BIZ!=GDZ-1){
+            if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and
+       z==8){ printf("g2s1048 %d %d %d %d %.2e %.2e
+       \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
+            }*/
+  }
+  __syncthreads();
+}
 
-                        if(z>=3*unit and z+3*unit<=BLOCK8  )
-                            pred = (-3*s_data[z - 3*unit][y][x]+23*s_data[z - unit][y][x] + 23*s_data[z + unit][y][x]-3*s_data[z + 3*unit][y][x]) / 40;
-                        else if (z+3*unit<=BLOCK8)
-                            pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
-                        else if (z>=3*unit)
-                            pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+template <
+    typename T1, typename T2,
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_profiling_16x16x16data(
+    T1* data, DIM3 data_size, STRIDE3 data_leap,
+    volatile T2 s_data[16][16][16])
+{
+  constexpr auto TOTAL = 16 * 16 * 16;
 
-                        else
-                            pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
-                    }
-                    else{
-                        if(z>=3*unit){
-                            if(z+3*unit<=BLOCK8 and global_z+3*unit<data_size.z)
-                                pred = (-3*s_data[z - 3*unit][y][x]+23*s_data[z - unit][y][x] + 23*s_data[z + unit][y][x]-3*s_data[z + 3*unit][y][x]) / 40;
-                            else if (global_z+unit<data_size.z)
-                                pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
-                            else
-                                pred=s_data[z - unit][y][x];
+  for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+    auto x = (_tix % 16);
+    auto y = (_tix / 16) % 16;
+    auto z = (_tix / 16) / 16;
+    auto gx_1 = x / 4;
+    auto gx_2 = x % 4;
+    auto gy_1 = y / 4;
+    auto gy_2 = y % 4;
+    auto gz_1 = z / 4;
+    auto gz_2 = z % 4;
+    auto gx = (data_size.x / 4) * gx_1 + gx_2;
+    auto gy = (data_size.y / 4) * gy_1 + gy_2;
+    auto gz = (data_size.z / 4) * gz_1 + gz_2;
 
-                        }
-                        else{
-                            if(z+3*unit<=BLOCK8 and global_z+3*unit<data_size.z)
-                                pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
-                            else if (global_z+unit<data_size.z)
-                                pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
-                            else
-                                pred=s_data[z - unit][y][x];
-                        } 
-                    }
-                }
-                if CONSTEXPR (YELLOW) {  //
-                   // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and y==7 and z==0){
-                   //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
-                  //  }
-                    if(BIY!=GDY-1){
-                        if(y>=3*unit and y+3*unit<=BLOCK8 )
-                            pred = (-3*s_data[z ][y- 3*unit][x]+23*s_data[z ][y- unit][x] + 23*s_data[z ][y+ unit][x]-3*s_data[z][y + 3*unit][x]) / 40;
-                        else if (y+3*unit<=BLOCK8)
-                            pred = (3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 8;
-                        else if (y>=3*unit)
-                            pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
-                        else
-                            pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
-                    }
-                    else{
-                        if(y>=3*unit){
-                            if(y+3*unit<=BLOCK8 and global_y+3*unit<data_size.y)
-                                pred = (-3*s_data[z ][y- 3*unit][x]+23*s_data[z][y - unit][x] + 23*s_data[z ][y+ unit][x]-3*s_data[z ][y+ 3*unit][x]) / 40;
-                            else if (global_y+unit<data_size.y)
-                                pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 8;
-                            else
-                                pred=s_data[z ][y- unit][x];
+    auto gid = gx + gy * data_leap.y + gz * data_leap.z;
 
-                        }
-                        else{
-                            if(y+3*unit<=BLOCK8 and global_y+3*unit<data_size.y)
-                                pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
-                            else if (global_y+unit<data_size.y)
-                                pred = (s_data[z ][y- unit][x] + s_data[z][y + unit][x]) / 2;
-                            else
-                                pred=s_data[z ][y- unit][x];
-                        } 
-                    }
-                }
-
-                if CONSTEXPR (HOLLOW) {  //
-                    //if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1)
-                    //    printf("%d %d %d\n",x,y,z);
-                    if(BIX!=GDX-1){
-                        if(x>=3*unit and x+3*unit<=BLOCK32 )
-                            pred = (-3*s_data[z ][y][x- 3*unit]+23*s_data[z ][y][x- unit] + 23*s_data[z ][y][x+ unit]-3*s_data[z ][y][x + 3*unit]) / 40;
-                        else if (x+3*unit<=BLOCK32)
-                            pred = (3*s_data[z ][y][x- unit] + 6*s_data[z ][y][x + unit]-s_data[z][y][x + 3*unit]) / 8;
-                        else if (x>=3*unit)
-                            pred = (-s_data[z][y][x - 3*unit]+6*s_data[z][y][x - unit] + 3*s_data[z ][y][x + unit]) / 8;
-                        else
-                            pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
-                    }
-                    else{
-                        if(x>=3*unit){
-                            if(x+3*unit<=BLOCK32 and global_x+3*unit<data_size.x)
-                                pred = (-3*s_data[z ][y][x- 3*unit]+23*s_data[z][y ][x- unit] + 23*s_data[z ][y][x+ unit]-3*s_data[z ][y][x+ 3*unit]) / 40;
-                            else if (global_x+unit<data_size.x)
-                                pred = (-s_data[z ][y][x- 3*unit]+6*s_data[z ][y][x- unit] + 3*s_data[z ][y][x+ unit]) / 8;
-                            else
-                                pred=s_data[z ][y][x- unit];
-
-                        }
-                        else{
-                            if(x+3*unit<=BLOCK32 and global_x+3*unit<data_size.x)
-                                pred = (3*s_data[z][y ][x- unit] + 6*s_data[z ][y][x+ unit]-s_data[z][y ][x+ 3*unit]) / 8;
-                            else if (global_x+unit<data_size.x)
-                                pred = (s_data[z ][y][x- unit] + s_data[z][y ][x+ unit]) / 2;
-                            else
-                                pred=s_data[z ][y][x- unit];
-                        } 
-                    }
-                }
+    if (gx < data_size.x and gy < data_size.y and gz < data_size.z)
+      s_data[z][y][x] = data[gid];
+    /*
+            if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and
+       z==4){ printf("g2s1084 %d %d %d %d %.2e %.2e
+       \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
             }
-                
-            
-            
 
-            if CONSTEXPR (WORKFLOW == SPLINE3_COMPR) {
-                
-                auto          err = s_data[z][y][x] - pred;
-                decltype(err) code;
-                // TODO unsafe, did not deal with the out-of-cap case
-                {
-                    code = fabs(err) * eb_r + 1;
-                    code = err < 0 ? -code : code;
-                    code = int(code / 2) + radius;
-                }
-                s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
-                /*
-                  if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==0)
-                        printf("440pred %.2e %.2e %.2e\n",pred,code,s_data[z][y][x]);
-                    if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==8 and z==0)
-                        printf("480pred %.2e %.2e %.2e\n",pred,code,s_data[z][y][x]);
-                        */
-               // if(fabs(pred)>=3)
-               //     printf("%d %d %d %d %d %d %d %d %d %d %.2e %.2e %.2e\n",unit,CONSTEXPR (BLUE),CONSTEXPR (YELLOW),CONSTEXPR (HOLLOW),BIX,BIY,BIZ,x,y,z,pred,code,s_data[z][y][x]);
-              
-                s_data[z][y][x]  = pred + (code - radius) * ebx2;
-                
+            if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and
+       z==8){ printf("g2s1048 %d %d %d %d %.2e %.2e
+       \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
+            }*/
+  }
+  __syncthreads();
+}
 
+template <
+    typename T1, typename T2,
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_profiling_data_2(
+    T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[64],
+    volatile T2 s_nx[64][4], volatile T2 s_ny[64][4], volatile T2 s_nz[64][4])
+{
+  constexpr auto TOTAL = 64 * 4;
+  int factors[4] = {-3, -1, 1, 3};
+  for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+    auto offset = (_tix % 4);
+    auto idx = _tix / 4;
+    auto x = idx % 4;
+    auto y = (idx / 4) % 4;
+    auto z = (idx / 4) / 4;
+    auto gx = (data_size.x / 4) * x + data_size.x / 8;
+    auto gy = (data_size.y / 4) * y + data_size.y / 8;
+    auto gz = (data_size.z / 4) * z + data_size.z / 8;
+
+    auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+
+    if (gx >= 3 and gy >= 3 and gz >= 3 and gx + 3 < data_size.x and
+        gy + 3 < data_size.y and gz + 3 < data_size.z) {
+      s_data[idx] = data[gid];
+
+      auto factor = factors[offset];
+      s_nx[idx][offset] = data[gid + factor];
+      s_ny[idx][offset] = data[gid + factor * data_leap.y];
+      s_nz[idx][offset] = data[gid + factor * data_leap.z];
+    }
+    /*
+            if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and
+       z==4){ printf("g2s1084 %d %d %d %d %.2e %.2e
+       \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
             }
-            else {  // TODO == DECOMPRESSS and static_assert
-                auto code       = s_ectrl[z][y][x];
-                s_data[z][y][x] = pred + (code - radius) * ebx2;
-                /*
-                if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==0)
-                        printf("440pred %.2e %.2e %.2e\n",pred,code,s_data[z][y][x]);
-                    if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==8 and z==0)
-                        printf("480pred %.2e %.2e %.2e\n",pred,code,s_data[z][y][x]);
-                        */
 
-                //if(BIX == 4 and BIY == 20 and BIZ == 20 and unit==1 and CONSTEXPR (BLUE)){
-               //     if(fabs(s_data[z][y][x])>=3)
+            if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and
+       z==8){ printf("g2s1048 %d %d %d %d %.2e %.2e
+       \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
+            }*/
+  }
+  __syncthreads();
+}
 
-              //      printf("%d %d %d %d %d %d %d %d %d %d %.2e %.2e %.2e\n",unit,CONSTEXPR (BLUE),CONSTEXPR (YELLOW),CONSTEXPR (HOLLOW),BIX,BIY,BIZ,x,y,z,pred,code,s_data[z][y][x]);
-               // }
+template <
+    typename T = float, typename E = u4,
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_fuse(
+    E* ectrl, dim3 ectrl_size, dim3 ectrl_leap, T* scattered_outlier,
+    volatile T s_ectrl[9][9][33])
+{
+  constexpr auto TOTAL = 33 * 9 * 9;
+
+  for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+    auto x = (_tix % 33);
+    auto y = (_tix / 33) % 9;
+    auto z = (_tix / 33) / 9;
+    auto gx = (x + BIX * BLOCK32);
+    auto gy = (y + BIY * BLOCK8);
+    auto gz = (z + BIZ * BLOCK8);
+    auto gid = gx + gy * ectrl_leap.y + gz * ectrl_leap.z;
+
+    if (gx < ectrl_size.x and gy < ectrl_size.y and gz < ectrl_size.z)
+      s_ectrl[z][y][x] = static_cast<T>(ectrl[gid]) + scattered_outlier[gid];
+  }
+  __syncthreads();
+}
+
+// dram_outlier should be the same in type with shared memory buf
+template <
+    typename T1, typename T2,
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void shmem2global_32x8x8data(
+    volatile T1 s_buf[9][9][33], T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap)
+{
+  auto x_size = BLOCK32 + (BIX == GDX - 1);
+  auto y_size = BLOCK8 + (BIY == GDY - 1);
+  auto z_size = BLOCK8 + (BIZ == GDZ - 1);
+  // constexpr auto TOTAL = 32 * 8 * 8;
+  auto TOTAL = x_size * y_size * z_size;
+
+  for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+    auto x = (_tix % x_size);
+    auto y = (_tix / x_size) % y_size;
+    auto z = (_tix / x_size) / y_size;
+    auto gx = (x + BIX * BLOCK32);
+    auto gy = (y + BIY * BLOCK8);
+    auto gz = (z + BIZ * BLOCK8);
+    auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+
+    if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z)
+      dram_buf[gid] = s_buf[z][y][x];
+    /*
+    if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and z==4){
+        printf("s2g1084 %d %d %d %d %.2e %.2e
+    \n",gx,gy,gz,gid,s_buf[z][y][x],dram_buf[gid]);
+    }
+
+    if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and z==8){
+        printf("s2g1048 %d %d %d %d %.2e %.2e
+    \n",gx,gy,gz,gid,s_buf[z][y][x],dram_buf[gid]);
+    }*/
+  }
+  __syncthreads();
+}
+
+// dram_outlier should be the same in type with shared memory buf
+template <
+    typename T1, typename T2,
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void shmem2global_32x8x8data_with_compaction(
+    volatile T1 s_buf[9][9][33], T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap,
+    int radius, T1* dram_compactval = nullptr,
+    uint32_t* dram_compactidx = nullptr, uint32_t* dram_compactnum = nullptr)
+{
+  auto x_size = BLOCK32 + (BIX == GDX - 1);
+  auto y_size = BLOCK8 + (BIY == GDY - 1);
+  auto z_size = BLOCK8 + (BIZ == GDZ - 1);
+  auto TOTAL = x_size * y_size * z_size;
+
+  for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+    auto x = (_tix % x_size);
+    auto y = (_tix / x_size) % y_size;
+    auto z = (_tix / x_size) / y_size;
+    auto gx = (x + BIX * BLOCK32);
+    auto gy = (y + BIY * BLOCK8);
+    auto gz = (z + BIZ * BLOCK8);
+    auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+
+    auto candidate = s_buf[z][y][x];
+    bool quantizable = (candidate >= 0) and (candidate < 2 * radius);
+
+    if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z) {
+      // TODO this is for algorithmic demo by reading from shmem
+      // For performance purpose, it can be inlined in quantization
+      dram_buf[gid] = quantizable * static_cast<T2>(candidate);
+
+      if (not quantizable) {
+        auto cur_idx = atomicAdd(dram_compactnum, 1);
+        dram_compactidx[cur_idx] = gid;
+        dram_compactval[cur_idx] = candidate;
+      }
+    }
+  }
+  __syncthreads();
+}
+
+template <
+    typename T1, typename T2, typename FP, typename LAMBDAX, typename LAMBDAY,
+    typename LAMBDAZ, bool BLUE, bool YELLOW, bool HOLLOW,
+    int LINEAR_BLOCK_SIZE, int BLOCK_DIMX, int BLOCK_DIMY, bool COARSEN,
+    int BLOCK_DIMZ, bool BORDER_INCLUSIVE, bool WORKFLOW>
+__forceinline__ __device__ void interpolate_stage(
+    volatile T1 s_data[9][9][33], volatile T2 s_ectrl[9][9][33],
+    DIM3 data_size, LAMBDAX xmap, LAMBDAY ymap, LAMBDAZ zmap, int unit,
+    FP eb_r, FP ebx2, int radius, bool interpolator)
+{
+  static_assert(
+      BLOCK_DIMX * BLOCK_DIMY * (COARSEN ? 1 : BLOCK_DIMZ) <= 384,
+      "block oversized");
+  static_assert((BLUE or YELLOW or HOLLOW) == true, "must be one hot");
+  static_assert((BLUE and YELLOW) == false, "must be only one hot (1)");
+  static_assert((BLUE and YELLOW) == false, "must be only one hot (2)");
+  static_assert((YELLOW and HOLLOW) == false, "must be only one hot (3)");
+
+  auto run = [&](auto x, auto y, auto z) {
+    if (xyz33x9x9_predicate<BORDER_INCLUSIVE>(x, y, z, data_size)) {
+      T1 pred = 0;
+
+      // if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and (CONSTEXPR
+      // (YELLOW)) )
+      //     printf("%d %d %d\n",x,y,z);
+      /*
+       if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4
+      and z==4) printf("444 %.2e %.2e \n",s_data[z - unit][y][x],s_data[z +
+      unit][y][x]);
+
+      if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and
+      z==0) printf("440 %.2e %.2e \n",s_data[z][y - unit][x],s_data[z][y +
+      unit][x]); if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4
+      and y==8 and z==0) printf("480 %.2e %.2e \n",s_data[z][y ][x-
+      unit],s_data[z][y ][x+ unit]);*/
+      //  }
+      auto global_x = BIX * BLOCK32 + x, global_y = BIY * BLOCK8 + y,
+           global_z = BIZ * BLOCK8 + z;
+      /*
+      int interpolation_coeff_set1[2]={-1,-3};
+      int interpolation_coeff_set2[2]={9,23};
+      int interpolation_coeff_set3[2]={16,40};
+      auto a=interpolation_coeff_set1[interpolator];
+      auto b=interpolation_coeff_set2[interpolator];
+      auto c=interpolation_coeff_set3[interpolator];
+      */
+      if (interpolator == 0) {
+        if CONSTEXPR (BLUE) {  //
+
+          if (BIZ != GDZ - 1) {
+            if (z >= 3 * unit and z + 3 * unit <= BLOCK8)
+              pred =
+                  (-s_data[z - 3 * unit][y][x] + 9 * s_data[z - unit][y][x] +
+                   9 * s_data[z + unit][y][x] - s_data[z + 3 * unit][y][x]) /
+                  16;
+            else if (z + 3 * unit <= BLOCK8)
+              pred = (3 * s_data[z - unit][y][x] + 6 * s_data[z + unit][y][x] -
+                      s_data[z + 3 * unit][y][x]) /
+                     8;
+            else if (z >= 3 * unit)
+              pred =
+                  (-s_data[z - 3 * unit][y][x] + 6 * s_data[z - unit][y][x] +
+                   3 * s_data[z + unit][y][x]) /
+                  8;
+
+            else
+              pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+          }
+          else {
+            if (z >= 3 * unit) {
+              if (z + 3 * unit <= BLOCK8 and global_z + 3 * unit < data_size.z)
+                pred =
+                    (-s_data[z - 3 * unit][y][x] + 9 * s_data[z - unit][y][x] +
+                     9 * s_data[z + unit][y][x] - s_data[z + 3 * unit][y][x]) /
+                    16;
+              else if (global_z + unit < data_size.z)
+                pred =
+                    (-s_data[z - 3 * unit][y][x] + 6 * s_data[z - unit][y][x] +
+                     3 * s_data[z + unit][y][x]) /
+                    8;
+              else
+                pred = s_data[z - unit][y][x];
             }
+            else {
+              if (z + 3 * unit <= BLOCK8 and global_z + 3 * unit < data_size.z)
+                pred =
+                    (3 * s_data[z - unit][y][x] + 6 * s_data[z + unit][y][x] -
+                     s_data[z + 3 * unit][y][x]) /
+                    8;
+              else if (global_z + unit < data_size.z)
+                pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+              else
+                pred = s_data[z - unit][y][x];
+            }
+          }
         }
-    };
-    // -------------------------------------------------------------------------------- //
-
-    if CONSTEXPR (COARSEN) {
-        constexpr auto TOTAL = BLOCK_DIMX * BLOCK_DIMY * BLOCK_DIMZ;
-        //if( BLOCK_DIMX *BLOCK_DIMY<= LINEAR_BLOCK_SIZE){
-            for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
-                auto itix = (_tix % BLOCK_DIMX);
-                auto itiy = (_tix / BLOCK_DIMX) % BLOCK_DIMY;
-                auto itiz = (_tix / BLOCK_DIMX) / BLOCK_DIMY;
-                auto x    = xmap(itix, unit);
-                auto y    = ymap(itiy, unit);
-                auto z    = zmap(itiz, unit);
-                
-                run(x, y, z);
+        if CONSTEXPR (YELLOW) {  //
+          // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and
+          // y==7 and z==0){
+          //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y-
+          //     3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
+          //  }
+          if (BIY != GDY - 1) {
+            if (y >= 3 * unit and y + 3 * unit <= BLOCK8)
+              pred =
+                  (-s_data[z][y - 3 * unit][x] + 9 * s_data[z][y - unit][x] +
+                   9 * s_data[z][y + unit][x] - s_data[z][y + 3 * unit][x]) /
+                  16;
+            else if (y + 3 * unit <= BLOCK8)
+              pred = (3 * s_data[z][y - unit][x] + 6 * s_data[z][y + unit][x] -
+                      s_data[z][y + 3 * unit][x]) /
+                     8;
+            else if (y >= 3 * unit)
+              pred =
+                  (-s_data[z][y - 3 * unit][x] + 6 * s_data[z][y - unit][x] +
+                   3 * s_data[z][y + unit][x]) /
+                  8;
+            else
+              pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+          }
+          else {
+            if (y >= 3 * unit) {
+              if (y + 3 * unit <= BLOCK8 and global_y + 3 * unit < data_size.y)
+                pred =
+                    (-s_data[z][y - 3 * unit][x] + 9 * s_data[z][y - unit][x] +
+                     9 * s_data[z][y + unit][x] - s_data[z][y + 3 * unit][x]) /
+                    16;
+              else if (global_y + unit < data_size.y)
+                pred =
+                    (-s_data[z][y - 3 * unit][x] + 6 * s_data[z][y - unit][x] +
+                     3 * s_data[z][y + unit][x]) /
+                    8;
+              else
+                pred = s_data[z][y - unit][x];
             }
-        //}
-        //may have bug    
+            else {
+              if (y + 3 * unit <= BLOCK8 and global_y + 3 * unit < data_size.y)
+                pred =
+                    (3 * s_data[z][y - unit][x] + 6 * s_data[z][y + unit][x] -
+                     s_data[z][y + 3 * unit][x]) /
+                    8;
+              else if (global_y + unit < data_size.y)
+                pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+              else
+                pred = s_data[z][y - unit][x];
+            }
+          }
+        }
+
+        if CONSTEXPR (HOLLOW) {  //
+          // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1)
+          //     printf("%d %d %d\n",x,y,z);
+          if (BIX != GDX - 1) {
+            if (x >= 3 * unit and x + 3 * unit <= BLOCK32)
+              pred =
+                  (-s_data[z][y][x - 3 * unit] + 9 * s_data[z][y][x - unit] +
+                   9 * s_data[z][y][x + unit] - s_data[z][y][x + 3 * unit]) /
+                  16;
+            else if (x + 3 * unit <= BLOCK32)
+              pred = (3 * s_data[z][y][x - unit] + 6 * s_data[z][y][x + unit] -
+                      s_data[z][y][x + 3 * unit]) /
+                     8;
+            else if (x >= 3 * unit)
+              pred =
+                  (-s_data[z][y][x - 3 * unit] + 6 * s_data[z][y][x - unit] +
+                   3 * s_data[z][y][x + unit]) /
+                  8;
+            else
+              pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+          }
+          else {
+            if (x >= 3 * unit) {
+              if (x + 3 * unit <= BLOCK32 and
+                  global_x + 3 * unit < data_size.x)
+                pred =
+                    (-s_data[z][y][x - 3 * unit] + 9 * s_data[z][y][x - unit] +
+                     9 * s_data[z][y][x + unit] - s_data[z][y][x + 3 * unit]) /
+                    16;
+              else if (global_x + unit < data_size.x)
+                pred =
+                    (-s_data[z][y][x - 3 * unit] + 6 * s_data[z][y][x - unit] +
+                     3 * s_data[z][y][x + unit]) /
+                    8;
+              else
+                pred = s_data[z][y][x - unit];
+            }
+            else {
+              if (x + 3 * unit <= BLOCK32 and
+                  global_x + 3 * unit < data_size.x)
+                pred =
+                    (3 * s_data[z][y][x - unit] + 6 * s_data[z][y][x + unit] -
+                     s_data[z][y][x + 3 * unit]) /
+                    8;
+              else if (global_x + unit < data_size.x)
+                pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+              else
+                pred = s_data[z][y][x - unit];
+            }
+          }
+        }
+      }
+      else {
+        if CONSTEXPR (BLUE) {  //
+
+          if (BIZ != GDZ - 1) {
+            if (z >= 3 * unit and z + 3 * unit <= BLOCK8)
+              pred =
+                  (-3 * s_data[z - 3 * unit][y][x] +
+                   23 * s_data[z - unit][y][x] + 23 * s_data[z + unit][y][x] -
+                   3 * s_data[z + 3 * unit][y][x]) /
+                  40;
+            else if (z + 3 * unit <= BLOCK8)
+              pred = (3 * s_data[z - unit][y][x] + 6 * s_data[z + unit][y][x] -
+                      s_data[z + 3 * unit][y][x]) /
+                     8;
+            else if (z >= 3 * unit)
+              pred =
+                  (-s_data[z - 3 * unit][y][x] + 6 * s_data[z - unit][y][x] +
+                   3 * s_data[z + unit][y][x]) /
+                  8;
+
+            else
+              pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+          }
+          else {
+            if (z >= 3 * unit) {
+              if (z + 3 * unit <= BLOCK8 and global_z + 3 * unit < data_size.z)
+                pred = (-3 * s_data[z - 3 * unit][y][x] +
+                        23 * s_data[z - unit][y][x] +
+                        23 * s_data[z + unit][y][x] -
+                        3 * s_data[z + 3 * unit][y][x]) /
+                       40;
+              else if (global_z + unit < data_size.z)
+                pred =
+                    (-s_data[z - 3 * unit][y][x] + 6 * s_data[z - unit][y][x] +
+                     3 * s_data[z + unit][y][x]) /
+                    8;
+              else
+                pred = s_data[z - unit][y][x];
+            }
+            else {
+              if (z + 3 * unit <= BLOCK8 and global_z + 3 * unit < data_size.z)
+                pred =
+                    (3 * s_data[z - unit][y][x] + 6 * s_data[z + unit][y][x] -
+                     s_data[z + 3 * unit][y][x]) /
+                    8;
+              else if (global_z + unit < data_size.z)
+                pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+              else
+                pred = s_data[z - unit][y][x];
+            }
+          }
+        }
+        if CONSTEXPR (YELLOW) {  //
+          // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and
+          // y==7 and z==0){
+          //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y-
+          //     3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
+          //  }
+          if (BIY != GDY - 1) {
+            if (y >= 3 * unit and y + 3 * unit <= BLOCK8)
+              pred =
+                  (-3 * s_data[z][y - 3 * unit][x] +
+                   23 * s_data[z][y - unit][x] + 23 * s_data[z][y + unit][x] -
+                   3 * s_data[z][y + 3 * unit][x]) /
+                  40;
+            else if (y + 3 * unit <= BLOCK8)
+              pred = (3 * s_data[z][y - unit][x] + 6 * s_data[z][y + unit][x] -
+                      s_data[z][y + 3 * unit][x]) /
+                     8;
+            else if (y >= 3 * unit)
+              pred =
+                  (-s_data[z][y - 3 * unit][x] + 6 * s_data[z][y - unit][x] +
+                   3 * s_data[z][y + unit][x]) /
+                  8;
+            else
+              pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+          }
+          else {
+            if (y >= 3 * unit) {
+              if (y + 3 * unit <= BLOCK8 and global_y + 3 * unit < data_size.y)
+                pred = (-3 * s_data[z][y - 3 * unit][x] +
+                        23 * s_data[z][y - unit][x] +
+                        23 * s_data[z][y + unit][x] -
+                        3 * s_data[z][y + 3 * unit][x]) /
+                       40;
+              else if (global_y + unit < data_size.y)
+                pred =
+                    (-s_data[z][y - 3 * unit][x] + 6 * s_data[z][y - unit][x] +
+                     3 * s_data[z][y + unit][x]) /
+                    8;
+              else
+                pred = s_data[z][y - unit][x];
+            }
+            else {
+              if (y + 3 * unit <= BLOCK8 and global_y + 3 * unit < data_size.y)
+                pred =
+                    (3 * s_data[z][y - unit][x] + 6 * s_data[z][y + unit][x] -
+                     s_data[z][y + 3 * unit][x]) /
+                    8;
+              else if (global_y + unit < data_size.y)
+                pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+              else
+                pred = s_data[z][y - unit][x];
+            }
+          }
+        }
+
+        if CONSTEXPR (HOLLOW) {  //
+          // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1)
+          //     printf("%d %d %d\n",x,y,z);
+          if (BIX != GDX - 1) {
+            if (x >= 3 * unit and x + 3 * unit <= BLOCK32)
+              pred =
+                  (-3 * s_data[z][y][x - 3 * unit] +
+                   23 * s_data[z][y][x - unit] + 23 * s_data[z][y][x + unit] -
+                   3 * s_data[z][y][x + 3 * unit]) /
+                  40;
+            else if (x + 3 * unit <= BLOCK32)
+              pred = (3 * s_data[z][y][x - unit] + 6 * s_data[z][y][x + unit] -
+                      s_data[z][y][x + 3 * unit]) /
+                     8;
+            else if (x >= 3 * unit)
+              pred =
+                  (-s_data[z][y][x - 3 * unit] + 6 * s_data[z][y][x - unit] +
+                   3 * s_data[z][y][x + unit]) /
+                  8;
+            else
+              pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+          }
+          else {
+            if (x >= 3 * unit) {
+              if (x + 3 * unit <= BLOCK32 and
+                  global_x + 3 * unit < data_size.x)
+                pred = (-3 * s_data[z][y][x - 3 * unit] +
+                        23 * s_data[z][y][x - unit] +
+                        23 * s_data[z][y][x + unit] -
+                        3 * s_data[z][y][x + 3 * unit]) /
+                       40;
+              else if (global_x + unit < data_size.x)
+                pred =
+                    (-s_data[z][y][x - 3 * unit] + 6 * s_data[z][y][x - unit] +
+                     3 * s_data[z][y][x + unit]) /
+                    8;
+              else
+                pred = s_data[z][y][x - unit];
+            }
+            else {
+              if (x + 3 * unit <= BLOCK32 and
+                  global_x + 3 * unit < data_size.x)
+                pred =
+                    (3 * s_data[z][y][x - unit] + 6 * s_data[z][y][x + unit] -
+                     s_data[z][y][x + 3 * unit]) /
+                    8;
+              else if (global_x + unit < data_size.x)
+                pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+              else
+                pred = s_data[z][y][x - unit];
+            }
+          }
+        }
+      }
+
+      if CONSTEXPR (WORKFLOW == SPLINE3_COMPR) {
+        auto err = s_data[z][y][x] - pred;
+        decltype(err) code;
+        // TODO unsafe, did not deal with the out-of-cap case
+        {
+          code = fabs(err) * eb_r + 1;
+          code = err < 0 ? -code : code;
+          code = int(code / 2) + radius;
+        }
+        s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
         /*
-        else{
-            for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
-                auto itix = (_tix % BLOCK_DIMX);
-                auto itiz = (_tix / BLOCK_DIMX) % BLOCK_DIMZ;
-                auto itiy = (_tix / BLOCK_DIMX) / BLOCK_DIMZ;
-                auto x    = xmap(itix, unit);
-                auto y    = ymap(itiy, unit);
-                auto z    = zmap(itiz, unit);
-                run(x, y, z);
-            }
-        }*/
-        //may have bug  end
-        
-    }
-    else {
-        auto itix = (TIX % BLOCK_DIMX);
-        auto itiy = (TIX / BLOCK_DIMX) % BLOCK_DIMY;
-        auto itiz = (TIX / BLOCK_DIMX) / BLOCK_DIMY;
-        auto x    = xmap(itix, unit);
-        auto y    = ymap(itiy, unit);
-        auto z    = zmap(itiz, unit);
+          if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4
+          and z==0) printf("440pred %.2e %.2e
+          %.2e\n",pred,code,s_data[z][y][x]); if(BIX == 7 and BIY == 47 and BIZ
+          == 15 and unit==4 and x==4 and y==8 and z==0) printf("480pred %.2e
+          %.2e %.2e\n",pred,code,s_data[z][y][x]);
+                */
+        // if(fabs(pred)>=3)
+        //     printf("%d %d %d %d %d %d %d %d %d %d %.2e %.2e
+        //     %.2e\n",unit,CONSTEXPR (BLUE),CONSTEXPR (YELLOW),CONSTEXPR
+        //     (HOLLOW),BIX,BIY,BIZ,x,y,z,pred,code,s_data[z][y][x]);
 
-        
+        s_data[z][y][x] = pred + (code - radius) * ebx2;
+      }
+      else {  // TODO == DECOMPRESSS and static_assert
+        auto code = s_ectrl[z][y][x];
+        s_data[z][y][x] = pred + (code - radius) * ebx2;
+        /*
+        if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4
+        and z==0) printf("440pred %.2e %.2e %.2e\n",pred,code,s_data[z][y][x]);
+            if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and
+        y==8 and z==0) printf("480pred %.2e %.2e
+        %.2e\n",pred,code,s_data[z][y][x]);
+                */
 
-     //   printf("%d %d %d\n", x,y,z);
-        run(x, y, z);
+        // if(BIX == 4 and BIY == 20 and BIZ == 20 and unit==1 and CONSTEXPR
+        // (BLUE)){
+        //     if(fabs(s_data[z][y][x])>=3)
+
+        //      printf("%d %d %d %d %d %d %d %d %d %d %.2e %.2e
+        //      %.2e\n",unit,CONSTEXPR (BLUE),CONSTEXPR (YELLOW),CONSTEXPR
+        //      (HOLLOW),BIX,BIY,BIZ,x,y,z,pred,code,s_data[z][y][x]);
+        // }
+      }
     }
-    __syncthreads();
+  };
+  // --------------------------------------------------------------------------------
+  // //
+
+  if CONSTEXPR (COARSEN) {
+    constexpr auto TOTAL = BLOCK_DIMX * BLOCK_DIMY * BLOCK_DIMZ;
+    // if( BLOCK_DIMX *BLOCK_DIMY<= LINEAR_BLOCK_SIZE){
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+      auto itix = (_tix % BLOCK_DIMX);
+      auto itiy = (_tix / BLOCK_DIMX) % BLOCK_DIMY;
+      auto itiz = (_tix / BLOCK_DIMX) / BLOCK_DIMY;
+      auto x = xmap(itix, unit);
+      auto y = ymap(itiy, unit);
+      auto z = zmap(itiz, unit);
+
+      run(x, y, z);
+    }
+    //}
+    // may have bug
+    /*
+    else{
+        for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+            auto itix = (_tix % BLOCK_DIMX);
+            auto itiz = (_tix / BLOCK_DIMX) % BLOCK_DIMZ;
+            auto itiy = (_tix / BLOCK_DIMX) / BLOCK_DIMZ;
+            auto x    = xmap(itix, unit);
+            auto y    = ymap(itiy, unit);
+            auto z    = zmap(itiz, unit);
+            run(x, y, z);
+        }
+    }*/
+    // may have bug  end
+  }
+  else {
+    auto itix = (TIX % BLOCK_DIMX);
+    auto itiy = (TIX / BLOCK_DIMX) % BLOCK_DIMY;
+    auto itiz = (TIX / BLOCK_DIMX) / BLOCK_DIMY;
+    auto x = xmap(itix, unit);
+    auto y = ymap(itiy, unit);
+    auto z = zmap(itiz, unit);
+
+    //   printf("%d %d %d\n", x,y,z);
+    run(x, y, z);
+  }
+  __syncthreads();
 }
 
 }  // namespace
@@ -895,13 +1038,11 @@ __forceinline__ __device__ void interpolate_stage(
 /********************************************************************************/
 /*
 template <typename T,typename FP,int  LINEAR_BLOCK_SIZE>
-__device__ void cusz::device_api::auto_tuning(volatile T s_data[9][9][33],  DIM3  data_size, FP eb_r, FP ebx2){
-    //current design: 4 points: (4,4,4), (12,4,4), (20,4,4), (28,4,4). 6 configs (3 directions, lin/cubic)
-    auto itix=TIX % 4;//follow the warp
-    auto c=TIX/4;//follow the warp
-    bool predicate=(c<6);
-    if(predicate){
-        auto x=4+8*itix;
+__device__ void cusz::device_api::auto_tuning(volatile T s_data[9][9][33], DIM3
+data_size, FP eb_r, FP ebx2){
+    //current design: 4 points: (4,4,4), (12,4,4), (20,4,4), (28,4,4). 6
+configs (3 directions, lin/cubic) auto itix=TIX % 4;//follow the warp auto
+c=TIX/4;//follow the warp bool predicate=(c<6); if(predicate){ auto x=4+8*itix;
         auto y=4;
         auto z=4;
         T pred=0;
@@ -915,369 +1056,433 @@ __device__ void cusz::device_api::auto_tuning(volatile T s_data[9][9][33],  DIM3
         bool flag_axis_x[3]={0,0,1};
         T adjust_rate[2]={8.0/9.0,1};
 
-        pred=(-flag_cub[cubic]*s_data[z - 3*unit*flag_axis_z[axis]][y- 3*unit*flag_axis_y[axis]][x- 3*unit*flag_axis_x[axis]]
-            +9*s_data[z -unit*flag_axis_z[axis]][y-unit*flag_axis_y[axis]][x- unit*flag_axis_x[axis]]
-            +9*s_data[z +unit*flag_axis_z[axis]][y+unit*flag_axis_y[axis]][x+ unit*flag_axis_x[axis]]
-            -flag_cub[cubic]*s_data[z + 3*unit*flag_axis_z[axis]][y+ 3*unit*flag_axis_y[axis]][x+ 3*unit*flag_axis_x[axis]])/16;
+        pred=(-flag_cub[cubic]*s_data[z - 3*unit*flag_axis_z[axis]][y-
+3*unit*flag_axis_y[axis]][x- 3*unit*flag_axis_x[axis]] +9*s_data[z
+-unit*flag_axis_z[axis]][y-unit*flag_axis_y[axis]][x- unit*flag_axis_x[axis]]
+            +9*s_data[z +unit*flag_axis_z[axis]][y+unit*flag_axis_y[axis]][x+
+unit*flag_axis_x[axis]] -flag_cub[cubic]*s_data[z +
+3*unit*flag_axis_z[axis]][y+ 3*unit*flag_axis_y[axis]][x+
+3*unit*flag_axis_x[axis]])/16;
 
         pred*=adjust_rate[cubic];
         T abs_error=fabs(pred-s_data[z][y][x]);
 
-    } 
-    
+    }
+
 }
 */
-template <typename T,int  LINEAR_BLOCK_SIZE>
-__device__ void cusz::device_api::auto_tuning(volatile T s_data[16][16][16],  volatile T local_errs[2], DIM3  data_size,  T * errs){
- 
-    if(TIX<2)
-        local_errs[TIX]=0;
-    __syncthreads(); 
-
-    auto local_idx=TIX%2;
-    auto temp=TIX/2;
-    
-
-    auto block_idx_x =  temp % 4;
-    auto block_idx_y = ( temp / 4) % 4;
-    auto block_idx_z = ( ( temp  / 4) / 4) % 4;
-    auto dir = ( ( temp  / 4) / 4) / 4;
-
-
-
-    bool predicate=  dir<2;
-    // __shared__ T local_errs[6];
-
-
-
-    
-    if(predicate){
-
-       
-        
-        auto x=4*block_idx_x+1+local_idx;
-        //auto x =16;
-        auto y=4*block_idx_y+1+local_idx;
-        auto z=4*block_idx_z+1+local_idx;
-
-        
-        T pred=0;
-
-        //auto unit = 1;
-        switch(dir){
-            case 0:
-                pred = (s_data[z - 1][y][x] + s_data[z + 1][y][x]) / 2;
-                break;
-
-            
-            case 1:
-                 pred = (s_data[z][y][x - 1] + s_data[z][y][x + 1]) / 2;
-                break;
-
-            default:
-            break;
-        }
-        
-        T abs_error=fabs(pred-s_data[z][y][x]);
-        atomicAdd(const_cast<T*>(local_errs) + dir, abs_error);
-        
-
-    } 
-    __syncthreads(); 
-    if(TIX<2)
-        errs[TIX]=local_errs[TIX];
-    __syncthreads(); 
-       
-}
-
-
-template <typename T,int  LINEAR_BLOCK_SIZE>
-__device__ void cusz::device_api::auto_tuning_2(volatile T s_data[64], volatile T s_nx[64][4], volatile T s_ny[64][4], volatile T s_nz[64][4],  volatile T local_errs[6], DIM3  data_size,  T * errs){
- 
-    if(TIX<6)
-        local_errs[TIX]=0;
-    __syncthreads(); 
-
-    auto point_idx=TIX%64;
-    auto c=TIX/64;
-
-
-    bool predicate=  c<6;
-    // __shared__ T local_errs[6];
-
-    
-    if(predicate){
-
-       
-    
-        
-        T pred=0;
-
-        //auto unit = 1;
-        switch(c){
-                case 0:
-                    pred = (-s_nz[point_idx][0]+9*s_nz[point_idx][1] + 9*s_nz[point_idx][2]-s_nz[point_idx][3]) / 16;
-                    break;
-
-                case 1:
-                    pred = (-3*s_nz[point_idx][0]+23*s_nz[point_idx][1] + 23*s_nz[point_idx][2]-3*s_nz[point_idx][3]) / 40;
-                    break;
-                case 2:
-                    pred = (-s_ny[point_idx][0]+9*s_ny[point_idx][1] + 9*s_ny[point_idx][2]-s_ny[point_idx][3]) / 16;
-                    break;
-                case 3:
-                    pred = (-3*s_ny[point_idx][0]+23*s_ny[point_idx][1] + 23*s_ny[point_idx][2]-3*s_ny[point_idx][3]) / 40;
-                    break;
-
-                case 4:
-                    pred = (-s_nx[point_idx][0]+9*s_nx[point_idx][1] + 9*s_nx[point_idx][2]-s_nx[point_idx][3]) / 16;
-                    break;
-                case 5:
-                    pred = (-3*s_nx[point_idx][0]+23*s_nx[point_idx][1] + 23*s_nx[point_idx][2]-3*s_nx[point_idx][3]) / 40;
-                    break;
-
-
-
-                default:
-                break;
-            }
-        
-        T abs_error=fabs(pred-s_data[point_idx]);
-        atomicAdd(const_cast<T*>(local_errs) + c, abs_error);
-        
-
-    } 
-    __syncthreads(); 
-    if(TIX<6)
-        errs[TIX]=local_errs[TIX];
-    __syncthreads(); 
-       
-}
-
-
-
-template <typename T1, typename T2, typename FP,int LINEAR_BLOCK_SIZE, bool WORKFLOW, bool PROBE_PRED_ERROR>
-__device__ void cusz::device_api::spline3d_layout2_interpolate(
-    volatile T1 s_data[9][9][33],
-    volatile T2 s_ectrl[9][9][33],
-     DIM3    data_size,
-    FP          eb_r,
-    FP          ebx2,
-    int         radius,
-    INTERPOLATION_PARAMS intp_param
-    )
+template <typename T, int LINEAR_BLOCK_SIZE>
+__device__ void cusz::device_api::auto_tuning(
+    volatile T s_data[16][16][16], volatile T local_errs[2], DIM3 data_size,
+    T* errs)
 {
-    auto xblue = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
-    auto yblue = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
-    auto zblue = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+  if (TIX < 2) local_errs[TIX] = 0;
+  __syncthreads();
 
-    auto xblue_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
-    auto yblue_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy ); };
-    auto zblue_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+  auto local_idx = TIX % 2;
+  auto temp = TIX / 2;
 
-    auto xyellow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
-    auto yyellow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
-    auto zyellow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+  auto block_idx_x = temp % 4;
+  auto block_idx_y = (temp / 4) % 4;
+  auto block_idx_z = ((temp / 4) / 4) % 4;
+  auto dir = ((temp / 4) / 4) / 4;
 
-    auto xyellow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
-    auto yyellow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
-    auto zyellow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2); };
+  bool predicate = dir < 2;
+  // __shared__ T local_errs[6];
 
+  if (predicate) {
+    auto x = 4 * block_idx_x + 1 + local_idx;
+    // auto x =16;
+    auto y = 4 * block_idx_y + 1 + local_idx;
+    auto z = 4 * block_idx_z + 1 + local_idx;
 
-    auto xhollow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
-    auto yhollow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy); };
-    auto zhollow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+    T pred = 0;
 
-    auto xhollow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
-    auto yhollow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
-    auto zhollow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz *2); };
+    // auto unit = 1;
+    switch (dir) {
+      case 0: pred = (s_data[z - 1][y][x] + s_data[z + 1][y][x]) / 2; break;
 
-    constexpr auto COARSEN          = true;
-    constexpr auto NO_COARSEN       = false;
-    constexpr auto BORDER_INCLUSIVE = true;
-    constexpr auto BORDER_EXCLUSIVE = false;
+      case 1: pred = (s_data[z][y][x - 1] + s_data[z][y][x + 1]) / 2; break;
 
-    
-    FP cur_ebx2=ebx2,cur_eb_r=eb_r;
-
-
-    auto calc_eb = [&](auto unit) {
-        cur_ebx2=ebx2,cur_eb_r=eb_r;
-        int temp=1;
-        while(temp<unit){
-            temp*=2;
-            cur_eb_r *= intp_param.alpha;
-            cur_ebx2 /= intp_param.alpha;
-
-        }
-        if(cur_ebx2 < ebx2 / intp_param.beta){
-            cur_ebx2 = ebx2 / intp_param.beta;
-            cur_eb_r = eb_r * intp_param.beta;
-
-        }
-    };
-
-    // iteration 1
-    /*
-    auto colors_0={false,false,false};
-    auto colors_1={false,false,false};
-    auto colors_2={false,false,false};
-    //auto interp_orders={0,1,2};
-
-    auto set_orders [&](auto reverse){
-        colors_0={false,false,false};
-        colors_1={false,false,false};
-        colors_2={false,false,false};
-        auto interp_orders={0,1,2};
-        if (reverse)
-            interp_orders={2,1,0};
-        colors_0[interp_orders[0]]=true;
-        colors_1[interp_orders[1]]=true;
-        colors_2[interp_orders[2]]=true;
-
+      default: break;
     }
-    */
-    
 
+    T abs_error = fabs(pred - s_data[z][y][x]);
+    atomicAdd(const_cast<T*>(local_errs) + dir, abs_error);
+  }
+  __syncthreads();
+  if (TIX < 2) errs[TIX] = local_errs[TIX];
+  __syncthreads();
+}
 
-    int unit = 4;
-    calc_eb(unit);
-    //set_orders(reverse[2]);
-    if(intp_param.reverse[2]){
-        interpolate_stage<
-            T1, T2, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
-            false, false, true, LINEAR_BLOCK_SIZE, 4, 2, NO_COARSEN, 2, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[0]);
+template <typename T, int LINEAR_BLOCK_SIZE>
+__device__ void cusz::device_api::auto_tuning_2(
+    volatile T s_data[64], volatile T s_nx[64][4], volatile T s_ny[64][4],
+    volatile T s_nz[64][4], volatile T local_errs[6], DIM3 data_size, T* errs)
+{
+  if (TIX < 6) local_errs[TIX] = 0;
+  __syncthreads();
 
-        interpolate_stage<
-            T1, T2, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
-            false, true, false, LINEAR_BLOCK_SIZE, 9, 1, NO_COARSEN, 2, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[1]);
-        interpolate_stage<
-            T1, T2, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
-            true, false, false, LINEAR_BLOCK_SIZE, 9, 3, NO_COARSEN, 1, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xblue_reverse, yblue_reverse, zblue_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[2]);
+  auto point_idx = TIX % 64;
+  auto c = TIX / 64;
 
+  bool predicate = c < 6;
+  // __shared__ T local_errs[6];
 
+  if (predicate) {
+    T pred = 0;
+
+    // auto unit = 1;
+    switch (c) {
+      case 0:
+        pred = (-s_nz[point_idx][0] + 9 * s_nz[point_idx][1] +
+                9 * s_nz[point_idx][2] - s_nz[point_idx][3]) /
+               16;
+        break;
+
+      case 1:
+        pred = (-3 * s_nz[point_idx][0] + 23 * s_nz[point_idx][1] +
+                23 * s_nz[point_idx][2] - 3 * s_nz[point_idx][3]) /
+               40;
+        break;
+      case 2:
+        pred = (-s_ny[point_idx][0] + 9 * s_ny[point_idx][1] +
+                9 * s_ny[point_idx][2] - s_ny[point_idx][3]) /
+               16;
+        break;
+      case 3:
+        pred = (-3 * s_ny[point_idx][0] + 23 * s_ny[point_idx][1] +
+                23 * s_ny[point_idx][2] - 3 * s_ny[point_idx][3]) /
+               40;
+        break;
+
+      case 4:
+        pred = (-s_nx[point_idx][0] + 9 * s_nx[point_idx][1] +
+                9 * s_nx[point_idx][2] - s_nx[point_idx][3]) /
+               16;
+        break;
+      case 5:
+        pred = (-3 * s_nx[point_idx][0] + 23 * s_nx[point_idx][1] +
+                23 * s_nx[point_idx][2] - 3 * s_nx[point_idx][3]) /
+               40;
+        break;
+
+      default: break;
     }
-    else{
-        //if( BIX==0 and BIY==0 and BIZ==0)
-       // printf("lv3s0\n");
-        interpolate_stage<
-            T1, T2, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
-            true, false, false, LINEAR_BLOCK_SIZE, 5, 2, NO_COARSEN, 1, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xblue, yblue, zblue, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[0]);
-       // if(BIX==0 and BIY==0 and BIZ==0)
-       // printf("lv3s1\n");
-        interpolate_stage<
-            T1, T2, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
-            false, true, false, LINEAR_BLOCK_SIZE, 5, 1, NO_COARSEN, 3, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xyellow, yyellow, zyellow, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[1]);
-        //if(BIX==0 and BIY==0 and BIZ==0)
-      //  printf("lv3s2\n");
-        interpolate_stage<
-            T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
-            false, false, true, LINEAR_BLOCK_SIZE, 4, 3, NO_COARSEN, 3, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xhollow, yhollow, zhollow, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[2]);
+
+    T abs_error = fabs(pred - s_data[point_idx]);
+    atomicAdd(const_cast<T*>(local_errs) + c, abs_error);
+  }
+  __syncthreads();
+  if (TIX < 6) errs[TIX] = local_errs[TIX];
+  __syncthreads();
+}
+
+template <
+    typename T1, typename T2, typename FP, int LINEAR_BLOCK_SIZE,
+    bool WORKFLOW, bool PROBE_PRED_ERROR>
+__device__ void cusz::device_api::spline3d_layout2_interpolate(
+    volatile T1 s_data[9][9][33], volatile T2 s_ectrl[9][9][33],
+    DIM3 data_size, FP eb_r, FP ebx2, int radius,
+    INTERPOLATION_PARAMS intp_param)
+{
+  auto xblue = [] __device__(int _tix, int unit) -> int {
+    return unit * (_tix * 2);
+  };
+  auto yblue = [] __device__(int _tiy, int unit) -> int {
+    return unit * (_tiy * 2);
+  };
+  auto zblue = [] __device__(int _tiz, int unit) -> int {
+    return unit * (_tiz * 2 + 1);
+  };
+
+  auto xblue_reverse = [] __device__(int _tix, int unit) -> int {
+    return unit * (_tix);
+  };
+  auto yblue_reverse = [] __device__(int _tiy, int unit) -> int {
+    return unit * (_tiy);
+  };
+  auto zblue_reverse = [] __device__(int _tiz, int unit) -> int {
+    return unit * (_tiz * 2 + 1);
+  };
+
+  auto xyellow = [] __device__(int _tix, int unit) -> int {
+    return unit * (_tix * 2);
+  };
+  auto yyellow = [] __device__(int _tiy, int unit) -> int {
+    return unit * (_tiy * 2 + 1);
+  };
+  auto zyellow = [] __device__(int _tiz, int unit) -> int {
+    return unit * (_tiz);
+  };
+
+  auto xyellow_reverse = [] __device__(int _tix, int unit) -> int {
+    return unit * (_tix);
+  };
+  auto yyellow_reverse = [] __device__(int _tiy, int unit) -> int {
+    return unit * (_tiy * 2 + 1);
+  };
+  auto zyellow_reverse = [] __device__(int _tiz, int unit) -> int {
+    return unit * (_tiz * 2);
+  };
+
+  auto xhollow = [] __device__(int _tix, int unit) -> int {
+    return unit * (_tix * 2 + 1);
+  };
+  auto yhollow = [] __device__(int _tiy, int unit) -> int {
+    return unit * (_tiy);
+  };
+  auto zhollow = [] __device__(int _tiz, int unit) -> int {
+    return unit * (_tiz);
+  };
+
+  auto xhollow_reverse = [] __device__(int _tix, int unit) -> int {
+    return unit * (_tix * 2 + 1);
+  };
+  auto yhollow_reverse = [] __device__(int _tiy, int unit) -> int {
+    return unit * (_tiy * 2);
+  };
+  auto zhollow_reverse = [] __device__(int _tiz, int unit) -> int {
+    return unit * (_tiz * 2);
+  };
+
+  constexpr auto COARSEN = true;
+  constexpr auto NO_COARSEN = false;
+  constexpr auto BORDER_INCLUSIVE = true;
+  constexpr auto BORDER_EXCLUSIVE = false;
+
+  FP cur_ebx2 = ebx2, cur_eb_r = eb_r;
+
+  auto calc_eb = [&](auto unit) {
+    cur_ebx2 = ebx2, cur_eb_r = eb_r;
+    int temp = 1;
+    while (temp < unit) {
+      temp *= 2;
+      cur_eb_r *= intp_param.alpha;
+      cur_ebx2 /= intp_param.alpha;
     }
-   // if(BIX==0 and BIY==0 and BIZ==0)
-   // printf("lv3\n");
-
-    unit = 2;
-    calc_eb(unit);
-    //set_orders(reverse[1]);
-
-    // iteration 2, TODO switch y-z order
-    if(intp_param.reverse[1]){
-        interpolate_stage<
-            T1, T2, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
-            false, false, true, LINEAR_BLOCK_SIZE, 8, 3, NO_COARSEN, 3, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[0]);
-        interpolate_stage<
-            T1, T2, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
-            false, true, false, LINEAR_BLOCK_SIZE, 17, 2, NO_COARSEN, 3, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[1]);
-        interpolate_stage<
-            T1, T2, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
-            true, false, false, LINEAR_BLOCK_SIZE, 17, 5, NO_COARSEN, 2, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xblue_reverse, yblue_reverse, zblue_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[2]);
+    if (cur_ebx2 < ebx2 / intp_param.beta) {
+      cur_ebx2 = ebx2 / intp_param.beta;
+      cur_eb_r = eb_r * intp_param.beta;
     }
-    else{
-        interpolate_stage<
-            T1, T2, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
-            true, false, false, LINEAR_BLOCK_SIZE, 9, 3, NO_COARSEN, 2, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xblue, yblue, zblue, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[0]);
-        interpolate_stage<
-            T1, T2, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
-            false, true, false, LINEAR_BLOCK_SIZE, 9, 2, NO_COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xyellow, yyellow, zyellow, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[1]);
-        interpolate_stage<
-            T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
-            false, false, true, LINEAR_BLOCK_SIZE, 8, 5, NO_COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xhollow, yhollow, zhollow, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[2]);
+  };
 
-    }
-    //if(TIX==0 and TIY==0 and TIZ==0 and BIX==0 and BIY==0 and BIZ==0)
-    //printf("lv2\n");
-    unit = 1;
-    calc_eb(unit);
-   // set_orders(reverse[0]);
+  // iteration 1
+  /*
+  auto colors_0={false,false,false};
+  auto colors_1={false,false,false};
+  auto colors_2={false,false,false};
+  //auto interp_orders={0,1,2};
 
-    // iteration 3
-    if(intp_param.reverse[0]){
-        //may have bug 
-        interpolate_stage<
-            T1, T2, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
-            false, false, true, LINEAR_BLOCK_SIZE, 16, 5, COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[0]);
-        interpolate_stage<
-            T1, T2, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
-            false, true, false, LINEAR_BLOCK_SIZE, 33, 4, COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[1]);
-        interpolate_stage<
-            T1, T2, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
-            true, false, false, LINEAR_BLOCK_SIZE, 33, 9, COARSEN, 4, BORDER_EXCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xblue_reverse, yblue_reverse, zblue_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[2]);
+  auto set_orders [&](auto reverse){
+      colors_0={false,false,false};
+      colors_1={false,false,false};
+      colors_2={false,false,false};
+      auto interp_orders={0,1,2};
+      if (reverse)
+          interp_orders={2,1,0};
+      colors_0[interp_orders[0]]=true;
+      colors_1[interp_orders[1]]=true;
+      colors_2[interp_orders[2]]=true;
 
-        //may have bug end
-    }
-    else{
-        interpolate_stage<
-            T1, T2, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
-            true, false, false, LINEAR_BLOCK_SIZE, 17, 5, COARSEN, 4, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xblue, yblue, zblue, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[0]);
-        interpolate_stage<
-            T1, T2, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
-            false, true, false, LINEAR_BLOCK_SIZE, 17, 4, COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xyellow, yyellow, zyellow, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[1]);
-       
-        interpolate_stage<
-            T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
-            false, false, true, LINEAR_BLOCK_SIZE, 16, 9, COARSEN, 9, BORDER_EXCLUSIVE, WORKFLOW>(
-            s_data, s_ectrl,data_size, xhollow, yhollow, zhollow, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[2]);
+  }
+  */
 
-    }
+  int unit = 4;
+  calc_eb(unit);
+  // set_orders(reverse[2]);
+  if (intp_param.reverse[2]) {
+    interpolate_stage<
+        T1, T2, FP, decltype(xhollow_reverse), decltype(yhollow_reverse),
+        decltype(zhollow_reverse),  //
+        false, false, true, LINEAR_BLOCK_SIZE, 4, 2, NO_COARSEN, 2,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xhollow_reverse, yhollow_reverse,
+        zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius,
+        intp_param.interpolators[0]);
+
+    interpolate_stage<
+        T1, T2, FP, decltype(xyellow_reverse), decltype(yyellow_reverse),
+        decltype(zyellow_reverse),  //
+        false, true, false, LINEAR_BLOCK_SIZE, 9, 1, NO_COARSEN, 2,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xyellow_reverse, yyellow_reverse,
+        zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius,
+        intp_param.interpolators[1]);
+    interpolate_stage<
+        T1, T2, FP, decltype(xblue_reverse), decltype(yblue_reverse),
+        decltype(zblue_reverse),  //
+        true, false, false, LINEAR_BLOCK_SIZE, 9, 3, NO_COARSEN, 1,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xblue_reverse, yblue_reverse,
+        zblue_reverse, unit, cur_eb_r, cur_ebx2, radius,
+        intp_param.interpolators[2]);
+  }
+  else {
+    // if( BIX==0 and BIY==0 and BIZ==0)
+    // printf("lv3s0\n");
+    interpolate_stage<
+        T1, T2, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+        true, false, false, LINEAR_BLOCK_SIZE, 5, 2, NO_COARSEN, 1,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xblue, yblue, zblue, unit, cur_eb_r,
+        cur_ebx2, radius, intp_param.interpolators[0]);
+    // if(BIX==0 and BIY==0 and BIZ==0)
+    // printf("lv3s1\n");
+    interpolate_stage<
+        T1, T2, FP, decltype(xyellow), decltype(yyellow),
+        decltype(zyellow),  //
+        false, true, false, LINEAR_BLOCK_SIZE, 5, 1, NO_COARSEN, 3,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xyellow, yyellow, zyellow, unit, cur_eb_r,
+        cur_ebx2, radius, intp_param.interpolators[1]);
+    // if(BIX==0 and BIY==0 and BIZ==0)
+    //  printf("lv3s2\n");
+    interpolate_stage<
+        T1, T2, FP, decltype(xhollow), decltype(yhollow),
+        decltype(zhollow),  //
+        false, false, true, LINEAR_BLOCK_SIZE, 4, 3, NO_COARSEN, 3,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xhollow, yhollow, zhollow, unit, cur_eb_r,
+        cur_ebx2, radius, intp_param.interpolators[2]);
+  }
+  // if(BIX==0 and BIY==0 and BIZ==0)
+  // printf("lv3\n");
+
+  unit = 2;
+  calc_eb(unit);
+  // set_orders(reverse[1]);
+
+  // iteration 2, TODO switch y-z order
+  if (intp_param.reverse[1]) {
+    interpolate_stage<
+        T1, T2, FP, decltype(xhollow_reverse), decltype(yhollow_reverse),
+        decltype(zhollow_reverse),  //
+        false, false, true, LINEAR_BLOCK_SIZE, 8, 3, NO_COARSEN, 3,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xhollow_reverse, yhollow_reverse,
+        zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius,
+        intp_param.interpolators[0]);
+    interpolate_stage<
+        T1, T2, FP, decltype(xyellow_reverse), decltype(yyellow_reverse),
+        decltype(zyellow_reverse),  //
+        false, true, false, LINEAR_BLOCK_SIZE, 17, 2, NO_COARSEN, 3,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xyellow_reverse, yyellow_reverse,
+        zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius,
+        intp_param.interpolators[1]);
+    interpolate_stage<
+        T1, T2, FP, decltype(xblue_reverse), decltype(yblue_reverse),
+        decltype(zblue_reverse),  //
+        true, false, false, LINEAR_BLOCK_SIZE, 17, 5, NO_COARSEN, 2,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xblue_reverse, yblue_reverse,
+        zblue_reverse, unit, cur_eb_r, cur_ebx2, radius,
+        intp_param.interpolators[2]);
+  }
+  else {
+    interpolate_stage<
+        T1, T2, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+        true, false, false, LINEAR_BLOCK_SIZE, 9, 3, NO_COARSEN, 2,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xblue, yblue, zblue, unit, cur_eb_r,
+        cur_ebx2, radius, intp_param.interpolators[0]);
+    interpolate_stage<
+        T1, T2, FP, decltype(xyellow), decltype(yyellow),
+        decltype(zyellow),  //
+        false, true, false, LINEAR_BLOCK_SIZE, 9, 2, NO_COARSEN, 5,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xyellow, yyellow, zyellow, unit, cur_eb_r,
+        cur_ebx2, radius, intp_param.interpolators[1]);
+    interpolate_stage<
+        T1, T2, FP, decltype(xhollow), decltype(yhollow),
+        decltype(zhollow),  //
+        false, false, true, LINEAR_BLOCK_SIZE, 8, 5, NO_COARSEN, 5,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xhollow, yhollow, zhollow, unit, cur_eb_r,
+        cur_ebx2, radius, intp_param.interpolators[2]);
+  }
+  // if(TIX==0 and TIY==0 and TIZ==0 and BIX==0 and BIY==0 and BIZ==0)
+  // printf("lv2\n");
+  unit = 1;
+  calc_eb(unit);
+  // set_orders(reverse[0]);
+
+  // iteration 3
+  if (intp_param.reverse[0]) {
+    // may have bug
+    interpolate_stage<
+        T1, T2, FP, decltype(xhollow_reverse), decltype(yhollow_reverse),
+        decltype(zhollow_reverse),  //
+        false, false, true, LINEAR_BLOCK_SIZE, 16, 5, COARSEN, 5,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xhollow_reverse, yhollow_reverse,
+        zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius,
+        intp_param.interpolators[0]);
+    interpolate_stage<
+        T1, T2, FP, decltype(xyellow_reverse), decltype(yyellow_reverse),
+        decltype(zyellow_reverse),  //
+        false, true, false, LINEAR_BLOCK_SIZE, 33, 4, COARSEN, 5,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xyellow_reverse, yyellow_reverse,
+        zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius,
+        intp_param.interpolators[1]);
+    interpolate_stage<
+        T1, T2, FP, decltype(xblue_reverse), decltype(yblue_reverse),
+        decltype(zblue_reverse),  //
+        true, false, false, LINEAR_BLOCK_SIZE, 33, 9, COARSEN, 4,
+        BORDER_EXCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xblue_reverse, yblue_reverse,
+        zblue_reverse, unit, cur_eb_r, cur_ebx2, radius,
+        intp_param.interpolators[2]);
+
+    // may have bug end
+  }
+  else {
+    interpolate_stage<
+        T1, T2, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+        true, false, false, LINEAR_BLOCK_SIZE, 17, 5, COARSEN, 4,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xblue, yblue, zblue, unit, cur_eb_r,
+        cur_ebx2, radius, intp_param.interpolators[0]);
+    interpolate_stage<
+        T1, T2, FP, decltype(xyellow), decltype(yyellow),
+        decltype(zyellow),  //
+        false, true, false, LINEAR_BLOCK_SIZE, 17, 4, COARSEN, 9,
+        BORDER_INCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xyellow, yyellow, zyellow, unit, cur_eb_r,
+        cur_ebx2, radius, intp_param.interpolators[1]);
+
+    interpolate_stage<
+        T1, T2, FP, decltype(xhollow), decltype(yhollow),
+        decltype(zhollow),  //
+        false, false, true, LINEAR_BLOCK_SIZE, 16, 9, COARSEN, 9,
+        BORDER_EXCLUSIVE, WORKFLOW>(
+        s_data, s_ectrl, data_size, xhollow, yhollow, zhollow, unit, cur_eb_r,
+        cur_ebx2, radius, intp_param.interpolators[2]);
+  }
   //  if(TIX==0 and TIY==0 and TIZ==0 and BIX==0 and BIY==0 and BIZ==0)
-   // printf("lv1\n");
-    
+  // printf("lv1\n");
 
+  /******************************************************************************
+  test only: last step inclusive
+  ******************************************************************************/
+  // interpolate_stage<
+  //     T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),
+  //     // false, false, true, LINEAR_BLOCK_SIZE, 33, 4, COARSEN, 9,
+  //     BORDER_INCLUSIVE, WORKFLOW>( s_data, s_ectrl, xhollow, yhollow,
+  //     zhollow, unit, eb_r, ebx2, radius);
+  /******************************************************************************
+   production
+   ******************************************************************************/
 
-     /******************************************************************************
-     test only: last step inclusive
-     ******************************************************************************/
-    // interpolate_stage<
-    //     T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
-    //     false, false, true, LINEAR_BLOCK_SIZE, 33, 4, COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
-    //     s_data, s_ectrl, xhollow, yhollow, zhollow, unit, eb_r, ebx2, radius);
-    /******************************************************************************
-     production
-     ******************************************************************************/
-
-    /******************************************************************************
-     test only: print a block
-     ******************************************************************************/
-    // if (TIX == 0 and BIX == 7 and BIY == 47 and BIZ == 15) { spline3d_print_block_from_GPU(s_ectrl); }
-   //  if (TIX == 0 and BIX == 4 and BIY == 20 and BIZ == 20) { spline3d_print_block_from_GPU(s_data); }
+  /******************************************************************************
+   test only: print a block
+   ******************************************************************************/
+  // if (TIX == 0 and BIX == 7 and BIY == 47 and BIZ == 15) {
+  // spline3d_print_block_from_GPU(s_ectrl); }
+  //  if (TIX == 0 and BIX == 4 and BIY == 20 and BIZ == 20) {
+  //  spline3d_print_block_from_GPU(s_data); }
 }
 
 /********************************************************************************
@@ -1285,234 +1490,209 @@ __device__ void cusz::device_api::spline3d_layout2_interpolate(
  ********************************************************************************/
 template <typename TITER, int LINEAR_BLOCK_SIZE>
 __global__ void cusz::c_spline3d_profiling_16x16x16data(
-    TITER   data,
-    DIM3    data_size,
-    STRIDE3 data_leap,
-    TITER errors)
+    TITER data, DIM3 data_size, STRIDE3 data_leap, TITER errors)
 {
-    // compile time variables
-    using T = typename std::remove_pointer<TITER>::type;
- 
+  // compile time variables
+  using T = typename std::remove_pointer<TITER>::type;
 
-    {
-        __shared__ struct {
-            T data[16][16][16];
-            T local_errs[2];
-           // T global_errs[6];
-        } shmem;
+  {
+    __shared__ struct {
+      T data[16][16][16];
+      T local_errs[2];
+      // T global_errs[6];
+    } shmem;
 
+    c_reset_scratch_profiling_16x16x16data<T, LINEAR_BLOCK_SIZE>(
+        shmem.data, 0.0);
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+    //     printf("reset\n");
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+    //     printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
 
-        c_reset_scratch_profiling_16x16x16data<T, LINEAR_BLOCK_SIZE>(shmem.data, 0.0);
-        //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-        //    printf("reset\n");
-        //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-        //    printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
+    global2shmem_profiling_16x16x16data<T, T, LINEAR_BLOCK_SIZE>(
+        data, data_size, data_leap, shmem.data);
 
-        global2shmem_profiling_16x16x16data<T, T, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data);
+    // if (TIX < 6 and BIX==0 and BIY==0 and BIZ==0) errors[TIX] = 0.0;//risky
 
+    //__syncthreads();
 
-
-     
-
-        //if (TIX < 6 and BIX==0 and BIY==0 and BIZ==0) errors[TIX] = 0.0;//risky
-
-        //__syncthreads();
-       
-
-        cusz::device_api::auto_tuning<T,LINEAR_BLOCK_SIZE>(
-            shmem.data, shmem.local_errs, data_size, errors);
-        //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-        //    printf("device %.4f %.4f\n",errors[0],errors[1]);
-
-        
-    }
+    cusz::device_api::auto_tuning<T, LINEAR_BLOCK_SIZE>(
+        shmem.data, shmem.local_errs, data_size, errors);
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+    //     printf("device %.4f %.4f\n",errors[0],errors[1]);
+  }
 }
 
 template <typename TITER, int LINEAR_BLOCK_SIZE>
 __global__ void cusz::c_spline3d_profiling_data_2(
-    TITER   data,
-    DIM3    data_size,
-    STRIDE3 data_leap,
-    TITER errors)
+    TITER data, DIM3 data_size, STRIDE3 data_leap, TITER errors)
 {
-    // compile time variables
-    using T = typename std::remove_pointer<TITER>::type;
- 
+  // compile time variables
+  using T = typename std::remove_pointer<TITER>::type;
 
-    {
-        __shared__ struct {
-            T data[64];
-            T neighbor_x [64][4];
-            T neighbor_y [64][4];
-            T neighbor_z [64][4];
-            T local_errs[6];
-           // T global_errs[6];
-        } shmem;
+  {
+    __shared__ struct {
+      T data[64];
+      T neighbor_x[64][4];
+      T neighbor_y[64][4];
+      T neighbor_z[64][4];
+      T local_errs[6];
+      // T global_errs[6];
+    } shmem;
 
+    c_reset_scratch_profiling_data_2<T, LINEAR_BLOCK_SIZE>(
+        shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z, 0.0);
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+    //     printf("reset\n");
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+    //     printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
 
-        c_reset_scratch_profiling_data_2<T, LINEAR_BLOCK_SIZE>(shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z,0.0);
-        //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-        //    printf("reset\n");
-        //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-        //    printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
+    global2shmem_profiling_data_2<T, T, LINEAR_BLOCK_SIZE>(
+        data, data_size, data_leap, shmem.data, shmem.neighbor_x,
+        shmem.neighbor_y, shmem.neighbor_z);
 
-        global2shmem_profiling_data_2<T, T, LINEAR_BLOCK_SIZE>(data, data_size, data_leap,shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z);
+    if (TIX < 6 and BIX == 0 and BIY == 0 and BIZ == 0)
+      errors[TIX] = 0.0;  // risky
 
+    //__syncthreads();
 
-
-     
-
-        if (TIX < 6 and BIX==0 and BIY==0 and BIZ==0) errors[TIX] = 0.0;//risky
-
-        //__syncthreads();
-       
-
-        cusz::device_api::auto_tuning_2<T,LINEAR_BLOCK_SIZE>(
-            shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z, shmem.local_errs, data_size, errors);
-
-        
-    }
-}
-
-
-template <typename TITER, typename EITER, typename FP, int LINEAR_BLOCK_SIZE, typename CompactVal, typename CompactIdx, typename CompactNum>
-__global__ void cusz::c_spline3d_infprecis_32x8x8data(
-    TITER   data,
-    DIM3    data_size,
-    STRIDE3 data_leap,
-    EITER   ectrl,
-    DIM3    ectrl_size,
-    STRIDE3 ectrl_leap,
-    TITER   anchor,
-    STRIDE3 anchor_leap,
-    CompactVal compact_val,
-    CompactIdx compact_idx,
-    CompactNum compact_num,
-    FP      eb_r,
-    FP      ebx2,
-    int     radius,
-    INTERPOLATION_PARAMS intp_param//,
-    //TITER errors
-    )
-{
-    // compile time variables
-    using T = typename std::remove_pointer<TITER>::type;
-    using E = typename std::remove_pointer<EITER>::type;
-
-    {
-        __shared__ struct {
-            T data[9][9][33];
-            T ectrl[9][9][33];
-
-           // T global_errs[6];
-        } shmem;
-
-       // T cubic_errors=errors[0]+errors[2]+errors[4];
-       // T linear_errors=errors[1]+errors[3]+errors[5];
-     // bool do_cubic=(cubic_errors<=linear_errors);
-      //intp_param.interpolators[0]=(errors[0]>errors[1]);
-      //intp_param.interpolators[1]=(errors[2]>errors[3]);
-      //intp_param.interpolators[2]=(errors[4]>errors[5]);
-      
-      //bool do_reverse=(errors[4+intp_param.interpolators[2]]>errors[intp_param.interpolators[0]]);
-        /*
-        if(intp_param.auto_tuning){
-            bool do_reverse=(errors[1]>3*errors[0]);
-           intp_param.reverse[0]=intp_param.reverse[1]=intp_param.reverse[2]=do_reverse;
-       }
-       */
-    /*
-       if(TIX==0 and BIX==0 and BIY==0 and BIZ==0){
-        printf("Errors: %.6f %.6f \n",errors[0],errors[1]);
-        printf("Cubic: %d %d %d\n",intp_param.interpolators[0],intp_param.interpolators[1],intp_param.interpolators[2]);
-        printf("reverse: %d %d %d\n",intp_param.reverse[0],intp_param.reverse[1],intp_param.reverse[2]);
-       }
-       */
-        
-
-        c_reset_scratch_33x9x9data<T, T, LINEAR_BLOCK_SIZE>(shmem.data, shmem.ectrl, radius);
-        //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-        //    printf("reset\n");
-        //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-        //    printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
-
-        global2shmem_33x9x9data<T, T, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data);
-
-       // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-        //    printf("g2s\n");
-        // version 1, use shmem, erroneous
-        // c_gather_anchor<T>(shmem.data, anchor, anchor_leap);
-        // version 2, use global mem, correct
-        c_gather_anchor<T>(data, data_size, data_leap, anchor, anchor_leap);
-
-
-       
-
-
-        cusz::device_api::spline3d_layout2_interpolate<T, T, FP,LINEAR_BLOCK_SIZE, SPLINE3_COMPR, false>(
-            shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
-        
-        
-
-        //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-        //    printf("interp\n");
-        //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-         //   printf("esz: %d %d %d\n",ectrl_size.x,ectrl_size.y,ectrl_size.z);
-
-
-        //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-
-        shmem2global_32x8x8data_with_compaction<T, E, LINEAR_BLOCK_SIZE>(shmem.ectrl, ectrl, ectrl_size, ectrl_leap, radius, compact_val, compact_idx, compact_num);
-
-        // shmem2global_32x8x8data<T, E, LINEAR_BLOCK_SIZE>(shmem.ectrl, ectrl, ectrl_size, ectrl_leap);
-
-        //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-        //    printf("s2g\n");
-    }
+    cusz::device_api::auto_tuning_2<T, LINEAR_BLOCK_SIZE>(
+        shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z,
+        shmem.local_errs, data_size, errors);
+  }
 }
 
 template <
-    typename EITER,
-    typename TITER,
-    typename FP,
-    int LINEAR_BLOCK_SIZE>
-__global__ void cusz::x_spline3d_infprecis_32x8x8data(
-    EITER   ectrl,        // input 1
-    DIM3    ectrl_size,   //
-    STRIDE3 ectrl_leap,   //
-    TITER   anchor,       // input 2
-    DIM3    anchor_size,  //
-    STRIDE3 anchor_leap,  //
-    TITER   data,         // output
-    DIM3    data_size,    //
-    STRIDE3 data_leap,    //
-    FP      eb_r,
-    FP      ebx2,
-    int     radius,
-    INTERPOLATION_PARAMS intp_param)
+    typename TITER, typename EITER, typename FP, int LINEAR_BLOCK_SIZE,
+    typename CompactVal, typename CompactIdx, typename CompactNum>
+__global__ void cusz::c_spline3d_infprecis_32x8x8data(
+    TITER data, DIM3 data_size, STRIDE3 data_leap, EITER ectrl,
+    DIM3 ectrl_size, STRIDE3 ectrl_leap, TITER anchor, STRIDE3 anchor_leap,
+    CompactVal compact_val, CompactIdx compact_idx, CompactNum compact_num,
+    FP eb_r, FP ebx2, int radius,
+    INTERPOLATION_PARAMS intp_param  //,
+    // TITER errors
+)
 {
-    // compile time variables
-    using E = typename std::remove_pointer<EITER>::type;
-    using T = typename std::remove_pointer<TITER>::type;
+  // compile time variables
+  using T = typename std::remove_pointer<TITER>::type;
+  using E = typename std::remove_pointer<EITER>::type;
 
+  {
     __shared__ struct {
-        T data[9][9][33];
-        T ectrl[9][9][33];
+      T data[9][9][33];
+      T ectrl[9][9][33];
+
+      // T global_errs[6];
     } shmem;
 
-    x_reset_scratch_33x9x9data<T, T, LINEAR_BLOCK_SIZE>(shmem.data, shmem.ectrl, anchor, anchor_size, anchor_leap);
+    // T cubic_errors=errors[0]+errors[2]+errors[4];
+    // T linear_errors=errors[1]+errors[3]+errors[5];
+    // bool do_cubic=(cubic_errors<=linear_errors);
+    // intp_param.interpolators[0]=(errors[0]>errors[1]);
+    // intp_param.interpolators[1]=(errors[2]>errors[3]);
+    // intp_param.interpolators[2]=(errors[4]>errors[5]);
 
-    //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-    //        printf("esz: %d %d %d\n",ectrl_size.x,ectrl_size.y,ectrl_size.z);
+    // bool
+    // do_reverse=(errors[4+intp_param.interpolators[2]]>errors[intp_param.interpolators[0]]);
+    /*
+    if(intp_param.auto_tuning){
+        bool do_reverse=(errors[1]>3*errors[0]);
+       intp_param.reverse[0]=intp_param.reverse[1]=intp_param.reverse[2]=do_reverse;
+   }
+   */
+    /*
+       if(TIX==0 and BIX==0 and BIY==0 and BIZ==0){
+        printf("Errors: %.6f %.6f \n",errors[0],errors[1]);
+        printf("Cubic: %d %d
+       %d\n",intp_param.interpolators[0],intp_param.interpolators[1],intp_param.interpolators[2]);
+        printf("reverse: %d %d
+       %d\n",intp_param.reverse[0],intp_param.reverse[1],intp_param.reverse[2]);
+       }
+       */
 
-    // global2shmem_33x9x9data<E, T, LINEAR_BLOCK_SIZE>(ectrl, ectrl_size, ectrl_leap, shmem.ectrl);
-    global2shmem_fuse<T, E, LINEAR_BLOCK_SIZE>(ectrl, ectrl_size, ectrl_leap, data, shmem.ectrl);
+    c_reset_scratch_33x9x9data<T, T, LINEAR_BLOCK_SIZE>(
+        shmem.data, shmem.ectrl, radius);
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+    //     printf("reset\n");
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+    //     printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
 
-    cusz::device_api::spline3d_layout2_interpolate<T, T, FP, LINEAR_BLOCK_SIZE, SPLINE3_DECOMPR, false>(
+    global2shmem_33x9x9data<T, T, LINEAR_BLOCK_SIZE>(
+        data, data_size, data_leap, shmem.data);
+
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+    //    printf("g2s\n");
+    // version 1, use shmem, erroneous
+    // c_gather_anchor<T>(shmem.data, anchor, anchor_leap);
+    // version 2, use global mem, correct
+    c_gather_anchor<T>(data, data_size, data_leap, anchor, anchor_leap);
+
+    cusz::device_api::spline3d_layout2_interpolate<
+        T, T, FP, LINEAR_BLOCK_SIZE, SPLINE3_COMPR, false>(
         shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
-    //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
-    //        printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
-    shmem2global_32x8x8data<T, T, LINEAR_BLOCK_SIZE>(shmem.data, data, data_size, data_leap);
+
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+    //     printf("interp\n");
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+    //    printf("esz: %d %d %d\n",ectrl_size.x,ectrl_size.y,ectrl_size.z);
+
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+
+    shmem2global_32x8x8data_with_compaction<T, E, LINEAR_BLOCK_SIZE>(
+        shmem.ectrl, ectrl, ectrl_size, ectrl_leap, radius, compact_val,
+        compact_idx, compact_num);
+
+    // shmem2global_32x8x8data<T, E, LINEAR_BLOCK_SIZE>(shmem.ectrl, ectrl,
+    // ectrl_size, ectrl_leap);
+
+    // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+    //     printf("s2g\n");
+  }
+}
+
+template <
+    typename EITER, typename TITER, typename FP,
+    int LINEAR_BLOCK_SIZE>
+__global__ void cusz::x_spline3d_infprecis_32x8x8data(
+    EITER ectrl,          // input 1
+    DIM3 ectrl_size,      //
+    STRIDE3 ectrl_leap,   //
+    TITER anchor,         // input 2
+    DIM3 anchor_size,     //
+    STRIDE3 anchor_leap,  //
+    TITER data,           // output
+    DIM3 data_size,       //
+    STRIDE3 data_leap,    //
+    FP eb_r, FP ebx2, int radius, INTERPOLATION_PARAMS intp_param)
+{
+  // compile time variables
+  using E = typename std::remove_pointer<EITER>::type;
+  using T = typename std::remove_pointer<TITER>::type;
+
+  __shared__ struct {
+    T data[9][9][33];
+    T ectrl[9][9][33];
+  } shmem;
+
+  x_reset_scratch_33x9x9data<T, T, LINEAR_BLOCK_SIZE>(
+      shmem.data, shmem.ectrl, anchor, anchor_size, anchor_leap);
+
+  // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+  //         printf("esz: %d %d %d\n",ectrl_size.x,ectrl_size.y,ectrl_size.z);
+
+  // global2shmem_33x9x9data<E, T, LINEAR_BLOCK_SIZE>(ectrl, ectrl_size,
+  // ectrl_leap, shmem.ectrl);
+  global2shmem_fuse<T, E, LINEAR_BLOCK_SIZE>(
+      ectrl, ectrl_size, ectrl_leap, data, shmem.ectrl);
+
+  cusz::device_api::spline3d_layout2_interpolate<
+      T, T, FP, LINEAR_BLOCK_SIZE, SPLINE3_DECOMPR, false>(
+      shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
+  // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+  //         printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
+  shmem2global_32x8x8data<T, T, LINEAR_BLOCK_SIZE>(
+      shmem.data, data, data_size, data_leap);
 }
 
 #undef TIX

--- a/src/kernel/detail/spline3_debug.inl
+++ b/src/kernel/detail/spline3_debug.inl
@@ -1,0 +1,104 @@
+auto input_x = x;
+auto input_BI = BIX;
+auto input_GD = GDX;
+auto input_gx = global_x;
+auto input_gs = data_size.x;
+int global_start_ = global_starts.x;
+int p1 = -1, p2 = 9, p3 = 9, p4 = -1, p5 = 16;
+if(interpolator==0){
+    p1 = -3, p2 = 23, p3 = 23, p4 = -3, p5 = 40;
+}
+if CONSTEXPR (BLUE){
+    input_x = z;
+    input_BI = BIZ;
+    input_GD = GDZ;
+    input_gx = global_z;
+    input_gs = data_size.z;
+    global_start_ = global_starts.z;
+}
+if CONSTEXPR (YELLOW){
+    input_x = y;
+    input_BI = BIY;
+    input_GD = GDY;
+    input_gx = global_y;
+    input_gs = data_size.y;
+    global_start_ = global_starts.y;
+}
+
+int id_[4], s_id[4];
+id_[0] =  input_x - 3 * unit;
+id_[0] =  id_[0] >= 0 ? id_[0] : 0;
+
+id_[1] = input_x - unit;
+id_[1] = id_[1] >= 0 ? id_[1] : 0;
+
+id_[2] = input_x + unit;
+id_[2] = id_[2] < 17 ? id_[2] : 0;
+
+id_[3] = input_x + 3 * unit;
+id_[3] = id_[3] < 17 ? id_[3] : 0;
+
+s_id[0] = 17 * 17 * z + 17 * y + id_[0];
+s_id[1] = 17 * 17 * z + 17 * y + id_[1];
+s_id[2] = 17 * 17 * z + 17 * y + id_[2];
+s_id[3] = 17 * 17 * z + 17 * y + id_[3];
+if CONSTEXPR (BLUE){
+s_id[0] = 17 * 17 * id_[0] + 17 * y + x;
+s_id[1] = 17 * 17 * id_[1] + 17 * y + x;
+s_id[2] = 17 * 17 * id_[2] + 17 * y + x;
+s_id[3] = 17 * 17 * id_[3] + 17 * y + x;
+}
+if CONSTEXPR (YELLOW){
+    s_id[0] = 17 * 17 * z + 17 * id_[0] + x;
+    s_id[1] = 17 * 17 * z + 17 * id_[1] + x;
+    s_id[2] = 17 * 17 * z + 17 * id_[2] + x;
+    s_id[3] = 17 * 17 * z + 17 * id_[3] + x;
+}
+
+T tmp_[4];
+
+bool case1 = (global_start_ + BLOCK16 < input_gs);
+bool case2 = (input_x >= 3 * unit);
+bool case3 = (input_x + 3 * unit <= BLOCK16);
+bool case4 = (input_gx + 3 * unit < input_gs);
+bool case5 = (input_gx + unit < input_gs);
+
+
+// tmp_[1] = *((T*)s_data + s_id[1]); 
+// pred = tmp_[1];
+
+// tmp_[2] = *((T*)s_data + s_id[2]); 
+// pred = ((case1 && !case2 && !case3) || (!case1 && !case2 && !(case3 && case4) && case5)) ? (tmp_[1] + tmp_[2]) / 2 : pred;
+
+// tmp_[3] = *((T*)s_data + s_id[3]); 
+
+// pred = ((case1 && !case2 && case3) || (!case1 && !case2 && case3 && case4)) ? (3*tmp_[1] + 6*tmp_[2]-tmp_[3]) / 8 : pred;
+
+// tmp_[0] = *((T*)s_data + s_id[0]); 
+// pred = ((case1 && case2 && !case3) || (!case1 && case2 && !(case3 && case4) && case5)) ? (-tmp_[0]+6*tmp_[1] + 3*tmp_[2]) / 8 : pred;
+
+// pred = ((case1 && case2 && case3) || (!case1 && case2 && case3 && case4)) ? (p1*tmp_[0] + p2 * tmp_[1] + p3 * tmp_[2] + p4 * tmp_[3]) / p5 : pred;
+
+
+// 预加载 shared memory 数据到寄存器
+T tmp0 = *((T*)s_data + s_id[0]); 
+T tmp1 = *((T*)s_data + s_id[1]); 
+T tmp2 = *((T*)s_data + s_id[2]); 
+T tmp3 = *((T*)s_data + s_id[3]); 
+
+// 初始预测值
+pred = tmp1;
+
+// 计算不同 case 对应的 pred
+if ((case1 && !case2 && !case3) || (!case1 && !case2 && !(case3 && case4) && case5)) {
+    pred = (tmp1 + tmp2) / 2;
+}
+else if ((case1 && !case2 && case3) || (!case1 && !case2 && case3 && case4)) {
+    pred = (3 * tmp1 + 6 * tmp2 - tmp3) / 8;
+}
+else if ((case1 && case2 && !case3) || (!case1 && case2 && !(case3 && case4) && case5)) {
+    pred = (-tmp0 + 6 * tmp1 + 3 * tmp2) / 8;
+}
+else if ((case1 && case2 && case3) || (!case1 && case2 && case3 && case4)) {
+    pred = (p1 * tmp0 + p2 * tmp1 + p3 * tmp2 + p4 * tmp3) / p5;
+}

--- a/src/kernel/detail/spline3_md.inl
+++ b/src/kernel/detail/spline3_md.inl
@@ -1,0 +1,2917 @@
+ /**
+ * @file spline3.inl
+ * @author Jinyang Liu, Shixun Wu, Jiannan Tian
+ * @brief
+ * @version 0.2
+ * @date 2021-05-15
+ *
+ * (copyright to be updated)
+ * (C) 2021 by Washington State University, Argonne National Laboratory
+ *
+ */
+
+#ifndef CUSZ_KERNEL_SPLINE3_CUH
+#define CUSZ_KERNEL_SPLINE3_CUH
+
+#include <stdint.h>
+#include <stdio.h>
+#include <type_traits>
+#include "cusz/type.h"
+#include "utils/err.hh"
+#include "utils/timer.hh"
+
+#define SPLINE3_COMPR true
+#define SPLINE3_DECOMPR false
+
+#define SPLINE3_PRED_ATT true
+#define SPLINE3_AB_ATT false
+
+#if __cplusplus >= 201703L
+#define CONSTEXPR constexpr
+#else
+#define CONSTEXPR
+#endif
+
+#define TIX threadIdx.x
+#define TIY threadIdx.y
+#define TIZ threadIdx.z
+#define BIX blockIdx.x
+#define BIY blockIdx.y
+#define BIZ blockIdx.z
+#define BDX blockDim.x
+#define BDY blockDim.y
+#define BDZ blockDim.z
+#define GDX gridDim.x
+#define GDY gridDim.y
+#define GDZ gridDim.z
+
+using DIM     = u4;
+using STRIDE  = u4;
+using DIM3    = dim3;
+using STRIDE3 = dim3;
+#define BLOCK_DIM_SIZE 384
+
+constexpr int BLOCK16 = 16;
+constexpr int BLOCK17 = 17;
+constexpr int DEFAULT_LINEAR_BLOCK_SIZE = BLOCK_DIM_SIZE;
+
+#define SHM_ERROR s_ectrl
+
+namespace cusz {
+
+/********************************************************************************
+ * host API
+ ********************************************************************************/
+template <typename TITER, int SPLINE_DIM,
+int PROFILE_BLOCK_SIZE_X,
+int PROFILE_BLOCK_SIZE_Y,
+int PROFILE_BLOCK_SIZE_Z,
+int PROFILE_NUM_BLOCK_X,
+int PROFILE_NUM_BLOCK_Y,
+int PROFILE_NUM_BLOCK_Z,
+int  LINEAR_BLOCK_SIZE>
+__global__ void c_spline_profiling_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    TITER errors);
+
+template <typename TITER, int SPLINE_DIM,
+int PROFILE_NUM_BLOCK_X,
+int PROFILE_NUM_BLOCK_Y,
+int PROFILE_NUM_BLOCK_Z,
+int  LINEAR_BLOCK_SIZE>
+__global__ void c_spline_profiling_data_2(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    TITER errors);
+
+template <
+    typename TITER,
+    typename EITER,
+    typename FP            = float,
+    int LEVEL = 4,
+    int SPLINE_DIM = 2,
+    int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8,
+    int AnchorBlockSizeZ = 1,
+    int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+    int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+    int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+    int  LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE, 
+    typename CompactVal = TITER,
+    typename CompactIdx = uint32_t*,
+    typename CompactNum = uint32_t*>
+__global__ void c_spline_infprecis_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    EITER   ectrl,
+    DIM3    ectrl_size,
+    STRIDE3 ectrl_leap,
+    TITER   anchor,
+    STRIDE3 anchor_leap,
+    CompactVal cval,
+    CompactIdx cidx,
+    CompactNum cn,
+    FP      eb_r,
+    FP      ebx2,
+    int     radius,
+    INTERPOLATION_PARAMS intp_param,
+    TITER errors);
+
+template <
+    typename EITER,
+    typename TITER,
+    typename FP           = float,
+    int LEVEL = 4,
+    int SPLINE_DIM = 2,
+    int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8,
+    int AnchorBlockSizeZ = 1,
+    int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+    int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+    int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__global__ void x_spline_infprecis_data(
+    EITER   ectrl,        // input 1
+    DIM3    ectrl_size,   //
+    STRIDE3 ectrl_leap,   //
+    TITER   anchor,       // input 2
+    DIM3    anchor_size,  //
+    STRIDE3 anchor_leap,  //
+    TITER   data,         // output
+    DIM3    data_size,    //
+    STRIDE3 data_leap,    //
+    FP      eb_r,
+    FP      ebx2,
+    int     radius,
+    INTERPOLATION_PARAMS intp_param);
+
+template <typename TITER>
+__global__ void reset_errors(TITER errors);
+
+template <typename TITER, typename FP, 
+int LEVEL = 4,
+int SPLINE_DIM = 2,
+int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8,
+int AnchorBlockSizeZ = 1,
+int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__global__ void pa_spline_infprecis_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    DIM3 sample_starts,
+    DIM3 sample_block_grid_sizes,
+    DIM3 sample_strides,
+    FP      eb_r,
+    FP      ebx2,
+    INTERPOLATION_PARAMS intp_param,
+    TITER errors,
+    bool workflow = SPLINE3_PRED_ATT
+    );
+
+
+namespace device_api {
+/********************************************************************************
+ * device API
+ ********************************************************************************/
+    template <typename T, 
+    int SPLINE_DIM = 3,
+int PROFILE_BLOCK_SIZE_X = 4,
+int PROFILE_BLOCK_SIZE_Y = 4,
+int PROFILE_BLOCK_SIZE_Z = 4,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+    int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void auto_tuning(
+    volatile T s_data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z]       
+                    [PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X],  volatile T local_errs[6], DIM3  data_size, volatile T* count);
+
+ template <typename T, 
+ int SPLINE_DIM = 3,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+ int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void auto_tuning_2(
+    volatile T s_data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z], volatile T s_nx[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T s_ny[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T s_nz[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4],  volatile T local_errs[6], DIM3  data_size, volatile T* count);
+
+template <
+    typename T1,
+    typename T2,
+    typename FP,
+    int LEVEL, 
+    int SPLINE_DIM = 2,
+int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8,
+int AnchorBlockSizeZ = 1,
+int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE,
+    bool WORKFLOW         = SPLINE3_COMPR,
+    bool PROBE_PRED_ERROR = false>
+__device__ void
+spline_layout_interpolate(
+    volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]       
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)][AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)], 
+    volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]       
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)][AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],  DIM3  data_size,FP eb_r, FP ebx2, int radius, INTERPOLATION_PARAMS intp_param);
+
+template <typename T, typename FP, int LEVEL, int SPLINE_DIM,
+int AnchorBlockSizeX, int AnchorBlockSizeY,
+int AnchorBlockSizeZ,
+int numAnchorBlockX,  // Number of Anchor blocks along X
+int numAnchorBlockY,  // Number of Anchor blocks along Y
+int numAnchorBlockZ,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE, bool WORKFLOW>
+__device__ void spline_layout_interpolate_att(
+    volatile T s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]       
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)][AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+     DIM3    data_size,
+    DIM3 global_starts,FP eb_r, FP ebx2,uint8_t level,INTERPOLATION_PARAMS intp_param,volatile T *error);
+
+
+}  // namespace device_api
+
+
+
+
+}  // namespace cusz
+
+/********************************************************************************
+ * helper function
+ ********************************************************************************/
+
+namespace {
+
+template <int SPLINE_DIM, 
+int AnchorBlockSizeX,
+int AnchorBlockSizeY, 
+int AnchorBlockSizeZ,
+int numAnchorBlockX,  // Number of Anchor blocks along X
+int numAnchorBlockY,  // Number of Anchor blocks along Y
+int numAnchorBlockZ,  // Number of Anchor blocks along Z
+bool INCLUSIVE = true>
+__forceinline__ __device__ bool xyz_predicate(unsigned int x, unsigned int y, unsigned int z,const DIM3 &data_size)
+{
+    if CONSTEXPR (INCLUSIVE) {  //
+
+        
+            return (x <= (AnchorBlockSizeX * numAnchorBlockX) and y <= (AnchorBlockSizeY * numAnchorBlockY) and z <= (AnchorBlockSizeZ * numAnchorBlockZ)) and BIX * (AnchorBlockSizeX * numAnchorBlockX) + x < data_size.x and BIY *  (AnchorBlockSizeY * numAnchorBlockY) + y < data_size.y and BIZ * (AnchorBlockSizeZ * numAnchorBlockZ) + z < data_size.z;
+    }
+    else {
+        return x < (AnchorBlockSizeX * numAnchorBlockX) + (BIX == GDX - 1) * (SPLINE_DIM <= 1) and y < (AnchorBlockSizeY * numAnchorBlockY) + (BIY == GDY - 1) * (SPLINE_DIM <= 2) and z < (AnchorBlockSizeZ * numAnchorBlockZ) + (BIZ == GDZ - 1) * (SPLINE_DIM <= 3) and BIX * (AnchorBlockSizeX * numAnchorBlockX) + x < data_size.x and BIY * (AnchorBlockSizeY * numAnchorBlockY) + y < data_size.y and BIZ * (AnchorBlockSizeZ * numAnchorBlockZ) + z < data_size.z;
+    }
+}
+
+template <int SPLINE_DIM,
+int AnchorBlockSizeX,
+int AnchorBlockSizeY,
+int AnchorBlockSizeZ,
+int numAnchorBlockX, 
+int numAnchorBlockY, 
+int numAnchorBlockZ, 
+bool INCLUSIVE = true>
+__forceinline__ __device__ bool xyz_predicate_att(unsigned int x, unsigned int y, unsigned int z,const DIM3 &data_size, const DIM3 & global_starts)
+{
+    if CONSTEXPR (INCLUSIVE) {
+            return (x <= (AnchorBlockSizeX * numAnchorBlockX) and y <= (AnchorBlockSizeY * numAnchorBlockY) and z <= (AnchorBlockSizeZ * numAnchorBlockZ)) and global_starts.x + x < data_size.x and global_starts.y + y < data_size.y and global_starts.z + z < data_size.z;
+    }
+    else {
+        return x < (AnchorBlockSizeX * numAnchorBlockX) + (BIX == GDX - 1) and y < (AnchorBlockSizeY * numAnchorBlockY) + (BIY == GDY - 1) and z < (AnchorBlockSizeZ * numAnchorBlockZ) + (BIZ == GDZ - 1) and global_starts.x + x < data_size.x and global_starts.y + y < data_size.y and global_starts.z + z < data_size.z;
+    }
+}
+
+template <typename T1, typename T2,
+int SPLINE_DIM, 
+int AnchorBlockSizeX, 
+int AnchorBlockSizeY,
+int AnchorBlockSizeZ,
+int numAnchorBlockX,  // Number of Anchor blocks along X
+int numAnchorBlockY,  // Number of Anchor blocks along Y
+int numAnchorBlockZ,  // Number of Anchor blocks along Z 
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void c_reset_scratch_data(
+    volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    int radius)
+{
+    for (auto _tix = TIX; _tix < (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) *
+            (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) * (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+            _tix += LINEAR_BLOCK_SIZE) {
+        auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+        auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+                    (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+                    (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+
+        s_data[z][y][x] = 0;
+        if (x % AnchorBlockSizeX == 0 and y % AnchorBlockSizeY == 0 and
+            z % AnchorBlockSizeZ == 0)
+          s_ectrl[z][y][x] = radius;
+    }
+    __syncthreads();
+}
+
+
+template <typename T, 
+int SPLINE_DIM = 3,
+int PROFILE_BLOCK_SIZE_X = 4,
+int PROFILE_BLOCK_SIZE_Y = 4,
+int PROFILE_BLOCK_SIZE_Z = 4,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void c_reset_scratch_profiling_data(
+    volatile T s_data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z][PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X], T default_value)
+{
+    auto x_size = PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X;
+    auto y_size = PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y;
+    auto z_size = PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z;
+    for (auto _tix = TIX; _tix < x_size * y_size * z_size; _tix += LINEAR_BLOCK_SIZE) {
+        auto x = (_tix % x_size);
+        auto y = (_tix / x_size) % y_size;
+        auto z = (_tix / x_size) / y_size;
+        s_data[z][y][x] = default_value;
+
+    }
+}
+
+template <typename T,
+int SPLINE_DIM = 3,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4, 
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void c_reset_scratch_profiling_data_2(volatile T s_data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z], T nx[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], T ny[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], T nz[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4],T default_value)
+{
+    for (auto _tix = TIX; _tix < PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z * 4; _tix += LINEAR_BLOCK_SIZE) {
+        auto offset = (_tix % 4);
+        auto idx = _tix / 4;
+        nx[idx][offset] = ny[idx][offset] = nz[idx][offset] = default_value;
+        // s_data[TIX] = default_value;
+        s_data[idx] = default_value;
+
+    }
+}
+
+
+template <typename T1, 
+int AnchorBlockSizeX, int AnchorBlockSizeY,
+     int AnchorBlockSizeZ,
+     int numAnchorBlockX,  // Number of Anchor blocks along X
+     int numAnchorBlockY,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ,  // Number of Anchor blocks along Z
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void c_gather_anchor(T1* data, DIM3 data_size, STRIDE3 data_leap, T1* anchor, STRIDE3 anchor_leap)
+{
+    auto ax = BIX ;//1 is block16 by anchor stride
+    auto ay = BIY ;
+    auto az = BIZ ;
+    // 2d bug may be here! 
+    auto x = (AnchorBlockSizeX * numAnchorBlockX) * ax;
+    auto y = (AnchorBlockSizeY * numAnchorBlockY) * ay;
+    auto z = (AnchorBlockSizeZ * numAnchorBlockZ) * az;
+
+    bool pred1 = TIX < 1;//1 is num of anchor
+    bool pred2 = x < data_size.x and y < data_size.y and z < data_size.z;
+
+    if (pred1 and pred2) {
+        auto data_id      = x + y * data_leap.y + z * data_leap.z;
+        auto anchor_id    = ax + ay * anchor_leap.y + az * anchor_leap.z;
+        anchor[anchor_id] = data[data_id];
+    }
+    __syncthreads();
+}
+
+
+
+template <typename T1, typename T2 = T1,
+int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+     int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+     int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+     int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+     int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+      int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void x_reset_scratch_data(
+    volatile T1 s_xdata[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    T1*         anchor,       //
+    DIM3        anchor_size,  //
+    STRIDE3     anchor_leap)
+{
+    for (auto _tix = TIX; _tix <  (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) * (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) * (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)); _tix += LINEAR_BLOCK_SIZE) {
+        auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+        auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+
+        s_ectrl[z][y][x] = 0;  // TODO explicitly handle zero-padding
+        /*****************************************************************************
+         okay to use
+         ******************************************************************************/
+        if (x % AnchorBlockSizeX == 0 and y % AnchorBlockSizeY == 0 and
+            z % AnchorBlockSizeZ == 0) {
+            s_xdata[z][y][x] = 0;
+
+            auto ax = ((x / AnchorBlockSizeX) + BIX * numAnchorBlockX);
+            auto ay = ((y / AnchorBlockSizeY) + BIY * numAnchorBlockY);
+            auto az = ((z / AnchorBlockSizeZ) + BIZ * numAnchorBlockZ);
+
+            if (ax < anchor_size.x and ay < anchor_size.y and az < anchor_size.z)
+                s_xdata[z][y][x] = anchor[ax + ay * anchor_leap.y + az * anchor_leap.z];
+
+        }
+
+    }
+
+    __syncthreads();
+}
+
+template <typename T1, typename T2, int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_data(T1* data, DIM3 data_size, STRIDE3 data_leap,
+    volatile T2 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)])
+{
+    constexpr auto TOTAL = (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) *
+                        (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) * 
+                        (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+        auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto gx  = (x + BIX * (AnchorBlockSizeX * numAnchorBlockX));
+        auto gy  = (y + BIY * (AnchorBlockSizeY * numAnchorBlockY));
+        auto gz  = (z + BIZ * (AnchorBlockSizeZ * numAnchorBlockZ));
+        auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+
+        if (gx < data_size.x and gy < data_size.y and gz < data_size.z) s_data[z][y][x] = data[gid];
+
+    }
+    __syncthreads();
+}
+
+template <typename T1, typename T2, 
+int SPLINE_DIM = 3,
+int PROFILE_BLOCK_SIZE_X = 4,
+int PROFILE_BLOCK_SIZE_Y = 4,
+int PROFILE_BLOCK_SIZE_Z = 4,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_profiling_data(T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z][PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X])
+{
+    constexpr auto x_size = PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X;
+    constexpr auto y_size = PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y;
+    constexpr auto z_size = PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z;
+    constexpr auto TOTAL = x_size * y_size * z_size;
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x   = (_tix % x_size);
+        auto y   = (_tix / x_size) % y_size;
+        auto z   = (_tix / x_size) / y_size;
+        auto gx_1 = x / PROFILE_BLOCK_SIZE_X;
+        auto gx_2 = x % PROFILE_BLOCK_SIZE_X;
+        auto gy_1 = y / PROFILE_BLOCK_SIZE_Y;
+        auto gy_2 = y % PROFILE_BLOCK_SIZE_Y;
+        auto gz_1 = z / PROFILE_BLOCK_SIZE_Z;
+        auto gz_2 = z % PROFILE_BLOCK_SIZE_Z;
+        auto gx = (data_size.x / PROFILE_NUM_BLOCK_X) * gx_1 + gx_2;
+        auto gy = (data_size.y / PROFILE_NUM_BLOCK_Y) * gy_1 + gy_2;
+        auto gz = (data_size.z / PROFILE_NUM_BLOCK_Z) * gz_1 + gz_2;
+
+        auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+
+        if (gx < data_size.x and gy < data_size.y and gz < data_size.z) s_data[z][y][x] = data[gid];
+
+    }
+    __syncthreads();
+}
+
+template <typename T1, typename T2,
+int SPLINE_DIM = 3,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_profiling_data_2(T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z], volatile T2 s_nx[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T2 s_ny[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T2 s_nz[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4])
+{
+    constexpr auto TOTAL = PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z * 4;
+    int factors[4] = {-3, -1, 1, 3};
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto offset   = (_tix % 4);
+        auto idx = _tix / 4;
+        auto x = idx % PROFILE_NUM_BLOCK_X;
+        auto y   = (idx / PROFILE_NUM_BLOCK_X) % PROFILE_NUM_BLOCK_Y;
+        auto z   = (idx / PROFILE_NUM_BLOCK_X) / PROFILE_NUM_BLOCK_Y;
+        auto gx=(data_size.x / PROFILE_NUM_BLOCK_X) * x + data_size.x / (PROFILE_NUM_BLOCK_X * 2);
+        auto gy=(data_size.y / PROFILE_NUM_BLOCK_Y) * y + data_size.y / (PROFILE_NUM_BLOCK_Y * 2);
+        auto gz=(data_size.z / PROFILE_NUM_BLOCK_Z) * z + data_size.z / (PROFILE_NUM_BLOCK_Z * 2);
+
+        auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+
+        if (gx >= 3 and gy >= 3 and gz >= 3 and gx + 3 < data_size.x and gy + 3 < data_size.y and gz + 3 < data_size.z) {
+            s_data[idx] = data[gid];
+            auto factor=factors[offset];
+            s_nx[idx][offset]=data[gid+factor];
+            s_ny[idx][offset]=data[gid+factor*data_leap.y];
+            s_nz[idx][offset]=data[gid+factor*data_leap.z];
+        }
+    }
+    __syncthreads();
+}
+
+template <typename T = float, typename E = u4, int LEVEL = 4,
+int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_fuse(E* ectrl, dim3 ectrl_size, dim3 ectrl_leap, T* scattered_outlier, 
+    volatile T s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    volatile STRIDE3 grid_leaps[LEVEL + 1],volatile size_t prefix_nums[LEVEL + 1])
+{
+    
+    constexpr auto TOTAL = (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) *
+    (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) *
+    (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x   = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+        auto y   = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) % (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto z   = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) / (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto gx  = (x + BIX * (AnchorBlockSizeX * numAnchorBlockX));
+        auto gy  = (y + BIY * (AnchorBlockSizeY * numAnchorBlockY));
+        auto gz  = (z + BIZ * (AnchorBlockSizeZ * numAnchorBlockZ));
+        if (gx < ectrl_size.x and gy < ectrl_size.y and gz < ectrl_size.z) {
+            //todo: pre-compute the leaps and their halves
+
+            int level = 0;
+            auto data_gid = gx + gy * ectrl_leap.y + gz * ectrl_leap.z;
+            while(gx % 2 == 0 and gy % 2 == 0 and gz % 2 == 0 and level < LEVEL){
+                gx = gx >> 1;
+                gy = gy >> 1;
+                gz = gz >> 1;
+                level++;
+            }
+            auto gid = gx + gy*grid_leaps[level].y+gz*grid_leaps[level].z;
+
+            if(level < LEVEL){//non-anchor
+                gid += prefix_nums[level] - ((gz + 1) >> 1) * grid_leaps[level + 1].z - (gz % 2 == 0) * ((gy + 1) >> 1) * grid_leaps[level + 1].y - (gz % 2 == 0 && gy % 2 == 0) * ((gx + 1) >> 1);
+            }
+
+            s_ectrl[z][y][x] = static_cast<T>(ectrl[gid]) + scattered_outlier[data_gid];
+        }
+    }
+    __syncthreads();
+}
+
+// dram_outlier should be the same in type with shared memory buf
+template <typename T1, typename T2,
+int SPLINE_DIM, int AnchorBlockSizeX,
+int AnchorBlockSizeY, int AnchorBlockSizeZ,
+int numAnchorBlockX,
+int numAnchorBlockY,
+int numAnchorBlockZ,
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void
+shmem2global_data(volatile T1 s_buf[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+[AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+[AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)], T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap)
+{
+    auto x_size = AnchorBlockSizeX * numAnchorBlockX + (BIX == GDX - 1) * (SPLINE_DIM >= 1);
+    auto y_size = AnchorBlockSizeY * numAnchorBlockY + (BIY == GDY - 1) * (SPLINE_DIM >= 2);
+    auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (BIZ == GDZ - 1) * (SPLINE_DIM >= 3);
+    auto TOTAL = x_size * y_size * z_size;
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x   = (_tix % x_size);
+        auto y   = (_tix / x_size) % y_size;
+        auto z   = (_tix / x_size) / y_size;
+        auto gx  = (x + BIX * AnchorBlockSizeX * numAnchorBlockX);
+        auto gy  = (y + BIY * AnchorBlockSizeY * numAnchorBlockY);
+        auto gz  = (z + BIZ * AnchorBlockSizeZ * numAnchorBlockZ);
+        auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+
+        if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z) dram_buf[gid] = s_buf[z][y][x];
+    }
+    __syncthreads();
+}
+
+
+// dram_outlier should be the same in type with shared memory buf
+template <typename T1, typename T2, int LEVEL = 4,
+int SPLINE_DIM = 2, int AnchorBlockSizeX = 8,
+int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8,
+int numAnchorBlockX = 4,  // Number of Anchor blocks along X
+int numAnchorBlockY = 1,  // Number of Anchor blocks along Y
+int numAnchorBlockZ = 1,  // Number of Anchor blocks along Z
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void
+shmem2global_data_with_compaction(volatile T1 s_buf[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+[AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+[AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)], T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap, int radius,volatile STRIDE3 grid_leaps[LEVEL + 1],volatile size_t prefix_nums[LEVEL + 1], T1* dram_compactval = nullptr, uint32_t* dram_compactidx = nullptr, uint32_t* dram_compactnum = nullptr)
+{
+    auto x_size = AnchorBlockSizeX * numAnchorBlockX + (BIX == GDX - 1) * (SPLINE_DIM >= 1);
+    auto y_size = AnchorBlockSizeY * numAnchorBlockY + (BIY == GDY - 1) * (SPLINE_DIM >= 2);
+    auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (BIZ == GDZ - 1) * (SPLINE_DIM >= 3);
+    auto TOTAL = x_size * y_size * z_size;
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x   = (_tix % x_size);
+        auto y   = (_tix / x_size) % y_size;
+        auto z   = (_tix / x_size) / y_size;
+        auto gx  = (x + BIX * AnchorBlockSizeX * numAnchorBlockX);
+        auto gy  = (y + BIY * AnchorBlockSizeY * numAnchorBlockY);
+        auto gz  = (z + BIZ * AnchorBlockSizeZ * numAnchorBlockZ);
+        //auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+
+        auto candidate = s_buf[z][y][x];
+        bool quantizable = (candidate >= 0) and (candidate < 2*radius);
+
+        if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z) {
+            if (not quantizable) {
+                auto data_gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+                auto cur_idx = atomicAdd(dram_compactnum, 1);
+                dram_compactidx[cur_idx] = data_gid;
+                dram_compactval[cur_idx] = candidate;
+            }
+            int level = 0;
+            //todo: pre-compute the leaps and their halves
+            while(gx % 2 == 0 and gy % 2 == 0 and gz % 2 == 0 and level < LEVEL){
+                gx = gx >> 1;
+                gy = gy >> 1;
+                gz = gz >> 1;
+                level++;
+            }
+            auto gid = gx + gy * grid_leaps[level].y + gz * grid_leaps[level].z;
+
+            if(level < LEVEL){//non-anchor
+                gid += prefix_nums[level]-((gz + 1) >> 1) * grid_leaps[level + 1].z - (gz % 2 == 0) * ((gy + 1) >> 1) * grid_leaps[level + 1].y - (gz % 2 == 0 && gy % 2 == 0) * ((gx + 1) >> 1);
+            }
+
+            // TODO this is for algorithmic demo by reading from shmem
+            // For performance purpose, it can be inlined in quantization
+            dram_buf[gid] = quantizable * static_cast<T2>(candidate);
+        }
+    }
+}
+
+
+
+template <
+    typename T1,
+    typename T2,
+    typename FP,
+    int SPLINE_DIM, int AnchorBlockSizeX,
+    int AnchorBlockSizeY, int AnchorBlockSizeZ,
+    int numAnchorBlockX,
+    int numAnchorBlockY,
+    int numAnchorBlockZ,
+    typename LAMBDAX,
+    typename LAMBDAY,
+    typename LAMBDAZ,
+    bool BLUE,
+    bool YELLOW,
+    bool HOLLOW,
+    bool COARSEN,
+    int  LINEAR_BLOCK_SIZE,
+    bool BORDER_INCLUSIVE,
+    bool WORKFLOW>
+__forceinline__ __device__ void interpolate_stage(
+    volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    DIM3    data_size,
+    LAMBDAX     xmap,
+    LAMBDAY     ymap,
+    LAMBDAZ     zmap,
+    int         unit,
+    FP          eb_r,
+    FP          ebx2,
+    int         radius,
+    bool interpolator,
+    int  BLOCK_DIMX,
+    int  BLOCK_DIMY,
+    int  BLOCK_DIMZ)
+{
+    // static_assert(BLOCK_DIMX * BLOCK_DIMY * (COARSEN ? 1 : BLOCK_DIMZ) <= BLOCK_DIM_SIZE, "block oversized");
+    static_assert((BLUE or YELLOW or HOLLOW) == true, "must be one hot");
+    static_assert((BLUE and YELLOW) == false, "must be only one hot (1)");
+    static_assert((BLUE and YELLOW) == false, "must be only one hot (2)");
+    static_assert((YELLOW and HOLLOW) == false, "must be only one hot (3)");
+
+
+    auto run = [&](auto x, auto y, auto z) {
+        if (xyz_predicate<SPLINE_DIM,
+            AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+            numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ,
+            BORDER_INCLUSIVE>(x, y, z,data_size)) {
+            auto global_x = BIX * AnchorBlockSizeX * numAnchorBlockX + x;
+            auto global_y = BIY * AnchorBlockSizeY * numAnchorBlockY + y;
+            auto global_z = BIZ * AnchorBlockSizeZ * numAnchorBlockZ + z;  
+            
+            T1 pred = 0;
+            auto input_x = x;
+            auto input_BI = BIX;
+            auto input_GD = GDX;
+            auto input_gx = global_x;
+            auto input_gs = data_size.x;
+            auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+            auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+            auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+            auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+            int p1 = -1, p2 = 9, p3 = 9, p4 = -1, p5 = 16;
+            if(interpolator==0){
+                p1 = -3, p2 = 23, p3 = 23, p4 = -3, p5 = 40;
+            }
+            if CONSTEXPR (BLUE){
+                input_x = z;
+                input_BI = BIZ;
+                input_GD = GDZ;
+                input_gx = global_z;
+                input_gs = data_size.z;
+                right_bound = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+            }
+            if CONSTEXPR (YELLOW){
+                input_x = y;
+                input_BI = BIY;
+                input_GD = GDY;
+                input_gx = global_y;
+                input_gs = data_size.y;
+                right_bound = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+            }
+            
+            int id_[4], s_id[4];
+            id_[0] =  input_x - 3 * unit;
+            id_[0] =  id_[0] >= 0 ? id_[0] : 0;
+        
+            id_[1] = input_x - unit;
+            id_[1] = id_[1] >= 0 ? id_[1] : 0;
+        
+            id_[2] = input_x + unit;
+            id_[2] = id_[2] < right_bound ? id_[2] : 0;
+            
+            id_[3] = input_x + 3 * unit;
+            id_[3] = id_[3] < right_bound ? id_[3] : 0;
+            
+            s_id[0] = x_size * y_size * z + x_size * y + id_[0];
+            s_id[1] = x_size * y_size * z + x_size * y + id_[1];
+            s_id[2] = x_size * y_size * z + x_size * y + id_[2];
+            s_id[3] = x_size * y_size * z + x_size * y + id_[3];
+            if CONSTEXPR (BLUE){
+            s_id[0] = x_size * y_size * id_[0] + x_size * y + x;
+            s_id[1] = x_size * y_size * id_[1] + x_size * y + x;
+            s_id[2] = x_size * y_size * id_[2] + x_size * y + x;
+            s_id[3] = x_size * y_size * id_[3] + x_size * y + x;
+            }
+            if CONSTEXPR (YELLOW){
+                s_id[0] = x_size * y_size * z + x_size * id_[0] + x;
+                s_id[1] = x_size * y_size * z + x_size * id_[1] + x;
+                s_id[2] = x_size * y_size * z + x_size * id_[2] + x;
+                s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
+            }
+
+            T1 tmp_[4];
+        
+            bool case1 = (input_BI != input_GD - 1);
+            bool case2 = (input_x >= 3 * unit);
+            bool case3 = (input_x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX);
+            bool case4 = (input_gx + 3 * unit < input_gs);
+            bool case5 = (input_gx + unit < input_gs);
+            
+            // 预加载 shared memory 数据到寄存器
+            T1 tmp0 = *((T1*)s_data + s_id[0]); 
+            T1 tmp1 = *((T1*)s_data + s_id[1]); 
+            T1 tmp2 = *((T1*)s_data + s_id[2]); 
+            T1 tmp3 = *((T1*)s_data + s_id[3]); 
+
+            // 初始预测值
+            pred = tmp1;
+
+            // 计算不同 case 对应的 pred
+            if ((case1 && !case2 && !case3) || (!case1 && !case2 && !(case3 && case4) && case5)) {
+                pred = (tmp1 + tmp2) / 2;
+            }
+            else if ((case1 && !case2 && case3) || (!case1 && !case2 && case3 && case4)) {
+                pred = (3 * tmp1 + 6 * tmp2 - tmp3) / 8;
+            }
+            else if ((case1 && case2 && !case3) || (!case1 && case2 && !(case3 && case4) && case5)) {
+                pred = (-tmp0 + 6 * tmp1 + 3 * tmp2) / 8;
+            }
+            else if ((case1 && case2 && case3) || (!case1 && case2 && case3 && case4)) {
+                pred = (p1 * tmp0 + p2 * tmp1 + p3 * tmp2 + p4 * tmp3) / p5;
+            }
+                        
+            
+
+            if CONSTEXPR (WORKFLOW == SPLINE3_COMPR) {
+                
+                auto          err = s_data[z][y][x] - pred;
+                decltype(err) code;
+                // TODO unsafe, did not deal with the out-of-cap case
+                {
+                    code = fabs(err) * eb_r + 1;
+                    code = err < 0 ? -code : code;
+                    code = int(code / 2) + radius;
+                }
+                s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
+                s_data[z][y][x]  = pred + (code - radius) * ebx2;
+                
+
+            }
+            else {  // TODO == DECOMPRESSS and static_assert
+                auto code       = s_ectrl[z][y][x];
+                s_data[z][y][x] = pred + (code - radius) * ebx2;
+
+            }
+        }
+    };
+    // -------------------------------------------------------------------------------- //
+    auto TOTAL = BLOCK_DIMX * BLOCK_DIMY * BLOCK_DIMZ;
+    if CONSTEXPR (COARSEN) {
+        
+        //if( BLOCK_DIMX *BLOCK_DIMY<= LINEAR_BLOCK_SIZE){
+            for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                auto itix = (_tix % BLOCK_DIMX);
+                auto itiy = (_tix / BLOCK_DIMX) % BLOCK_DIMY;
+                auto itiz = (_tix / BLOCK_DIMX) / BLOCK_DIMY;
+                auto x    = xmap(itix, unit);
+                auto y    = ymap(itiy, unit);
+                auto z    = zmap(itiz, unit);
+                
+                run(x, y, z);
+            }
+
+        
+    }
+    else {
+        if(TIX < TOTAL){
+            auto itix = (TIX % BLOCK_DIMX);
+            auto itiy = (TIX / BLOCK_DIMX) % BLOCK_DIMY;
+            auto itiz = (TIX / BLOCK_DIMX) / BLOCK_DIMY;
+            auto x    = xmap(itix, unit);
+            auto y    = ymap(itiy, unit);
+            auto z    = zmap(itiz, unit);
+
+
+            run(x, y, z);
+        }
+    }
+    __syncthreads();
+}
+
+template <
+    typename T1,
+    typename T2,
+    typename FP,
+    int SPLINE_DIM, int AnchorBlockSizeX,
+    int AnchorBlockSizeY, int AnchorBlockSizeZ,
+    int numAnchorBlockX,
+    int numAnchorBlockY,
+    int numAnchorBlockZ,
+    typename LAMBDA,
+    bool LINE,
+    bool FACE,
+    bool CUBE,
+    int  LINEAR_BLOCK_SIZE,
+    bool COARSEN,
+    bool BORDER_INCLUSIVE,
+    bool WORKFLOW,
+    typename INTERP>
+__forceinline__ __device__ void interpolate_stage_md(
+    volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+ [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+ [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    DIM3    data_size,
+    LAMBDA xyzmap,
+    int         unit,
+    FP          eb_r,
+    FP          ebx2,
+    int         radius,
+    INTERP cubic_interpolator,
+    int NUM_ELE)
+{
+    // static_assert(COARSEN or (NUM_ELE <= BLOCK_DIM_SIZE), "block oversized");
+    static_assert((LINE or FACE or CUBE) == true, "must be one hot");
+    static_assert((LINE and FACE) == false, "must be only one hot (1)");
+    static_assert((LINE and CUBE) == false, "must be only one hot (2)");
+    static_assert((FACE and CUBE) == false, "must be only one hot (3)");
+
+    auto run = [&](auto x, auto y, auto z) {
+
+        if (xyz_predicate<SPLINE_DIM,
+            AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+            numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, BORDER_INCLUSIVE>(x, y, z,data_size)) {
+            T1 pred = 0;
+            auto global_x = BIX * AnchorBlockSizeX * numAnchorBlockX + x;
+            auto global_y = BIY * AnchorBlockSizeY * numAnchorBlockY + y;
+            auto global_z = BIZ * AnchorBlockSizeZ * numAnchorBlockZ + z;  
+
+           T1 tmp_z[4], tmp_y[4], tmp_x[4];
+           int id_z[4], id_y[4], id_x[4];
+           id_z[0] = (z - 3 * unit >= 0) ? z - 3 * unit : 0;
+           id_z[1] = (z - unit >= 0) ? z - unit : 0;
+           id_z[2] = (z + unit <= AnchorBlockSizeZ * numAnchorBlockZ) ? z + unit : 0;
+           id_z[3] = (z + 3 * unit <= AnchorBlockSizeZ * numAnchorBlockZ) ? z + 3 * unit : 0;
+           
+           id_y[0] = (y - 3 * unit >= 0) ? y - 3 * unit : 0;
+           id_y[1] = (y - unit >= 0) ? y - unit : 0;
+           id_y[2] = (y + unit <= AnchorBlockSizeY * numAnchorBlockY) ? y + unit : 0;
+           id_y[3] = (y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY) ? y + 3 * unit : 0;
+           
+           id_x[0] = (x - 3 * unit >= 0) ? x - 3 * unit : 0;
+           id_x[1] = (x - unit >= 0) ? x - unit : 0;
+           id_x[2] = (x + unit <= AnchorBlockSizeX * numAnchorBlockX) ? x + unit : 0;
+           id_x[3] = (x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX) ? x + 3 * unit : 0;
+           
+            if CONSTEXPR (LINE) {
+                bool I_Y = (y % (2*unit) )> 0; 
+                bool I_Z = (z % (2*unit) )> 0; 
+
+                pred = 0;
+                auto input_x = x;
+                auto input_BI = BIX;
+                auto input_GD = GDX;
+                auto input_gx = global_x;
+                auto input_gs = data_size.x;
+
+                auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                
+                if (I_Z){
+                    input_x = z;
+                    input_BI = BIZ;
+                    input_GD = GDZ;
+                    input_gx = global_z;
+                    input_gs = data_size.z;
+                    right_bound = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                }
+                else if (I_Y){
+                    input_x = y;
+                    input_BI = BIY;
+                    input_GD = GDY;
+                    input_gx = global_y;
+                    input_gs = data_size.y;
+                    right_bound = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                }
+                
+                int id_[4], s_id[4];
+                id_[0] =  input_x - 3 * unit;
+                id_[0] =  id_[0] >= 0 ? id_[0] : 0;
+            
+                id_[1] = input_x - unit;
+                id_[1] = id_[1] >= 0 ? id_[1] : 0;
+            
+                id_[2] = input_x + unit;
+                id_[2] = id_[2] < right_bound ? id_[2] : 0;
+                
+                id_[3] = input_x + 3 * unit;
+                id_[3] = id_[3] < right_bound ? id_[3] : 0;
+                
+                s_id[0] = x_size * y_size * z + x_size * y + id_[0];
+                s_id[1] = x_size * y_size * z + x_size * y + id_[1];
+                s_id[2] = x_size * y_size * z + x_size * y + id_[2];
+                s_id[3] = x_size * y_size * z + x_size * y + id_[3];
+                if (I_Z){
+                s_id[0] = x_size * y_size * id_[0] + x_size * y + x;
+                s_id[1] = x_size * y_size * id_[1] + x_size * y + x;
+                s_id[2] = x_size * y_size * id_[2] + x_size * y + x;
+                s_id[3] = x_size * y_size * id_[3] + x_size * y + x;
+                }
+                else if (I_Y){
+                    s_id[0] = x_size * y_size * z + x_size * id_[0] + x;
+                    s_id[1] = x_size * y_size * z + x_size * id_[1] + x;
+                    s_id[2] = x_size * y_size * z + x_size * id_[2] + x;
+                    s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
+                }
+
+                T1 tmp_[4];
+            
+                bool case1 = (input_BI != input_GD - 1);
+                bool case2 = (input_x >= 3 * unit);
+                bool case3 = (input_x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX);
+                bool case4 = (input_gx + 3 * unit < input_gs);
+                bool case5 = (input_gx + unit < input_gs);
+                
+                
+                // 预加载 shared memory 数据到寄存器
+                T1 tmp0 = *((T1*)s_data + s_id[0]); 
+                T1 tmp1 = *((T1*)s_data + s_id[1]); 
+                T1 tmp2 = *((T1*)s_data + s_id[2]); 
+                T1 tmp3 = *((T1*)s_data + s_id[3]); 
+    
+                // 初始预测值
+                pred = tmp1;
+    
+                // 计算不同 case 对应的 pred
+                if ( (case1 && case2 && case3) || (!case1 && case2 && case3 && case4)) {
+                    pred = cubic_interpolator(tmp0, tmp1, tmp2, tmp3);
+                    
+                }
+                else if ((case1 && case2 && !case3) || ( !case1 && case2 && !(case3 && case4) && case5)) {
+                    pred = (-tmp0 + 6 * tmp1 + 3 * tmp2) / 8;
+                }
+                else if ((case1 && !case2 && case3) || (!case1 && !case2 && case3 && case4 )){
+                    pred = (3 * tmp1 + 6 * tmp2 - tmp3) / 8;   
+                }
+                else if ((case1 && !case2 && !case3) || (!case1 && !case2 && !(case3 && case4) && case5)) {
+                    pred = (tmp1 + tmp2) / 2;
+                }
+
+            }
+            auto get_interp_order = [&](auto x, auto BI, auto GD, auto gx, auto gs){
+                int b = (x >= 3 * unit) ? 3 : 1;
+                int f = ((x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX) && ((BI != GD - 1) || (gx + 3 * unit < gs))) ? 3 :
+                (((BI != GD - 1) || (gx + unit < gs)) ? 1 : 0);
+
+                return (b == 3) ? ((f == 3) ? 4 : ((f == 1) ? 3 : 0)) 
+                                : ((f == 3) ? 2 : ((f == 1) ? 1 : 0));
+            };
+            if CONSTEXPR (FACE) {  //
+               // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and y==7 and z==0){
+               //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
+              //  }
+
+                bool I_YZ = (x % (2*unit) ) == 0;
+                bool I_XZ = (y % (2*unit ) )== 0;
+
+                //if(BIX == 10 and BIY == 12 and BIZ == 0 and x==13 and y==6 and z==9)
+               //     printf("face %d %d\n", I_YZ,I_XZ);
+                int x_1,BI_1,GD_1,gx_1,gs_1;
+                int x_2,BI_2,GD_2,gx_2,gs_2;
+                int s_id_1[4], s_id_2[4];
+                auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                if (I_YZ){
+                   
+                 x_1 = z,BI_1 = BIZ, GD_1 = GDZ, gx_1 = global_z,gs_1 = data_size.z;
+                 x_2 = y,BI_2 = BIY, GD_2 = GDY, gx_2 = global_y, gs_2 = data_size.y;
+                 s_id_1[0] = x_size * y_size * id_z[0] + x_size * y + x;
+                 s_id_1[1] = x_size * y_size * id_z[1] + x_size * y + x;
+                 s_id_1[2] = x_size * y_size * id_z[2] + x_size * y + x;
+                 s_id_1[3] = x_size * y_size * id_z[3] + x_size * y + x;
+                 s_id_2[0] = x_size * y_size * z + x_size * id_y[0] + x;
+                 s_id_2[1] = x_size * y_size * z + x_size * id_y[1] + x;
+                 s_id_2[2] = x_size * y_size * z + x_size * id_y[2] + x;
+                 s_id_2[3] = x_size * y_size * z + x_size * id_y[3] + x;
+                 pred = s_data[id_z[1]][id_y[1]][x];
+
+                }
+                else if (I_XZ){
+                    x_1 = z,BI_1 = BIZ, GD_1 = GDZ, gx_1 = global_z,gs_1 = data_size.z;
+                    x_2 = x,BI_2 = BIX, GD_2 = GDX, gx_2 = global_x, gs_2 = data_size.x;
+                    s_id_1[0] = x_size * y_size * id_z[0] + x_size * y + x;
+                    s_id_1[1] = x_size * y_size * id_z[1] + x_size * y + x;
+                    s_id_1[2] = x_size * y_size * id_z[2] + x_size * y + x;
+                    s_id_1[3] = x_size * y_size * id_z[3] + x_size * y + x;
+                    
+                    s_id_2[0] = x_size * y_size * z + x_size * y + id_x[0];
+                    s_id_2[1] = x_size * y_size * z + x_size * y + id_x[1];
+                    s_id_2[2] = x_size * y_size * z + x_size * y + id_x[2];
+                    s_id_2[3] = x_size * y_size * z + x_size * y + id_x[3];
+                    pred = s_data[id_z[1]][y][id_x[1]];
+                    
+                }
+                else{
+                    x_1 = y,BI_1 = BIY, GD_1 = GDY, gx_1 = global_y, gs_1 = data_size.y;
+                    x_2 = x,BI_2 = BIX, GD_2 = GDX, gx_2 = global_x, gs_2 = data_size.x;
+                    s_id_1[0] = x_size * y_size * z + x_size * id_y[0] + x;
+                    s_id_1[1] = x_size * y_size * z + x_size * id_y[1] + x;
+                    s_id_1[2] = x_size * y_size * z + x_size * id_y[2] + x;
+                    s_id_1[3] = x_size * y_size * z + x_size * id_y[3] + x;
+                    s_id_2[0] = x_size * y_size * z + x_size * y + id_x[0];
+                    s_id_2[1] = x_size * y_size * z + x_size * y + id_x[1];
+                    s_id_2[2] = x_size * y_size * z + x_size * y + id_x[2];
+                    s_id_2[3] = x_size * y_size * z + x_size * y + id_x[3];
+                    pred = s_data[z][id_y[1]][id_x[1]];
+                }
+
+                    auto interp_1 = get_interp_order(x_1,BI_1,GD_1,gx_1,gs_1);
+                    auto interp_2 = get_interp_order(x_2,BI_2,GD_2,gx_2,gs_2);
+
+                    int case_num = interp_1 + interp_2 * 5;
+
+
+                    if (interp_1 == 4 && interp_2 == 4) {
+                        pred = (cubic_interpolator(*((T1*)s_data + s_id_1[0]), 
+                        *((T1*)s_data + s_id_1[1]), 
+                        *((T1*)s_data + s_id_1[2]), 
+                        *((T1*)s_data + s_id_1[3])) +
+                         cubic_interpolator(*((T1*)s_data + s_id_2[0]), 
+                        *((T1*)s_data + s_id_2[1]), 
+                        *((T1*)s_data + s_id_2[2]), 
+                        *((T1*)s_data + s_id_2[3]))) / 2;
+                    } else if (interp_1 != 4 && interp_2 == 4) {
+                        pred = cubic_interpolator(*((T1*)s_data + s_id_2[0]), 
+                        *((T1*)s_data + s_id_2[1]), 
+                        *((T1*)s_data + s_id_2[2]), 
+                        *((T1*)s_data + s_id_2[3]));
+                    } else if (interp_1 == 4 && interp_2 != 4) {
+                        pred = cubic_interpolator(*((T1*)s_data + s_id_1[0]), 
+                        *((T1*)s_data + s_id_1[1]), 
+                        *((T1*)s_data + s_id_1[2]), 
+                        *((T1*)s_data + s_id_1[3]));
+                    } else if (interp_1 == 3 && interp_2 == 3) {
+                        pred = (-(*((T1*)s_data + s_id_2[0]))+6*(*((T1*)s_data + s_id_2[1])) + 3*(*((T1*)s_data + s_id_2[2]))) / 8;
+                        pred += (-(*((T1*)s_data + s_id_1[0]))+6*(*((T1*)s_data + s_id_1[1])) + 3*(*((T1*)s_data + s_id_1[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 3 && interp_2 == 2) {
+                        pred = (3*(*((T1*)s_data + s_id_2[1]))+6*(*((T1*)s_data + s_id_2[2])) - (*((T1*)s_data + s_id_2[3]))) / 8;
+                        pred += (-(*((T1*)s_data + s_id_1[0]))+6*(*((T1*)s_data + s_id_1[1])) + 3*(*((T1*)s_data + s_id_1[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 3 && interp_2 < 2) {
+                        pred = (-(*((T1*)s_data + s_id_1[0]))+6*(*((T1*)s_data + s_id_1[1])) + 3*(*((T1*)s_data + s_id_1[2]))) / 8;
+                    } else if (interp_1 == 2 && interp_2 == 3) {
+                        pred = (3*(*((T1*)s_data + s_id_1[1]))+6*(*((T1*)s_data + s_id_1[2])) - (*((T1*)s_data + s_id_1[3]))) / 8;
+                        pred += (-(*((T1*)s_data + s_id_2[0]))+6*(*((T1*)s_data + s_id_2[1])) + 3*(*((T1*)s_data + s_id_2[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 2 && interp_2 == 2) {
+                        pred = (3*(*((T1*)s_data + s_id_1[1]))+6*(*((T1*)s_data + s_id_1[2])) - (*((T1*)s_data + s_id_1[3]))) / 8;
+                        pred += (3*(*((T1*)s_data + s_id_2[1]))+6*(*((T1*)s_data + s_id_2[2])) - (*((T1*)s_data + s_id_2[3]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 2 && interp_2 < 2) {
+                        pred = (3*(*((T1*)s_data + s_id_1[1]))+6*(*((T1*)s_data + s_id_1[2])) - (*((T1*)s_data + s_id_1[3]))) / 8;
+                    } else if (interp_1 <= 1 && interp_2 == 3) {
+                        pred = (-(*((T1*)s_data + s_id_2[0]))+6*(*((T1*)s_data + s_id_2[1])) + 3*(*((T1*)s_data + s_id_2[2]))) / 8;
+                    } else if (interp_1 <= 1 && interp_2 == 2) {
+                        pred = (3*(*((T1*)s_data + s_id_2[1]))+6*(*((T1*)s_data + s_id_2[2])) - (*((T1*)s_data + s_id_2[3]))) / 8;
+                    } else if (interp_1 == 1 && interp_2 == 1) {
+                        pred = ((*((T1*)s_data + s_id_2[1]))+(*((T1*)s_data + s_id_2[2]))) / 2;
+                        pred += ((*((T1*)s_data + s_id_1[1]))+(*((T1*)s_data + s_id_1[2]))) / 2;
+                        pred /= 2;
+                    } else if (interp_1 == 1 && interp_2 < 1) {
+                        
+                        pred = ((*((T1*)s_data + s_id_1[1]))+(*((T1*)s_data + s_id_1[2]))) / 2;
+                    } else if (interp_1 == 0 && interp_2 == 1) {
+                        pred = ((*((T1*)s_data + s_id_2[1]))+(*((T1*)s_data + s_id_2[2]))) / 2;
+                    }
+                    else{
+                        pred = (*((T1*)s_data + s_id_1[1])) + (*((T1*)s_data + s_id_2[1])) - pred;
+                    }
+                    
+            }
+
+            if CONSTEXPR (CUBE) {  //
+                auto interp_z = get_interp_order(z,BIZ,GDZ,global_z,data_size.z);
+                auto interp_y = get_interp_order(y,BIY,GDY,global_y,data_size.y);
+                auto interp_x = get_interp_order(x,BIX,GDX,global_x,data_size.x);
+                
+                #pragma unroll
+                for(int id_itr = 0; id_itr < 4; ++id_itr){
+                 tmp_x[id_itr] = s_data[z][y][id_x[id_itr]]; 
+                }
+                if(interp_z == 4){
+                    #pragma unroll
+                    for(int id_itr = 0; id_itr < 4; ++id_itr){
+                        tmp_z[id_itr] = s_data[id_z[id_itr]][y][x];
+                       }
+                }
+                if(interp_y == 4){
+                    #pragma unroll
+                    for(int id_itr = 0; id_itr < 4; ++id_itr){
+                     tmp_y[id_itr] = s_data[z][id_y[id_itr]][x]; 
+                    }
+                }
+
+
+                T1 pred_z[5], pred_y[5], pred_x[5];
+                pred_x[0] = tmp_x[1];
+                pred_x[1] = cubic_interpolator(tmp_x[0],tmp_x[1],tmp_x[2],tmp_x[3]);
+                pred_x[2] = (-tmp_x[0]+6*tmp_x[1] + 3*tmp_x[2]) / 8;
+                pred_x[3] = (3*tmp_x[1] + 6*tmp_x[2]-tmp_x[3]) / 8;
+                pred_x[4] = (tmp_x[1] + tmp_x[2]) / 2;
+                
+                pred_y[1] = cubic_interpolator(tmp_y[0],tmp_y[1],tmp_y[2],tmp_y[3]);
+
+                
+                pred_z[1] = cubic_interpolator(tmp_z[0],tmp_z[1],tmp_z[2],tmp_z[3]);
+                
+                pred = pred_x[0];
+                pred = (interp_z == 4 && interp_y == 4 && interp_x == 4) ? (pred_x[1] +  pred_y[1] + pred_z[1]) / 3 : pred;
+                
+                pred = (interp_z == 4 && interp_y == 4 && interp_x != 4) ? (pred_z[1] + pred_y[1]) / 2 : pred;
+                pred = (interp_z == 4 && interp_y != 4 && interp_x == 4) ? (pred_z[1] + pred_x[1]) / 2 : pred;
+                pred = (interp_z != 4 && interp_y == 4 && interp_x == 4) ? (pred_y[1] + pred_x[1]) / 2 : pred;
+                
+                pred = (interp_z == 4 && interp_y != 4 && interp_x != 4) ? pred_z[1]: pred;
+                pred = (interp_z != 4 && interp_y == 4 && interp_x != 4) ? pred_y[1]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 4) ? pred_x[1]: pred;
+
+
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 3) ? pred_x[2]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 2) ? pred_x[3]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 1) ? pred_x[4]: pred;
+                // pred = (interp_z != 4 && interp_y != 4 && interp_x == 0) ? pred_x[0]: pred;
+            }
+
+            if CONSTEXPR (WORKFLOW == SPLINE3_COMPR) {
+                
+                auto          err = s_data[z][y][x] - pred;
+                decltype(err) code;
+                // TODO unsafe, did not deal with the out-of-cap case
+                {
+                    code = fabs(err) * eb_r + 1;
+                    code = err < 0 ? -code : code;
+                    code = int(code / 2) + radius;
+                }
+                s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
+              
+                s_data[z][y][x]  = pred + (code - radius) * ebx2;
+                
+
+            }
+            else {  // TODO == DECOMPRESSS and static_assert
+
+                
+                auto code       = s_ectrl[z][y][x];
+                s_data[z][y][x] = pred + (code - radius) * ebx2;
+            }
+        }
+    };
+    // -------------------------------------------------------------------------------- //
+
+    if CONSTEXPR (COARSEN) {
+        auto TOTAL = NUM_ELE;
+        for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+            auto [x,y,z]    = xyzmap(_tix, unit);
+            run(x, y, z);
+        }
+        
+    }
+    else {
+        if(TIX<NUM_ELE){
+            auto [x,y,z]    = xyzmap(TIX, unit);
+            run(x, y, z);
+        }
+    }
+    __syncthreads();
+}
+
+}  // namespace
+
+template <typename T, int SPLINE_DIM = 3,
+int PROFILE_BLOCK_SIZE_X = 4,
+int PROFILE_BLOCK_SIZE_Y = 4,
+int PROFILE_BLOCK_SIZE_Z = 4,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4,
+int  LINEAR_BLOCK_SIZE>
+__device__ void cusz::device_api::auto_tuning(volatile T s_data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z]       
+    [PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X],  volatile T local_errs[2], DIM3  data_size,  T * errs){
+ 
+    if(TIX < 2)
+        local_errs[TIX] = 0;
+    __syncthreads(); 
+
+    auto local_idx = TIX % 2;
+    auto temp = TIX / 2;
+    
+
+    auto block_idx_x =  temp % PROFILE_NUM_BLOCK_X;
+    auto block_idx_y = ( temp / PROFILE_NUM_BLOCK_X) % PROFILE_NUM_BLOCK_Y;
+    auto block_idx_z = ( ( temp  / PROFILE_NUM_BLOCK_X) / PROFILE_NUM_BLOCK_Y) % PROFILE_NUM_BLOCK_Z;
+    auto dir = ( ( temp  / PROFILE_NUM_BLOCK_X) / PROFILE_NUM_BLOCK_Y) / PROFILE_NUM_BLOCK_Z;
+
+
+
+    bool predicate = dir < 2;
+
+    if(predicate){
+        auto x = PROFILE_BLOCK_SIZE_X * block_idx_x + 1 + local_idx;
+        auto y = PROFILE_BLOCK_SIZE_Y * block_idx_y + 1 + local_idx;
+        auto z = PROFILE_BLOCK_SIZE_Z * block_idx_z + 1 + local_idx;
+        T pred = 0;
+        switch(dir){
+            case 0:
+                pred = (s_data[z - 1][y][x] + s_data[z + 1][y][x]) / 2;
+                break;
+            case 1:
+                pred = (s_data[z][y][x - 1] + s_data[z][y][x + 1]) / 2;
+                break;
+            default:
+            break;
+        }
+        
+        T abs_error = fabs(pred - s_data[z][y][x]);
+        atomicAdd(const_cast<T*>(local_errs) + dir, abs_error);
+    } 
+    __syncthreads(); 
+    if(TIX < 2)
+        errs[TIX]=local_errs[TIX];
+    __syncthreads(); 
+       
+}
+
+template <typename T,
+int SPLINE_DIM = 3,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4, 
+int  LINEAR_BLOCK_SIZE>
+__device__ void cusz::device_api::auto_tuning_2(volatile T s_data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z], volatile T s_nx[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T s_ny[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4], volatile T s_nz[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4],  volatile T local_errs[6], DIM3  data_size,  T * errs){
+ 
+    if(TIX<6)
+        local_errs[TIX]=0;
+    __syncthreads(); 
+
+    auto point_idx = TIX % (PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z);
+    auto c = TIX / (PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z);
+
+
+    bool predicate = c < 6;
+    if(predicate){
+
+        T pred=0;
+
+        //auto unit = 1;
+        switch(c){
+                case 0:
+                    pred = (-s_nz[point_idx][0] + 9 * s_nz[point_idx][1] + 9 * s_nz[point_idx][2] - s_nz[point_idx][3]) / 16;
+                    break;
+
+                case 1:
+                    pred = (-3 * s_nz[point_idx][0] + 23 * s_nz[point_idx][1] + 23* s_nz[point_idx][2] - 3 * s_nz[point_idx][3]) / 40;
+                    break;
+                case 2:
+                    pred = (-s_ny[point_idx][0] + 9 * s_ny[point_idx][1] + 9 * s_ny[point_idx][2] - s_ny[point_idx][3]) / 16;
+                    break;
+                case 3:
+                    pred = (-3 * s_ny[point_idx][0] + 23 * s_ny[point_idx][1] + 23 * s_ny[point_idx][2] - 3 * s_ny[point_idx][3]) / 40;
+                    break;
+
+                case 4:
+                    pred = (-s_nx[point_idx][0] + 9 * s_nx[point_idx][1] + 9 * s_nx[point_idx][2] - s_nx[point_idx][3]) / 16;
+                    break;
+                case 5:
+                    pred = (-3 * s_nx[point_idx][0] + 23 * s_nx[point_idx][1] + 23 * s_nx[point_idx][2] - 3 * s_nx[point_idx][3]) / 40;
+                    break;
+                default:
+                break;
+            }
+        T abs_error=fabs(pred-s_data[point_idx]);
+        atomicAdd(const_cast<T*>(local_errs) + c, abs_error);
+    } 
+    __syncthreads(); 
+    if(TIX<6)
+        errs[TIX]=local_errs[TIX];
+    __syncthreads(); 
+       
+}
+
+template<int SPLINE_DIM, int BLOCKSIZE>
+__device__ std::tuple<int, int, int> xyzmap_line(int _tix, const int UNIT);
+template<int SPLINE_DIM, int BLOCKSIZE>
+__device__ std::tuple<int, int, int> xyzmap_face(int _tix, const int UNIT);
+template<int SPLINE_DIM, int BLOCKSIZE>
+__device__ std::tuple<int, int, int> xyzmap_cube(int _tix, const int UNIT);
+
+
+template<int SPLINE_DIM, int BLOCKSIZE>
+__device__ std::tuple<int, int, int> xyzmap_line(int _tix, const int UNIT) {
+    if constexpr (SPLINE_DIM == 3) {
+        auto N = BLOCKSIZE / (UNIT * 2);
+        auto L = N * (N+1) * (N+1); 
+        auto Q = (N+1) * (N+1); 
+        auto group = _tix / L ;
+        auto m = _tix % L ;
+        auto i = m / Q;
+        auto j = (m % Q) / (N+1);
+        auto k = (m % Q) % (N+1);
+        if(group == 0)
+            return std::make_tuple(2 * UNIT * i + UNIT, 2 * UNIT * j, 2 * UNIT * k);
+        else if (group == 1)
+            return std::make_tuple(2 * UNIT * k, 2 * UNIT * i + UNIT, 2 * UNIT * j);
+        else
+            return std::make_tuple(2 * UNIT * j, 2 * UNIT * k, 2 * UNIT * i + UNIT);
+    }
+    if constexpr (SPLINE_DIM == 2) {
+        auto N = BLOCKSIZE / (UNIT * 2);
+        auto L = N * (N+1); 
+        auto Q = (N+1); 
+        auto group = _tix / L ;
+        auto m = _tix % L ;
+        auto i = m / Q;
+        auto j = (m % Q);
+        if(group == 0)
+            return std::make_tuple(2 * UNIT * i + UNIT, 2 * UNIT * j, 0);
+        else if (group == 1)
+            return std::make_tuple(2 * UNIT * j, 2 * UNIT * i + UNIT, 0);
+    }
+}
+
+template<int SPLINE_DIM, int BLOCKSIZE>
+__device__ std::tuple<int, int, int> xyzmap_face(int _tix, const int UNIT) {
+    if constexpr (SPLINE_DIM == 3) {
+        auto N = BLOCKSIZE / (UNIT * 2);
+        auto L = N * N * (N+1);
+        auto Q = N * N; 
+        auto group = _tix / L ;
+        auto m = _tix % L ;
+        auto i = m / Q;
+        auto j = (m % Q) / N;
+        auto k = (m % Q) % N;
+        if(group == 0)
+            return std::make_tuple(2 * UNIT * i, 2 * UNIT * j + UNIT, 2 * UNIT * k + UNIT);
+        else if (group == 1)
+            return std::make_tuple(2 * UNIT * k + UNIT, 2 * UNIT * i, 2 * UNIT * j + UNIT);
+        else
+            return std::make_tuple(2 * UNIT * j + UNIT, 2 * UNIT * k + UNIT, 2 * UNIT * i);
+    }
+    if constexpr (SPLINE_DIM == 2) {
+        auto N = BLOCKSIZE / (UNIT * 2);
+        auto L = N * N;
+        auto Q = N * N; 
+        auto group = _tix / L ;
+        auto m = _tix % L ;
+        
+        auto i = (m % Q) / N;
+        auto j = (m % Q) % N;
+        return std::make_tuple(2 * UNIT * i + UNIT, 2 * UNIT * j + UNIT, 0);
+    }
+}
+
+
+template<int SPLINE_DIM, int BLOCKSIZE>
+__device__ std::tuple<int, int, int> xyzmap_cube(int _tix, const int UNIT) {
+    if constexpr (SPLINE_DIM == 3) {
+        auto N = BLOCKSIZE / (UNIT * 2);
+        auto Q = N * N; 
+        auto i = _tix / Q;
+        auto j = (_tix % Q) / N;
+        auto k = (_tix % Q) % N;
+        return std::make_tuple(2 * UNIT * i + UNIT, 2 * UNIT * j + UNIT, 2 * UNIT * k + UNIT);
+    }
+}
+
+
+
+template <typename T1, typename T2, typename FP, int LEVEL, int SPLINE_DIM, int AnchorBlockSizeX, int AnchorBlockSizeY, int AnchorBlockSizeZ, int numAnchorBlockX, int numAnchorBlockY, int numAnchorBlockZ, int LINEAR_BLOCK_SIZE, bool WORKFLOW, bool PROBE_PRED_ERROR>
+__device__ void cusz::device_api::spline_layout_interpolate(
+    volatile T1 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                       [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                       [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    DIM3    data_size,
+    FP          eb_r,
+    FP          ebx2,
+    int         radius,
+    INTERPOLATION_PARAMS intp_param
+    )
+{
+    auto xblue = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+    auto yblue = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+    auto zblue = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+
+    auto xblue_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+    auto yblue_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy ); };
+    auto zblue_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+
+    auto xyellow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+    auto yyellow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
+    auto zyellow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+
+    auto xyellow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+    auto yyellow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
+    auto zyellow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2); };
+
+
+    auto xhollow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
+    auto yhollow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy); };
+    auto zhollow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+
+    auto xhollow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
+    auto yhollow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+    auto zhollow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz *2); };
+
+    auto nan_cubic_interp = [] __device__ (T1 a, T1 b, T1 c, T1 d) -> T1{
+        return (-a+9*b+9*c-d) / 16;
+    };
+
+    auto nat_cubic_interp = [] __device__ (T1 a, T1 b, T1 c, T1 d) -> T1{
+        return (-3*a+23*b+23*c-3*d) / 40;
+    };
+
+    constexpr auto COARSEN          = true;
+    constexpr auto NO_COARSEN       = false;
+    constexpr auto BORDER_INCLUSIVE = true;
+    constexpr auto BORDER_EXCLUSIVE = false;
+
+    
+    FP cur_ebx2=ebx2,cur_eb_r=eb_r;
+
+
+    auto calc_eb = [&](auto unit) {
+        cur_ebx2=ebx2,cur_eb_r=eb_r;
+        int temp=1;
+        while(temp<unit){
+            temp*=2;
+            cur_eb_r *= intp_param.alpha;
+            cur_ebx2 /= intp_param.alpha;
+
+        }
+        if(cur_ebx2 < ebx2 / intp_param.beta){
+            cur_ebx2 = ebx2 / intp_param.beta;
+            cur_eb_r = eb_r * intp_param.beta;
+
+        }
+    };
+    
+    int max_unit = ((AnchorBlockSizeX >= AnchorBlockSizeY) ? AnchorBlockSizeX : AnchorBlockSizeY);
+    max_unit = ((max_unit >= AnchorBlockSizeZ) ? max_unit : AnchorBlockSizeZ);
+    max_unit /= 2;
+    int unit_x = AnchorBlockSizeX, unit_y = AnchorBlockSizeY, unit_z = AnchorBlockSizeZ;
+    int level_id = LEVEL;
+    level_id -= 1;
+    #pragma unroll
+    for(int unit = max_unit; unit >= 1; unit /= 2, level_id--){
+        calc_eb(unit);
+        unit_x = (SPLINE_DIM >= 1) ? unit * 2 : 1;
+        unit_y = (SPLINE_DIM >= 2) ? unit * 2 : 1;
+        unit_z = (SPLINE_DIM >= 3) ? unit * 2 : 1;
+        if(level_id != 0){
+            if(intp_param.use_md[level_id]){
+                int N_x = AnchorBlockSizeX / (unit * 2);
+                int N_y = AnchorBlockSizeY / (unit * 2);
+                int N_z = AnchorBlockSizeZ / (unit * 2);
+                int N_line = N_x * (N_y + 1) * (N_z + 1) + (N_x + 1) * N_y * (N_z + 1) + (N_x + 1) * (N_y + 1) * N_z;
+                int N_face = N_x * N_y * (N_z + 1) + N_x * (N_y + 1) * N_z + (N_x + 1) * N_y * N_z; 
+                int N_cube = N_x * N_y * N_z;
+                if(intp_param.use_natural[level_id]==0){
+                    if constexpr (SPLINE_DIM >= 1)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>), true, false, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp, N_line);
+                    if constexpr (SPLINE_DIM >= 2)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>), false, true, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp, N_face);
+                    if constexpr (SPLINE_DIM >= 3)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>), false, false, true, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp, N_cube);
+                }
+                else{
+                    if constexpr (SPLINE_DIM >= 1)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>), true, false, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp, N_line);
+                    if constexpr (SPLINE_DIM >= 2)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>), false, true, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp, N_face);
+                    if constexpr (SPLINE_DIM >= 3)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>), false, false, true, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp, N_cube);
+                }
+            }
+            else{
+                if(intp_param.reverse[level_id]){
+                    if constexpr (SPLINE_DIM >= 1) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse), false, false, true, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_x /= 2;
+                    }
+                    if constexpr (SPLINE_DIM >= 2) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse), false, true, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y,numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_y /= 2;
+                    }
+                    if constexpr (SPLINE_DIM >= 3) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse), true, false, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xblue_reverse, yblue_reverse, zblue_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                    unit_z /= 2;
+                    }
+                }
+                else{
+                    if constexpr (SPLINE_DIM >= 3) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue), decltype(yblue), decltype(zblue), true, false, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xblue, yblue, zblue, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                    unit_z /= 2;
+                    }
+                    if constexpr (SPLINE_DIM >= 2) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow), decltype(yyellow), decltype(zyellow), false, true, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyellow, yyellow, zyellow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y, numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_y /= 2;
+                    }
+                    if constexpr (SPLINE_DIM >= 1) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow), decltype(yhollow), decltype(zhollow), false, false, true, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xhollow, yhollow, zhollow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_x /= 2;
+                    }
+                }
+        }
+
+        }
+        else{
+            if(intp_param.use_md[level_id]){
+                int N_x = AnchorBlockSizeX / (unit * 2);
+                int N_y = AnchorBlockSizeY / (unit * 2);
+                int N_z = AnchorBlockSizeZ / (unit * 2);
+                int N_line = N_x * (N_y + 1) * (N_z + 1) + (N_x + 1) * N_y * (N_z + 1) + (N_x + 1) * (N_y + 1) * N_z;
+                int N_face = N_x * N_y * (N_z + 1) + N_x * (N_y + 1) * N_z + (N_x + 1) * N_y * N_z; 
+                int N_cube = N_x * N_y * N_z;
+                if(intp_param.use_natural[level_id]==0){
+                    if constexpr (SPLINE_DIM >= 1)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>), true, false, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp, N_line);
+                    if constexpr (SPLINE_DIM >= 2)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>), false, true, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp, N_face);
+                    if constexpr (SPLINE_DIM >= 3)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>), false, false, true, LINEAR_BLOCK_SIZE, COARSEN, BORDER_EXCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp, N_cube);
+                }
+                else{
+                    if constexpr (SPLINE_DIM >= 1)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>), true, false, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp, N_line);
+                    if constexpr (SPLINE_DIM >= 2)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>), false, true, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp, N_face);
+                    if constexpr (SPLINE_DIM >= 3)
+                    interpolate_stage_md<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>), false, false, true, LINEAR_BLOCK_SIZE, COARSEN, BORDER_EXCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp, N_cube);
+                }
+            }
+            else{
+                if(intp_param.reverse[level_id]){
+                    if constexpr (SPLINE_DIM >= 1) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse), false, false, true, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_x /= 2;
+                    }
+                    if constexpr (SPLINE_DIM >= 2) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse), false, true, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y,numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_y /= 2;
+                    }
+                    if constexpr (SPLINE_DIM >= 3) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse), true, false, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_EXCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xblue_reverse, yblue_reverse, zblue_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                    unit_z /= 2;
+                    }
+                }
+                else{
+                    if constexpr (SPLINE_DIM >= 3) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue), decltype(yblue), decltype(zblue), true, false, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xblue, yblue, zblue, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                    unit_z /= 2;
+                    }
+                    if constexpr (SPLINE_DIM >= 2) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow), decltype(yyellow), decltype(zyellow), false, true, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xyellow, yyellow, zyellow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y, numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_y /= 2;
+                    }
+                    if constexpr (SPLINE_DIM >= 1) {
+                    interpolate_stage<T1, T2, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow), decltype(yhollow), decltype(zhollow), false, false, true, COARSEN, LINEAR_BLOCK_SIZE, BORDER_EXCLUSIVE, WORKFLOW>(s_data, s_ectrl,data_size, xhollow, yhollow, zhollow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[level_id], numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_x /= 2;
+                    }
+                }
+        }
+
+        }
+    }
+
+}
+
+/********************************************************************************
+ * host API/kernel
+ ********************************************************************************/
+template <typename TITER, int SPLINE_DIM = 3,
+int PROFILE_BLOCK_SIZE_X = 4,
+int PROFILE_BLOCK_SIZE_Y = 4,
+int PROFILE_BLOCK_SIZE_Z = 4,
+int PROFILE_NUM_BLOCK_X = 4,
+int PROFILE_NUM_BLOCK_Y = 4,
+int PROFILE_NUM_BLOCK_Z = 4, 
+int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__global__ void cusz::c_spline_profiling_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    TITER errors)
+{
+    // compile time variables
+    using T = typename std::remove_pointer<TITER>::type;
+ 
+
+    {
+        __shared__ struct {
+            T data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z][PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X];
+            T local_errs[2];
+           // T global_errs[6];
+        } shmem;
+        c_reset_scratch_profiling_data<T, SPLINE_DIM, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem.data, 0.0);
+        
+        global2shmem_profiling_data<T, T, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data);
+
+        cusz::device_api::auto_tuning<T, SPLINE_DIM, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem.data, shmem.local_errs, data_size, errors);
+
+    }
+}
+
+template <typename TITER, int SPLINE_DIM = 3, int PROFILE_NUM_BLOCK_X = 4, int PROFILE_NUM_BLOCK_Y = 4, int PROFILE_NUM_BLOCK_Z = 4, int  LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__global__ void cusz::c_spline_profiling_data_2(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    TITER errors)
+{
+    // compile time variables
+    using T = typename std::remove_pointer<TITER>::type;
+ 
+
+    {
+        __shared__ struct {
+            T data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z];
+            T neighbor_x [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+            T neighbor_y [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+            T neighbor_z [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+            T local_errs[6];
+           // T global_errs[6];
+        } shmem;
+
+
+        c_reset_scratch_profiling_data_2<T, SPLINE_DIM, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z,0.0);
+        global2shmem_profiling_data_2<T, T, SPLINE_DIM, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(data, data_size, data_leap,shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z);
+
+        if (TIX < 6 and BIX==0 and BIY==0 and BIZ==0) errors[TIX] = 0.0;//risky
+
+        cusz::device_api::auto_tuning_2<T, SPLINE_DIM, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(
+            shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z, shmem.local_errs, data_size, errors);
+
+        
+    }
+}
+
+
+template <int LEVEL> __forceinline__ __device__ void pre_compute(DIM3 data_size, volatile STRIDE3 grid_leaps[LEVEL + 1], volatile size_t prefix_nums[LEVEL + 1]){
+    if(TIX==0){
+        auto d_size = data_size;
+        
+        int level = 0;
+        while(level <= LEVEL){
+            grid_leaps[level].x = 1;
+            grid_leaps[level].y = d_size.x;
+            grid_leaps[level].z = d_size.x * d_size.y;
+            if(level < LEVEL){
+                d_size.x = (d_size.x + 1) >> 1;
+                d_size.y = (d_size.y + 1) >> 1;
+                d_size.z = (d_size.z + 1) >> 1;
+                prefix_nums[level] = d_size.x * d_size.y * d_size.z;
+            }
+            level++;
+        }   
+        prefix_nums[LEVEL] = 0;
+    }
+    __syncthreads(); 
+}
+
+template <typename TITER, typename EITER, typename FP,  int LEVEL, int SPLINE_DIM, int AnchorBlockSizeX, int AnchorBlockSizeY, int AnchorBlockSizeZ, int numAnchorBlockX, 
+int numAnchorBlockY, int numAnchorBlockZ, int LINEAR_BLOCK_SIZE, typename CompactVal, typename CompactIdx, typename CompactNum>
+__global__ void cusz::c_spline_infprecis_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    EITER   ectrl,
+    DIM3    ectrl_size,
+    STRIDE3 ectrl_leap,
+    TITER   anchor,
+    STRIDE3 anchor_leap,
+    CompactVal compact_val,
+    CompactIdx compact_idx,
+    CompactNum compact_num,
+    FP      eb_r,
+    FP      ebx2,
+    int     radius,
+    INTERPOLATION_PARAMS intp_param//,
+    )
+{
+    // compile time variables
+    using T = typename std::remove_pointer<TITER>::type;
+    using E = typename std::remove_pointer<EITER>::type;
+
+    {
+        __shared__ struct {
+            T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+             [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+             [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+            T ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+                    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+                    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+            STRIDE3 grid_leaps[LEVEL + 1];
+            size_t prefix_nums[LEVEL + 1];
+        } shmem;
+
+   
+        pre_compute<LEVEL>(ectrl_size, shmem.grid_leaps, shmem.prefix_nums);
+
+        c_reset_scratch_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.data, shmem.ectrl, radius);
+
+        global2shmem_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data);
+
+        c_gather_anchor<T, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ>(data, data_size, data_leap, anchor, anchor_leap);
+        cusz::device_api::spline_layout_interpolate<T, T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_COMPR, false>(
+            shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
+
+        shmem2global_data_with_compaction<T, E, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY,  numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.ectrl, ectrl, ectrl_size, ectrl_leap, radius, shmem.grid_leaps,shmem.prefix_nums, compact_val, compact_idx, compact_num);
+    }
+}
+
+template <
+    typename EITER,
+    typename TITER,
+    typename FP, 
+    int LEVEL,
+    int SPLINE_DIM, int AnchorBlockSizeX,
+    int AnchorBlockSizeY, int AnchorBlockSizeZ,
+    int numAnchorBlockX,  // Number of Anchor blocks along X
+    int numAnchorBlockY,  // Number of Anchor blocks along Y
+    int numAnchorBlockZ,  // Number of Anchor blocks along Z
+    int LINEAR_BLOCK_SIZE>
+__global__ void cusz::x_spline_infprecis_data(
+    EITER   ectrl,        // input 1
+    DIM3    ectrl_size,   //
+    STRIDE3 ectrl_leap,   //
+    TITER   anchor,       // input 2
+    DIM3    anchor_size,  //
+    STRIDE3 anchor_leap,  //
+    TITER   data,         // output
+    DIM3    data_size,    //
+    STRIDE3 data_leap,    //
+    TITER outlier_tmp,
+    FP      eb_r,
+    FP      ebx2,
+    int     radius,
+    INTERPOLATION_PARAMS intp_param)
+{
+    // compile time variables
+    using E = typename std::remove_pointer<EITER>::type;
+    using T = typename std::remove_pointer<TITER>::type;
+
+    __shared__ struct {
+        T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+        T ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+        STRIDE3 grid_leaps[LEVEL + 1];
+        size_t prefix_nums[LEVEL + 1];
+    } shmem;
+
+    pre_compute<LEVEL>(ectrl_size, shmem.grid_leaps, shmem.prefix_nums);
+
+    x_reset_scratch_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.data, shmem.ectrl, anchor, anchor_size, anchor_leap);
+    global2shmem_fuse<T, E, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(ectrl, ectrl_size, ectrl_leap, outlier_tmp, shmem.ectrl, shmem.grid_leaps, shmem.prefix_nums);
+
+    cusz::device_api::spline_layout_interpolate<T, T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_DECOMPR, false>(
+        shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
+    shmem2global_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.data, data, data_size, data_leap);
+}
+
+
+template <typename TITER>
+__global__ void cusz::reset_errors(TITER errors)
+{
+    if(TIX<36)
+        errors[TIX]=0;
+}
+
+template <typename T, int SPLINE_DIM>
+__forceinline__ __device__ void pre_compute_att(DIM3 sam_starts, DIM3 sam_bgs, DIM3 sam_strides, DIM3 &global_starts, INTERPOLATION_PARAMS &intp_param, uint8_t &level, uint8_t &unit, volatile T err[6], bool workflow);
+
+// template <typename T>
+// __forceinline__ __device__ void pre_compute_att<T, 3>(DIM3 sam_starts, DIM3 sam_bgs, DIM3 sam_strides, DIM3 &global_starts, INTERPOLATION_PARAMS &intp_param, uint8_t &level, uint8_t &unit, volatile T err[6], bool workflow){
+template <typename T, int SPLINE_DIM, int LEVEL>
+__forceinline__ __device__ void pre_compute_att(DIM3 sam_starts, DIM3 sam_bgs, DIM3 sam_strides, DIM3 &global_starts, INTERPOLATION_PARAMS &intp_param, uint8_t &level, uint8_t &unit, volatile T err[6], bool workflow){
+
+    if(TIX < 6) err[TIX] = 0.0;
+
+    auto grid_idx_x = BIX % sam_bgs.x;
+    auto grid_idx_y = (BIX / sam_bgs.x) % sam_bgs.y;
+    auto grid_idx_z = (BIX / sam_bgs.x) / sam_bgs.y;
+    global_starts.x = sam_starts.x + grid_idx_x * sam_strides.x;
+    global_starts.y = sam_starts.y + grid_idx_y * sam_strides.y;
+    global_starts.z = sam_starts.z + grid_idx_z * sam_strides.z;
+    
+    if CONSTEXPR (SPLINE_DIM == 3){
+        if(workflow == SPLINE3_PRED_ATT){
+            bool use_natural = false, use_md = false, reverse = false;
+            if (BIY == 0){
+                level = 2;
+            }
+            else if (BIY < 3){
+                level = 1;
+                use_natural = (BIY == 2);
+            }
+            else{
+                level = 0;
+                use_natural = BIY > 5;
+                use_md = (BIY == 5 or BIY == 8);
+                reverse = BIY % 3;
+            }       
+            intp_param.use_natural[level] = use_natural;
+            intp_param.use_md[level] = use_md;
+            intp_param.reverse[level] = reverse;
+        }
+        else{
+            level = 0;
+            if(BIY == 0){
+                intp_param.alpha = 1.0;
+                intp_param.beta = 2.0;
+            }
+            else if (BIY == 1){
+                intp_param.alpha = 1.25;
+                intp_param.beta = 2.0;
+            }
+            else{
+                intp_param.alpha = 1.5 + 0.25 * ((BIY - 2) / 3);
+                intp_param.beta = 2.0 + ((BIY - 2) % 3);
+            }
+        }
+        unit = 1 << level;
+    }
+
+    if CONSTEXPR (SPLINE_DIM == 2){
+    
+        if(workflow == SPLINE3_PRED_ATT){
+            bool use_natural = false, use_md = false, reverse = false;
+            level = LEVEL - (BIY / 6) - 1;
+            use_natural = (BIY % 6) >= 3;
+            use_md = (BIY % 3) == 2;
+            reverse = BIY % 3;
+            intp_param.use_natural[level] = use_natural;
+            intp_param.use_md[level] = use_md;
+            intp_param.reverse[level] = reverse;
+        }
+        else{
+            level = 0;
+            if(BIY == 0){
+                intp_param.alpha = 1.0;
+                intp_param.beta = 2.0;
+            }
+            else if (BIY == 1){
+                intp_param.alpha = 1.25;
+                intp_param.beta = 2.0;
+            }
+            else{
+                intp_param.alpha = 1.5 + 0.25 * ((BIY - 2) / 3);
+                intp_param.beta = 2.0 + ((BIY - 2) % 3);
+            }
+        }
+        unit = 1 << level;
+    }
+    
+    __syncthreads();
+}
+
+
+template <typename T1, typename T2, int SPLINE_DIM = 2, int AnchorBlockSizeX = 8, int AnchorBlockSizeY = 8, int AnchorBlockSizeZ = 8, int numAnchorBlockX = 4, int numAnchorBlockY = 1,  int numAnchorBlockZ = 1, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+__device__ void global2shmem_data_att(T1* data, DIM3 data_size, STRIDE3 data_leap,   volatile T2 s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+[AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+[AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)], DIM3 global_starts, uint8_t unit)
+{
+    constexpr auto TOTAL = (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)) *
+    (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)) * 
+    (AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3));
+
+    for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+        auto x = (_tix % (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)));
+        auto y = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) %
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto z = (_tix / (AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1))) /
+                 (AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2));
+        auto gx  = (x + global_starts.x);
+        auto gy  = (y + global_starts.y);
+        auto gz  = (z + global_starts.z);
+        auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+
+        if (gx < data_size.x and gy < data_size.y and gz < data_size.z  ) s_data[z][y][x] = data[gid];
+    }
+    __syncthreads();
+}
+
+
+template <
+    typename T,
+    typename FP,
+    int SPLINE_DIM, int AnchorBlockSizeX,
+    int AnchorBlockSizeY, int AnchorBlockSizeZ,
+    int numAnchorBlockX,
+    int numAnchorBlockY,
+    int numAnchorBlockZ,
+    typename LAMBDAX,
+    typename LAMBDAY,
+    typename LAMBDAZ,
+    bool BLUE,
+    bool YELLOW,
+    bool HOLLOW,
+    bool COARSEN,
+    int  LINEAR_BLOCK_SIZE,
+    bool BORDER_INCLUSIVE,
+    bool WORKFLOW
+    >
+__forceinline__ __device__ void interpolate_stage_att(
+    volatile T s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)][AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)][AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    DIM3    data_size,
+     DIM3    global_starts,
+    LAMBDAX     xmap,
+    LAMBDAY     ymap,
+    LAMBDAZ     zmap,
+    int         unit,
+    FP eb_r,
+    FP ebx2,
+    bool interpolator,
+    volatile T* error,
+    int  BLOCK_DIMX,
+    int  BLOCK_DIMY,
+    int  BLOCK_DIMZ)
+{
+    
+    // static_assert(BLOCK_DIMX * BLOCK_DIMY * (COARSEN ? 1 : BLOCK_DIMZ) <= BLOCK_DIM_SIZE, "block oversized");
+    static_assert((BLUE or YELLOW or HOLLOW) == true, "must be one hot");
+    static_assert((BLUE and YELLOW) == false, "must be only one hot (1)");
+    static_assert((BLUE and YELLOW) == false, "must be only one hot (2)");
+    static_assert((YELLOW and HOLLOW) == false, "must be only one hot (3)");
+    //DIM3 global_starts (global_starts_v.x,global_starts_v.y, global_starts_v.z);
+    auto run = [&](auto x, auto y, auto z) {
+        if (xyz_predicate_att<SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, BORDER_INCLUSIVE>(x, y, z,data_size, global_starts)) {
+            T pred = 0;
+
+            auto global_x=global_starts.x+x, global_y=global_starts.y+y, global_z=global_starts.z+z;
+            auto input_x = x;
+            auto input_BI = BIX;
+            auto input_GD = GDX;
+            auto input_gx = global_x;
+            auto input_gs = data_size.x;
+            auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+            auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+            auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+            auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+            int global_start_ = global_starts.x;
+            int p1 = -1, p2 = 9, p3 = 9, p4 = -1, p5 = 16;
+            if(interpolator==0){
+               p1 = -3, p2 = 23, p3 = 23, p4 = -3, p5 = 40;
+           }
+           if CONSTEXPR (BLUE){
+               input_x = z;
+               input_BI = BIZ;
+               input_GD = GDZ;
+               input_gx = global_z;
+               input_gs = data_size.z;
+               global_start_ = global_starts.z;
+               right_bound = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+           }
+           if CONSTEXPR (YELLOW){
+               input_x = y;
+               input_BI = BIY;
+               input_GD = GDY;
+               input_gx = global_y;
+               input_gs = data_size.y;
+               global_start_ = global_starts.y;
+               right_bound = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+           }
+           
+           int id_[4], s_id[4];
+           id_[0] =  input_x - 3 * unit;
+           id_[0] =  id_[0] >= 0 ? id_[0] : 0;
+           
+           id_[1] = input_x - unit;
+           id_[1] = id_[1] >= 0 ? id_[1] : 0;
+           
+           id_[2] = input_x + unit;
+           id_[2] = id_[2] < right_bound ? id_[2] : 0;
+           
+           id_[3] = input_x + 3 * unit;
+           id_[3] = id_[3] < right_bound ? id_[3] : 0;
+           
+           s_id[0] = x_size * y_size * z + x_size * y + id_[0];
+           s_id[1] = x_size * y_size * z + x_size * y + id_[1];
+           s_id[2] = x_size * y_size * z + x_size * y + id_[2];
+           s_id[3] = x_size * y_size * z + x_size * y + id_[3];
+           if CONSTEXPR (BLUE){
+            s_id[0] = x_size * y_size * id_[0] + x_size * y + x;
+            s_id[1] = x_size * y_size * id_[1] + x_size * y + x;
+            s_id[2] = x_size * y_size * id_[2] + x_size * y + x;
+            s_id[3] = x_size * y_size * id_[3] + x_size * y + x;
+           }
+           if CONSTEXPR (YELLOW){
+            s_id[0] = x_size * y_size * z + x_size * id_[0] + x;
+            s_id[1] = x_size * y_size * z + x_size * id_[1] + x;
+            s_id[2] = x_size * y_size * z + x_size * id_[2] + x;
+            s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
+           }
+           
+           T tmp_[4];
+           
+           bool case1 = (global_start_ + AnchorBlockSizeX * numAnchorBlockX < input_gs);
+           bool case2 = (input_x >= 3 * unit);
+           bool case3 = (input_x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX);
+           bool case4 = (input_gx + 3 * unit < input_gs);
+           bool case5 = (input_gx + unit < input_gs);
+           
+           
+           // 预加载 shared memory 数据到寄存器
+           T tmp0 = *((T*)s_data + s_id[0]); 
+           T tmp1 = *((T*)s_data + s_id[1]); 
+           T tmp2 = *((T*)s_data + s_id[2]); 
+           T tmp3 = *((T*)s_data + s_id[3]); 
+           
+           // 初始预测值
+           pred = tmp1;
+           
+           // 计算不同 case 对应的 pred
+           if ((case1 && !case2 && !case3) || (!case1 && !case2 && !(case3 && case4) && case5)) {
+               pred = (tmp1 + tmp2) / 2;
+           }
+           else if ((case1 && !case2 && case3) || (!case1 && !case2 && case3 && case4)) {
+               pred = (3 * tmp1 + 6 * tmp2 - tmp3) / 8;
+           }
+           else if ((case1 && case2 && !case3) || (!case1 && case2 && !(case3 && case4) && case5)) {
+               pred = (-tmp0 + 6 * tmp1 + 3 * tmp2) / 8;
+           }
+           else if ((case1 && case2 && case3) || (!case1 && case2 && case3 && case4)) {
+               pred = (p1 * tmp0 + p2 * tmp1 + p3 * tmp2 + p4 * tmp3) / p5;
+           }
+
+             if CONSTEXPR (WORKFLOW == SPLINE3_AB_ATT) {
+                
+                auto          err = s_data[z][y][x] - pred;
+                decltype(err) code;
+                // TODO unsafe, did not deal with the out-of-cap case
+                {
+                    code = fabs(err) * eb_r + 1;
+                    code = err < 0 ? -code : code;
+                    code = int(code / 2) ;
+                }
+                
+                s_data[z][y][x]  = pred + code * ebx2;
+                atomicAdd(const_cast<T*>(error),code!=0);
+                
+
+            }
+            else{
+                // if(TIX == 0 and BIX == 0) printf("BIY=%d s_data[%d][%d][%d]=%f, pred=%f\n", BIY, z, y, x, s_data[z][y][x], pred);
+                atomicAdd(const_cast<T*>(error),fabs(s_data[z][y][x]-pred));
+            }
+        }
+    };
+    // -------------------------------------------------------------------------------- //
+    auto TOTAL = BLOCK_DIMX * BLOCK_DIMY * BLOCK_DIMZ;
+    // if(TIX == 0 and BIX == 0) printf("interpolate_stage_att BIY=%d, BLOCK_DIMX=%d, BLOCK_DIMY=%d, BLOCK_DIMZ=%d, TOTAL=%d\n", BIY, BLOCK_DIMX, BLOCK_DIMY, BLOCK_DIMZ, TOTAL);
+    if CONSTEXPR (COARSEN) {
+        for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+            auto itix = (_tix % BLOCK_DIMX);
+            auto itiy = (_tix / BLOCK_DIMX) % BLOCK_DIMY;
+            auto itiz = (_tix / BLOCK_DIMX) / BLOCK_DIMY;
+            auto x    = xmap(itix, unit);
+            auto y    = ymap(itiy, unit);
+            auto z    = zmap(itiz, unit);
+            
+            run(x, y, z);
+        }
+    }
+    else {
+        if (TIX < TOTAL){
+            auto itix = (TIX % BLOCK_DIMX);
+            auto itiy = (TIX / BLOCK_DIMX) % BLOCK_DIMY;
+            auto itiz = (TIX / BLOCK_DIMX) / BLOCK_DIMY;
+            auto x    = xmap(itix, unit);
+            auto y    = ymap(itiy, unit);
+            auto z    = zmap(itiz, unit);
+            run(x, y, z);
+        }
+    }
+    __syncthreads();
+}
+
+template <
+    typename T,
+    typename FP,
+    int SPLINE_DIM, int AnchorBlockSizeX,
+    int AnchorBlockSizeY, int AnchorBlockSizeZ,
+    int numAnchorBlockX,
+    int numAnchorBlockY,
+    int numAnchorBlockZ,
+    typename LAMBDA,
+    bool LINE,
+    bool FACE,
+    bool CUBE,
+    int  LINEAR_BLOCK_SIZE,
+    bool COARSEN,
+    bool BORDER_INCLUSIVE,
+    bool WORKFLOW,
+    typename INTERP>
+__forceinline__ __device__ void interpolate_stage_md_att(
+    volatile T s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)][AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)][AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    DIM3    data_size,
+    DIM3    global_starts,
+    LAMBDA xyzmap,
+    int         unit,
+    FP eb_r,
+    FP ebx2,
+    INTERP cubic_interpolator,
+    volatile T* error,
+    int NUM_ELE)
+{
+    // static_assert(COARSEN or (NUM_ELE <= BLOCK_DIM_SIZE), "block oversized");
+    static_assert((LINE or FACE or CUBE) == true, "must be one hot");
+    static_assert((LINE and FACE) == false, "must be only one hot (1)");
+    static_assert((LINE and CUBE) == false, "must be only one hot (2)");
+    static_assert((FACE and CUBE) == false, "must be only one hot (3)");
+    //DIM3 global_starts (global_starts_v.x,global_starts_v.y, global_starts_v.z);
+    auto run = [&](auto x, auto y, auto z) {
+        if (xyz_predicate_att<SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, BORDER_INCLUSIVE>(x, y, z, data_size, global_starts)) {
+            T pred = 0;
+
+            auto global_x=global_starts.x+x, global_y=global_starts.y+y, global_z=global_starts.z+z;
+           T tmp_z[4], tmp_y[4], tmp_x[4];
+           int id_z[4], id_y[4], id_x[4];
+           id_z[0] = (z - 3 * unit >= 0) ? z - 3 * unit : 0;
+           id_z[1] = (z - unit >= 0) ? z - unit : 0;
+           id_z[2] = (z + unit <=  AnchorBlockSizeZ * numAnchorBlockZ) ? z + unit : 0;
+           id_z[3] = (z + 3 * unit <=  AnchorBlockSizeZ * numAnchorBlockZ) ? z + 3 * unit : 0;
+           
+           id_y[0] = (y - 3 * unit >= 0) ? y - 3 * unit : 0;
+           id_y[1] = (y - unit >= 0) ? y - unit : 0;
+           id_y[2] = (y + unit <= AnchorBlockSizeY * numAnchorBlockY) ? y + unit : 0;
+           id_y[3] = (y + 3 * unit <= AnchorBlockSizeY * numAnchorBlockY) ? y + 3 * unit : 0;
+           
+           id_x[0] = (x - 3 * unit >= 0) ? x - 3 * unit : 0;
+           id_x[1] = (x - unit >= 0) ? x - unit : 0;
+           id_x[2] = (x + unit <= AnchorBlockSizeX * numAnchorBlockX) ? x + unit : 0;
+           id_x[3] = (x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX) ? x + 3 * unit : 0;
+           
+            if CONSTEXPR (LINE) {
+                bool I_Y = (y % (2*unit) )> 0; 
+                bool I_Z = (z % (2*unit) )> 0; 
+
+                pred = 0;
+                auto input_x = x;
+                auto input_BI = BIX;
+                auto input_GD = GDX;
+                auto input_gx = global_x;
+                auto input_gs = data_size.x;
+                auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                int global_start_ = global_starts.x;
+                if (I_Z){
+                    input_x = z;
+                    input_BI = BIZ;
+                    input_GD = GDZ;
+                    input_gx = global_z;
+                    input_gs = data_size.z;
+                    global_start_ = global_starts.z;
+                    right_bound = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                }
+                else if (I_Y){
+                    input_x = y;
+                    input_BI = BIY;
+                    input_GD = GDY;
+                    input_gx = global_y;
+                    input_gs = data_size.y;
+                    global_start_ = global_starts.y;
+                    right_bound = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                }
+                
+                int id_[4], s_id[4];
+                id_[0] =  input_x - 3 * unit;
+                id_[0] =  id_[0] >= 0 ? id_[0] : 0;
+            
+                id_[1] = input_x - unit;
+                id_[1] = id_[1] >= 0 ? id_[1] : 0;
+            
+                id_[2] = input_x + unit;
+                id_[2] = id_[2] < right_bound ? id_[2] : 0;
+                
+                id_[3] = input_x + 3 * unit;
+                id_[3] = id_[3] < right_bound ? id_[3] : 0;
+                
+                s_id[0] = x_size * y_size * z + x_size * y + id_[0];
+                s_id[1] = x_size * y_size * z + x_size * y + id_[1];
+                s_id[2] = x_size * y_size * z + x_size * y + id_[2];
+                s_id[3] = x_size * y_size * z + x_size * y + id_[3];
+                if (I_Z){
+                    s_id[0] = x_size * y_size * id_[0] + x_size * y + x;
+                    s_id[1] = x_size * y_size * id_[1] + x_size * y + x;
+                    s_id[2] = x_size * y_size * id_[2] + x_size * y + x;
+                    s_id[3] = x_size * y_size * id_[3] + x_size * y + x;
+                }
+                else if (I_Y){
+                    s_id[0] = x_size * y_size * z + x_size * id_[0] + x;
+                    s_id[1] = x_size * y_size * z + x_size * id_[1] + x;
+                    s_id[2] = x_size * y_size * z + x_size * id_[2] + x;
+                    s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
+                }
+
+                T tmp_[4];
+            
+                bool case1 = (global_start_ + AnchorBlockSizeX * numAnchorBlockX < input_gs);
+                bool case2 = (input_x >= 3 * unit);
+                bool case3 = (input_x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX);
+                bool case4 = (input_gx + 3 * unit < input_gs);
+                bool case5 = (input_gx + unit < input_gs);
+                
+                
+                // 预加载 shared memory 数据到寄存器
+                T tmp0 = *((T*)s_data + s_id[0]); 
+                T tmp1 = *((T*)s_data + s_id[1]); 
+                T tmp2 = *((T*)s_data + s_id[2]); 
+                T tmp3 = *((T*)s_data + s_id[3]); 
+    
+                // 初始预测值
+                pred = tmp1;
+    
+                // 计算不同 case 对应的 pred
+                if ( (case1 && case2 && case3) || (!case1 && case2 && case3 && case4)) {
+                    pred = cubic_interpolator(tmp0, tmp1, tmp2, tmp3);
+                    
+                }
+                else if ((case1 && case2 && !case3) || ( !case1 && case2 && !(case3 && case4) && case5)) {
+                    pred = (-tmp0 + 6 * tmp1 + 3 * tmp2) / 8;
+                }
+                else if ((case1 && !case2 && case3) || (!case1 && !case2 && case3 && case4 )){
+                    pred = (3 * tmp1 + 6 * tmp2 - tmp3) / 8;   
+                }
+                else if ((case1 && !case2 && !case3) || (!case1 && !case2 && !(case3 && case4) && case5)) {
+                    pred = (tmp1 + tmp2) / 2;
+                }
+
+            }
+            auto get_interp_order = [&](auto x, auto gx, auto gs){
+                int b = (x >= 3 * unit) ? 3 : 1;
+                int f = ((x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX) && ((gx + 3 * unit < gs))) ? 3 :
+                (((gx + unit < gs)) ? 1 : 0);
+
+                return (b == 3) ? ((f == 3) ? 4 : ((f == 1) ? 3 : 0)) 
+                                : ((f == 3) ? 2 : ((f == 1) ? 1 : 0));
+            };
+            if CONSTEXPR (FACE) {  //
+
+                bool I_YZ = (x % (2*unit) ) == 0;
+                bool I_XZ = (y % (2*unit ) )== 0;
+                int x_1,BI_1,GD_1,gx_1,gs_1;
+                int x_2,BI_2,GD_2,gx_2,gs_2;
+                int s_id_1[4], s_id_2[4];
+                auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
+                auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
+                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                if (I_YZ){
+                   
+                 x_1 = z,BI_1 = BIZ, GD_1 = GDZ, gx_1 = global_z,gs_1 = data_size.z;
+                 x_2 = y,BI_2 = BIY, GD_2 = GDY, gx_2 = global_y, gs_2 = data_size.y;
+                 s_id_1[0] = x_size * y_size * id_z[0] + x_size * y + x;
+                 s_id_1[1] = x_size * y_size * id_z[1] + x_size * y + x;
+                 s_id_1[2] = x_size * y_size * id_z[2] + x_size * y + x;
+                 s_id_1[3] = x_size * y_size * id_z[3] + x_size * y + x;
+                 s_id_2[0] = x_size * y_size * z + x_size * id_y[0] + x;
+                 s_id_2[1] = x_size * y_size * z + x_size * id_y[1] + x;
+                 s_id_2[2] = x_size * y_size * z + x_size * id_y[2] + x;
+                 s_id_2[3] = x_size * y_size * z + x_size * id_y[3] + x;
+                 pred = s_data[id_z[1]][id_y[1]][x];
+
+                }
+                else if (I_XZ){
+                    x_1 = z,BI_1 = BIZ, GD_1 = GDZ, gx_1 = global_z,gs_1 = data_size.z;
+                    x_2 = x,BI_2 = BIX, GD_2 = GDX, gx_2 = global_x, gs_2 = data_size.x;
+                    s_id_1[0] = x_size * y_size * id_z[0] + x_size * y + x;
+                    s_id_1[1] = x_size * y_size * id_z[1] + x_size * y + x;
+                    s_id_1[2] = x_size * y_size * id_z[2] + x_size * y + x;
+                    s_id_1[3] = x_size * y_size * id_z[3] + x_size * y + x;
+                    
+                    s_id_2[0] = x_size * y_size * z + x_size * y + id_x[0];
+                    s_id_2[1] = x_size * y_size * z + x_size * y + id_x[1];
+                    s_id_2[2] = x_size * y_size * z + x_size * y + id_x[2];
+                    s_id_2[3] = x_size * y_size * z + x_size * y + id_x[3];
+                    pred = s_data[id_z[1]][y][id_x[1]];
+                    
+                }
+                else{
+                    x_1 = y,BI_1 = BIY, GD_1 = GDY, gx_1 = global_y, gs_1 = data_size.y;
+                    x_2 = x,BI_2 = BIX, GD_2 = GDX, gx_2 = global_x, gs_2 = data_size.x;
+                    s_id_1[0] = x_size * y_size * z + x_size * id_y[0] + x;
+                    s_id_1[1] = x_size * y_size * z + x_size * id_y[1] + x;
+                    s_id_1[2] = x_size * y_size * z + x_size * id_y[2] + x;
+                    s_id_1[3] = x_size * y_size * z + x_size * id_y[3] + x;
+                    s_id_2[0] = x_size * y_size * z + x_size * y + id_x[0];
+                    s_id_2[1] = x_size * y_size * z + x_size * y + id_x[1];
+                    s_id_2[2] = x_size * y_size * z + x_size * y + id_x[2];
+                    s_id_2[3] = x_size * y_size * z + x_size * y + id_x[3];
+                    pred = s_data[z][id_y[1]][id_x[1]];
+                }
+
+                    auto interp_1 = get_interp_order(x_1,gx_1,gs_1);
+                    auto interp_2 = get_interp_order(x_2,gx_2,gs_2);
+
+                    int case_num = interp_1 + interp_2 * 5;
+
+                    if (interp_1 == 4 && interp_2 == 4) {
+                        pred = (cubic_interpolator(*((T*)s_data + s_id_1[0]), 
+                        *((T*)s_data + s_id_1[1]), 
+                        *((T*)s_data + s_id_1[2]), 
+                        *((T*)s_data + s_id_1[3])) +
+                         cubic_interpolator(*((T*)s_data + s_id_2[0]), 
+                        *((T*)s_data + s_id_2[1]), 
+                        *((T*)s_data + s_id_2[2]), 
+                        *((T*)s_data + s_id_2[3]))) / 2;
+                    } else if (interp_1 != 4 && interp_2 == 4) {
+                        pred = cubic_interpolator(*((T*)s_data + s_id_2[0]), 
+                        *((T*)s_data + s_id_2[1]), 
+                        *((T*)s_data + s_id_2[2]), 
+                        *((T*)s_data + s_id_2[3]));
+                    } else if (interp_1 == 4 && interp_2 != 4) {
+                        pred = cubic_interpolator(*((T*)s_data + s_id_1[0]), 
+                        *((T*)s_data + s_id_1[1]), 
+                        *((T*)s_data + s_id_1[2]), 
+                        *((T*)s_data + s_id_1[3]));
+                    } else if (interp_1 == 3 && interp_2 == 3) {
+                        pred = (-(*((T*)s_data + s_id_2[0]))+6*(*((T*)s_data + s_id_2[1])) + 3*(*((T*)s_data + s_id_2[2]))) / 8;
+                        pred += (-(*((T*)s_data + s_id_1[0]))+6*(*((T*)s_data + s_id_1[1])) + 3*(*((T*)s_data + s_id_1[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 3 && interp_2 == 2) {
+                        pred = (3*(*((T*)s_data + s_id_2[1]))+6*(*((T*)s_data + s_id_2[2])) - (*((T*)s_data + s_id_2[3]))) / 8;
+                        pred += (-(*((T*)s_data + s_id_1[0]))+6*(*((T*)s_data + s_id_1[1])) + 3*(*((T*)s_data + s_id_1[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 3 && interp_2 < 2) {
+                        pred = (-(*((T*)s_data + s_id_1[0]))+6*(*((T*)s_data + s_id_1[1])) + 3*(*((T*)s_data + s_id_1[2]))) / 8;
+                    } else if (interp_1 == 2 && interp_2 == 3) {
+                        pred = (3*(*((T*)s_data + s_id_1[1]))+6*(*((T*)s_data + s_id_1[2])) - (*((T*)s_data + s_id_1[3]))) / 8;
+                        pred += (-(*((T*)s_data + s_id_2[0]))+6*(*((T*)s_data + s_id_2[1])) + 3*(*((T*)s_data + s_id_2[2]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 2 && interp_2 == 2) {
+                        pred = (3*(*((T*)s_data + s_id_1[1]))+6*(*((T*)s_data + s_id_1[2])) - (*((T*)s_data + s_id_1[3]))) / 8;
+                        pred += (3*(*((T*)s_data + s_id_2[1]))+6*(*((T*)s_data + s_id_2[2])) - (*((T*)s_data + s_id_2[3]))) / 8;
+                        pred /= 2;
+                    } else if (interp_1 == 2 && interp_2 < 2) {
+                        pred = (3*(*((T*)s_data + s_id_1[1]))+6*(*((T*)s_data + s_id_1[2])) - (*((T*)s_data + s_id_1[3]))) / 8;
+                    } else if (interp_1 <= 1 && interp_2 == 3) {
+                        pred = (-(*((T*)s_data + s_id_2[0]))+6*(*((T*)s_data + s_id_2[1])) + 3*(*((T*)s_data + s_id_2[2]))) / 8;
+                    } else if (interp_1 <= 1 && interp_2 == 2) {
+                        pred = (3*(*((T*)s_data + s_id_2[1]))+6*(*((T*)s_data + s_id_2[2])) - (*((T*)s_data + s_id_2[3]))) / 8;
+                    } else if (interp_1 == 1 && interp_2 == 1) {
+                        pred = ((*((T*)s_data + s_id_2[1]))+(*((T*)s_data + s_id_2[2]))) / 2;
+                        pred += ((*((T*)s_data + s_id_1[1]))+(*((T*)s_data + s_id_1[2]))) / 2;
+                        pred /= 2;
+                    } else if (interp_1 == 1 && interp_2 < 1) {
+                        
+                        pred = ((*((T*)s_data + s_id_1[1]))+(*((T*)s_data + s_id_1[2]))) / 2;
+                    } else if (interp_1 == 0 && interp_2 == 1) {
+                        pred = ((*((T*)s_data + s_id_2[1]))+(*((T*)s_data + s_id_2[2]))) / 2;
+                    }
+                    else{
+                        pred = (*((T*)s_data + s_id_1[1])) + (*((T*)s_data + s_id_2[1])) - pred;
+                    }
+                    
+            }
+
+            if CONSTEXPR (CUBE) {  //
+                auto interp_z = get_interp_order(z,global_z,data_size.z);
+                auto interp_y = get_interp_order(y,global_y,data_size.y);
+                auto interp_x = get_interp_order(x,global_x,data_size.x);
+                
+                #pragma unroll
+                for(int id_itr = 0; id_itr < 4; ++id_itr){
+                 tmp_x[id_itr] = s_data[z][y][id_x[id_itr]]; 
+                }
+                if(interp_z == 4){
+                    #pragma unroll
+                    for(int id_itr = 0; id_itr < 4; ++id_itr){
+                        tmp_z[id_itr] = s_data[id_z[id_itr]][y][x];
+                       }
+                }
+                if(interp_y == 4){
+                    #pragma unroll
+                    for(int id_itr = 0; id_itr < 4; ++id_itr){
+                     tmp_y[id_itr] = s_data[z][id_y[id_itr]][x]; 
+                    }
+                }
+
+
+                T pred_z[5], pred_y[5], pred_x[5];
+                pred_x[0] = tmp_x[1];
+                pred_x[1] = cubic_interpolator(tmp_x[0],tmp_x[1],tmp_x[2],tmp_x[3]);
+                pred_x[2] = (-tmp_x[0]+6*tmp_x[1] + 3*tmp_x[2]) / 8;
+                pred_x[3] = (3*tmp_x[1] + 6*tmp_x[2]-tmp_x[3]) / 8;
+                pred_x[4] = (tmp_x[1] + tmp_x[2]) / 2;
+                
+                pred_y[1] = cubic_interpolator(tmp_y[0],tmp_y[1],tmp_y[2],tmp_y[3]);
+
+                
+                pred_z[1] = cubic_interpolator(tmp_z[0],tmp_z[1],tmp_z[2],tmp_z[3]);
+                
+            
+                
+                pred = pred_x[0];
+                pred = (interp_z == 4 && interp_y == 4 && interp_x == 4) ? (pred_x[1] +  pred_y[1] + pred_z[1]) / 3 : pred;
+                
+                pred = (interp_z == 4 && interp_y == 4 && interp_x != 4) ? (pred_z[1] + pred_y[1]) / 2 : pred;
+                pred = (interp_z == 4 && interp_y != 4 && interp_x == 4) ? (pred_z[1] + pred_x[1]) / 2 : pred;
+                pred = (interp_z != 4 && interp_y == 4 && interp_x == 4) ? (pred_y[1] + pred_x[1]) / 2 : pred;
+                
+                pred = (interp_z == 4 && interp_y != 4 && interp_x != 4) ? pred_z[1]: pred;
+                pred = (interp_z != 4 && interp_y == 4 && interp_x != 4) ? pred_y[1]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 4) ? pred_x[1]: pred;
+
+
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 3) ? pred_x[2]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 2) ? pred_x[3]: pred;
+                pred = (interp_z != 4 && interp_y != 4 && interp_x == 1) ? pred_x[4]: pred;
+                // pred = (interp_z != 4 && interp_y != 4 && interp_x == 0) ? pred_x[0]: pred;
+            }
+
+
+  
+            if CONSTEXPR (WORKFLOW == SPLINE3_AB_ATT) {
+                
+                auto          err = s_data[z][y][x] - pred;
+                decltype(err) code;
+                // TODO unsafe, did not deal with the out-of-cap case
+                {
+                    code = fabs(err) * eb_r + 1;
+                    code = err < 0 ? -code : code;
+                    code = int(code / 2) ;
+                }
+                s_data[z][y][x]  = pred + code * ebx2;
+                atomicAdd(const_cast<T*>(error),code!=0);
+            }
+            else{
+                atomicAdd(const_cast<T*>(error),fabs(s_data[z][y][x]-pred));
+            }
+        }
+    };
+    // -------------------------------------------------------------------------------- //
+
+    if CONSTEXPR (COARSEN) {
+        auto TOTAL = NUM_ELE;
+            for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                auto [x,y,z]    = xyzmap(_tix, unit);
+                run(x, y, z);
+            }   
+    }
+    else {
+        if(TIX<NUM_ELE){
+            auto [x,y,z]    = xyzmap(TIX, unit);
+            run(x, y, z);
+        }
+    }
+    __syncthreads();
+}
+
+
+template <typename T, typename FP, int LEVEL, int SPLINE_DIM, int AnchorBlockSizeX, int AnchorBlockSizeY, int AnchorBlockSizeZ, int numAnchorBlockX, int numAnchorBlockY, int numAnchorBlockZ, int LINEAR_BLOCK_SIZE, bool WORKFLOW>
+__device__ void cusz::device_api::spline_layout_interpolate_att(
+    volatile T s_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)],
+    DIM3    data_size,
+    DIM3 global_starts, FP eb_r, FP ebx2, uint8_t level, INTERPOLATION_PARAMS intp_param, volatile T *error)
+{
+    auto xblue = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+    auto yblue = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+    auto zblue = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+
+    auto xblue_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+    auto yblue_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy ); };
+    auto zblue_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+
+    auto xyellow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+    auto yyellow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
+    auto zyellow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+
+    auto xyellow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+    auto yyellow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2 + 1); };
+    auto zyellow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2); };
+
+
+    auto xhollow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 + 1); };
+    auto yhollow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy); };
+    auto zhollow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+
+    auto xhollow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 + 1); };
+    auto yhollow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+    auto zhollow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz *2); };
+
+    auto nan_cubic_interp = [] __device__ (T a, T b, T c, T d) -> T{
+        return (-a+9*b+9*c-d) / 16;
+    };
+
+    auto nat_cubic_interp = [] __device__ (T a, T b, T c, T d) -> T{
+        return (-3*a+23*b+23*c-3*d) / 40;
+    };
+    constexpr auto COARSEN          = true;
+    constexpr auto NO_COARSEN       = false;
+    constexpr auto BORDER_INCLUSIVE = true;
+    constexpr auto BORDER_EXCLUSIVE = false;
+
+
+    int unit;
+
+    FP cur_ebx2 = ebx2, cur_eb_r = eb_r;
+
+
+    auto calc_eb = [&](auto unit) {
+        cur_ebx2 = ebx2, cur_eb_r = eb_r;
+        int temp = 1;
+        while(temp < unit){
+            temp *= 2;
+            cur_eb_r *= intp_param.alpha;
+            cur_ebx2 /= intp_param.alpha;
+        }
+        if(cur_ebx2 < ebx2 / intp_param.beta){
+            cur_ebx2 = ebx2 / intp_param.beta;
+            cur_eb_r = eb_r * intp_param.beta;
+        }
+    };
+
+   
+ 
+    
+    if CONSTEXPR (WORKFLOW == SPLINE3_AB_ATT){
+        int max_unit = ((AnchorBlockSizeX >= AnchorBlockSizeY) ? AnchorBlockSizeX : AnchorBlockSizeY);
+        max_unit = ((max_unit >= AnchorBlockSizeZ) ? max_unit : AnchorBlockSizeZ);
+        max_unit /= 2;
+        int unit_x = AnchorBlockSizeX, unit_y = AnchorBlockSizeY, unit_z = AnchorBlockSizeZ;
+        #pragma unroll
+        for(int unit = max_unit; unit >= 1; unit /= 2){
+            calc_eb(unit);
+            unit_x = (SPLINE_DIM >= 1) ? unit * 2 : 1;
+            unit_y = (SPLINE_DIM >= 2) ? unit * 2 : 1;
+            unit_z = (SPLINE_DIM >= 3) ? unit * 2 : 1;
+            if(intp_param.use_md[level]){
+                int N_x = AnchorBlockSizeX / (unit * 2);
+                int N_y = AnchorBlockSizeY / (unit * 2);
+                int N_z = AnchorBlockSizeZ / (unit * 2);
+                int N_line = N_x * (N_y + 1) * (N_z + 1) + (N_x + 1) * N_y * (N_z + 1) + (N_x + 1) * (N_y + 1) * N_z;
+                int N_face = N_x * N_y * (N_z + 1) + N_x * (N_y + 1) * N_z + (N_x + 1) * N_y * N_z; 
+                int N_cube = N_x * N_y * N_z;
+                if(intp_param.use_natural[level] == 0){
+                    if CONSTEXPR (SPLINE_DIM >= 1)
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>), true, false, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r,cur_ebx2, nan_cubic_interp,error, N_line);
+
+                    if CONSTEXPR (SPLINE_DIM >= 2)
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>), false, true, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size,global_starts, xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r,cur_ebx2, nan_cubic_interp,error, N_face);
+
+                    if CONSTEXPR (SPLINE_DIM >= 3)
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>), false, false, true, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r,cur_ebx2, nan_cubic_interp, error, N_cube);
+                }
+                else{
+                    if CONSTEXPR (SPLINE_DIM >= 1)
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>), true, false, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size, global_starts, xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r,cur_ebx2, nat_cubic_interp, error, N_line);
+
+                    if CONSTEXPR (SPLINE_DIM >= 2)
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>), false, true, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size, global_starts, xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, nat_cubic_interp, error, N_face);
+
+                    if CONSTEXPR (SPLINE_DIM >= 3)
+                    interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>), false, false, true, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size, global_starts, xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, nat_cubic_interp, error, N_cube);
+                }
+
+            }
+            else{
+                if(intp_param.reverse[level]){
+                    if CONSTEXPR (SPLINE_DIM >= 1){
+                        interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  false, false, true, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size, global_starts, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r,cur_ebx2, intp_param.use_natural[level], error, numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                        unit_x /= 2;
+                    }
+                    if CONSTEXPR (SPLINE_DIM >= 2){
+                        interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse), false, true, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size, global_starts, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r,cur_ebx2, intp_param.use_natural[level], error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y, numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                        unit_y /= 2;
+                    }
+                    if CONSTEXPR (SPLINE_DIM >= 3){
+                        interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse), true, false, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xblue_reverse, yblue_reverse, zblue_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[level],error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                        unit_z /= 2;
+                    }
+                }
+                else{
+                    if CONSTEXPR (SPLINE_DIM >= 3){
+                        interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue), decltype(yblue), decltype(zblue),  true, false, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xblue, yblue, zblue, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[level], error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                        unit_z /= 2;
+                    }
+                    if CONSTEXPR (SPLINE_DIM >= 2){
+                        interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow), decltype(yyellow), decltype(zyellow), false, true, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xyellow, yyellow, zyellow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[level],error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y, numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                        unit_y /= 2;
+                    }
+                    if CONSTEXPR (SPLINE_DIM >= 1){
+                        interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow), decltype(yhollow), decltype(zhollow), false, false, true, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xhollow, yhollow, zhollow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[level],error,  numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                        unit_x /= 2;
+                    }
+                }
+            }
+        }
+    }
+
+    if CONSTEXPR (WORKFLOW != SPLINE3_AB_ATT){
+        
+        unit = 1 << level;
+        int unit_x = (SPLINE_DIM >= 1) ? unit * 2 : 1;
+        int unit_y = (SPLINE_DIM >= 2) ? unit * 2 : 1;
+        int unit_z = (SPLINE_DIM >= 3) ? unit * 2 : 1;
+        if(intp_param.use_md[level]){
+            int N_x = AnchorBlockSizeX / (unit * 2);
+            int N_y = AnchorBlockSizeY / (unit * 2);
+            int N_z = AnchorBlockSizeZ / (unit * 2);
+            int N_line = N_x * (N_y + 1) * (N_z + 1) + (N_x + 1) * N_y * (N_z + 1) + (N_x + 1) * (N_y + 1) * N_z;
+            int N_face = N_x * N_y * (N_z + 1) + N_x * (N_y + 1) * N_z + (N_x + 1) * N_y * N_z; 
+            int N_cube = N_x * N_y * N_z;
+
+            // auto cubic_interp = (intp_param.use_natural[level] == 0) ? nan_cubic_interp : nat_cubic_interp;
+
+            if(intp_param.use_natural[level] == 0){
+                if CONSTEXPR (SPLINE_DIM >= 1)
+                interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>), true, false, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r,cur_ebx2, nan_cubic_interp,error, N_line);
+
+                if CONSTEXPR (SPLINE_DIM >= 2)
+                interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>), false, true, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size,global_starts, xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r,cur_ebx2, nan_cubic_interp,error, N_face);
+
+                if CONSTEXPR (SPLINE_DIM >= 3)
+                interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>), false, false, true, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r,cur_ebx2, nan_cubic_interp, error, N_cube);
+            }
+            else{
+                if CONSTEXPR (SPLINE_DIM >= 1)
+                interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>), true, false, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size, global_starts, xyzmap_line<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r,cur_ebx2, nat_cubic_interp, error, N_line);
+
+                if CONSTEXPR (SPLINE_DIM >= 2)
+                interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>), false, true, false, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size, global_starts, xyzmap_face<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, nat_cubic_interp, error, N_face);
+
+                if CONSTEXPR (SPLINE_DIM >= 3)
+                interpolate_stage_md_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>), false, false, true, LINEAR_BLOCK_SIZE, COARSEN, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size, global_starts, xyzmap_cube<SPLINE_DIM, AnchorBlockSizeX>, unit, cur_eb_r, cur_ebx2, nat_cubic_interp, error, N_cube);
+            }
+
+        }
+        else{
+            if(intp_param.reverse[level]){
+                if CONSTEXPR (SPLINE_DIM >= 1){
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  false, false, true, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size, global_starts, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r,cur_ebx2, intp_param.use_natural[level], error, numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_x /= 2;
+                }
+                if CONSTEXPR (SPLINE_DIM >= 2){
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse), false, true, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data, data_size, global_starts, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r,cur_ebx2, intp_param.use_natural[level], error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y, numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_y /= 2;
+                }
+                if CONSTEXPR (SPLINE_DIM >= 3){
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse), true, false, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xblue_reverse, yblue_reverse, zblue_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[level],error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                    unit_z /= 2;
+                }
+            }
+            else{
+                if CONSTEXPR (SPLINE_DIM >= 3){
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xblue), decltype(yblue), decltype(zblue),  true, false, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xblue, yblue, zblue, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[level], error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z);
+                    unit_z /= 2;
+                }
+                if CONSTEXPR (SPLINE_DIM >= 2){
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xyellow), decltype(yyellow), decltype(zyellow), false, true, false, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xyellow, yyellow, zyellow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[level],error, numAnchorBlockX * AnchorBlockSizeX / unit_x + (SPLINE_DIM >= 1), numAnchorBlockY * AnchorBlockSizeY / unit_y, numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_y /= 2;
+                }
+                if CONSTEXPR (SPLINE_DIM >= 1){
+                    interpolate_stage_att<T, FP, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, decltype(xhollow), decltype(yhollow), decltype(zhollow), false, false, true, COARSEN, LINEAR_BLOCK_SIZE, BORDER_INCLUSIVE, WORKFLOW>(s_data,data_size,global_starts, xhollow, yhollow, zhollow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[level],error,  numAnchorBlockX * AnchorBlockSizeX / unit_x, numAnchorBlockY * AnchorBlockSizeY / unit_y + (SPLINE_DIM >= 2), numAnchorBlockZ * AnchorBlockSizeZ / unit_z + (SPLINE_DIM >= 3));
+                    unit_x /= 2;
+                }
+            }
+        }
+    }
+}
+
+
+
+template <typename TITER, typename FP, int LEVEL, int SPLINE_DIM, int AnchorBlockSizeX, int AnchorBlockSizeY, int AnchorBlockSizeZ, int numAnchorBlockX, int numAnchorBlockY, int numAnchorBlockZ, int LINEAR_BLOCK_SIZE>
+__global__ void cusz::pa_spline_infprecis_data(
+    TITER   data,
+    DIM3    data_size,
+    STRIDE3 data_leap,
+    DIM3 sample_starts,
+    DIM3 sample_block_grid_sizes,
+    DIM3 sample_strides,
+    FP eb_r,
+    FP eb_x2,
+    INTERPOLATION_PARAMS intp_param,
+    TITER errors,
+    bool workflow
+    )
+{
+    // compile time variables
+    using T = typename std::remove_pointer<TITER>::type;
+
+    {
+        // if CONSTEXPR (SPLINE_DIM == 3)
+        __shared__ struct {
+            T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+            [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+            [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+            T err[6];
+        } shmem;
+        // if CONSTEXPR (SPLINE_DIM == 2)
+        // __shared__ struct {
+        //     T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+        //     [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+        //     [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+        //     T err[1];
+        // } shmem;
+
+        DIM3 global_starts;
+        uint8_t level = 0;
+        uint8_t unit = 1;
+        pre_compute_att<T, SPLINE_DIM, LEVEL>(sample_starts, sample_block_grid_sizes, sample_strides, global_starts, intp_param, level, unit, shmem.err, workflow);
+        
+        global2shmem_data_att<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ,LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data,global_starts,unit);
+        
+        if CONSTEXPR (SPLINE_DIM == 3){
+            if(workflow){
+                if(level==2){
+                    uint8_t level3 = 3;
+                    intp_param.use_natural[3] = false;
+                    intp_param.use_natural[2] = false;
+                    intp_param.use_md[3] = false;
+                    intp_param.reverse[3] = false;
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err);
+                    intp_param.reverse[3] = true;
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err+1);
+                    intp_param.use_md[3] = true;
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err+2);
+
+
+                    intp_param.use_md[2] = false;
+                    intp_param.reverse[2] = false;
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+3);
+                    intp_param.reverse[2] = true;
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+4);
+                    intp_param.use_md[2] = true;
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+5);
+                    if(TIX<6){
+                        atomicAdd(const_cast<T*>(errors+TIX),shmem.err[TIX]);
+                    }
+                }
+                else if (level == 1){
+                    intp_param.use_md[1] = false;
+                    intp_param.reverse[1] = false;
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+                    intp_param.reverse[1] = true;
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+1);
+                    intp_param.use_md[1] = true;
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+2);
+
+                    if(TIX<3){
+                    atomicAdd(const_cast<T*>(errors + 3 + BIY * 3 + TIX),shmem.err[TIX]);
+                    }
+                }
+                else{
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size, global_starts, eb_r, eb_x2, level, intp_param, shmem.err);
+                    if(TIX==0){
+                        atomicAdd(const_cast<T*>(errors + 9 + BIY), shmem.err[0]);
+                    }
+                }
+                
+            }
+            else{
+                cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_AB_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+                if(TIX==0)
+                    atomicAdd(const_cast<T*>(errors+BIY),shmem.err[0]);
+            
+            }
+        }
+        if CONSTEXPR (SPLINE_DIM == 2){
+            if(workflow){
+                cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size, global_starts, eb_r, eb_x2, level, intp_param, shmem.err);
+                if(TIX==0){
+                    atomicAdd(const_cast<T*>(errors + BIY), shmem.err[0]);
+                }
+            }
+            else{
+                cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_AB_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+                if(TIX==0)
+                    atomicAdd(const_cast<T*>(errors+BIY),shmem.err[0]);
+            
+            }
+        }
+    }
+}
+
+
+
+#undef TIX
+#undef TIY
+#undef TIZ
+#undef BIX
+#undef BIY
+#undef BIZ
+#undef BDX
+#undef BDY
+#undef BDZ
+#undef GDX
+#undef GDY
+#undef GDZ
+
+#endif

--- a/src/kernel/detail/spline3_md.inl
+++ b/src/kernel/detail/spline3_md.inl
@@ -762,7 +762,7 @@ __forceinline__ __device__ void interpolate_stage(
             auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
             auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
             auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
-            auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+            // auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
             int p1 = -1, p2 = 9, p3 = 9, p4 = -1, p5 = 16;
             if(interpolator==0){
                 p1 = -3, p2 = 23, p3 = 23, p4 = -3, p5 = 40;
@@ -814,7 +814,6 @@ __forceinline__ __device__ void interpolate_stage(
                 s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
             }
 
-            T1 tmp_[4];
         
             bool case1 = (input_BI != input_GD - 1);
             bool case2 = (input_x >= 3 * unit);
@@ -953,7 +952,7 @@ volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
             auto global_y = BIY * AnchorBlockSizeY * numAnchorBlockY + y;
             auto global_z = BIZ * AnchorBlockSizeZ * numAnchorBlockZ + z;  
 
-           T1 tmp_z[4], tmp_y[4], tmp_x[4];
+          
            int id_z[4], id_y[4], id_x[4];
            id_z[0] = (z - 3 * unit >= 0) ? z - 3 * unit : 0;
            id_z[1] = (z - unit >= 0) ? z - unit : 0;
@@ -971,6 +970,7 @@ volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
            id_x[3] = (x + 3 * unit <= AnchorBlockSizeX * numAnchorBlockX) ? x + 3 * unit : 0;
            
             if CONSTEXPR (LINE) {
+                
                 bool I_Y = (y % (2*unit) )> 0; 
                 bool I_Z = (z % (2*unit) )> 0; 
 
@@ -984,7 +984,7 @@ volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
                 auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
                 auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
                 auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
-                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                // auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
                 
                 if (I_Z){
                     input_x = z;
@@ -1033,7 +1033,6 @@ volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
                     s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
                 }
 
-                T1 tmp_[4];
             
                 bool case1 = (input_BI != input_GD - 1);
                 bool case2 = (input_x >= 3 * unit);
@@ -1090,7 +1089,7 @@ volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
                 int s_id_1[4], s_id_2[4];
                 auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
                 auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
-                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                // auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
                 if (I_YZ){
                    
                  x_1 = z,BI_1 = BIZ, GD_1 = GDZ, gx_1 = global_z,gs_1 = data_size.z;
@@ -1201,6 +1200,7 @@ volatile T2 s_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
             }
 
             if CONSTEXPR (CUBE) {  //
+                T1 tmp_z[4], tmp_y[4], tmp_x[4];
                 auto interp_z = get_interp_order(z,BIZ,GDZ,global_z,data_size.z);
                 auto interp_y = get_interp_order(y,BIY,GDY,global_y,data_size.y);
                 auto interp_x = get_interp_order(x,BIX,GDX,global_x,data_size.x);
@@ -1479,7 +1479,7 @@ __device__ std::tuple<int, int, int> xyzmap_line(int _tix, const int UNIT) {
         auto j = (m % Q);
         if(group == 0)
             return std::make_tuple(2 * UNIT * i + UNIT, 2 * UNIT * j, 0);
-        else if (group == 1)
+        else
             return std::make_tuple(2 * UNIT * j, 2 * UNIT * i + UNIT, 0);
     }
 }
@@ -1506,7 +1506,7 @@ __device__ std::tuple<int, int, int> xyzmap_face(int _tix, const int UNIT) {
         auto N = BLOCKSIZE / (UNIT * 2);
         auto L = N * N;
         auto Q = N * N; 
-        auto group = _tix / L ;
+        // auto group = _tix / L ;
         auto m = _tix % L ;
         
         auto i = (m % Q) / N;
@@ -1579,7 +1579,7 @@ __device__ void cusz::device_api::spline_layout_interpolate(
     };
 
     constexpr auto COARSEN          = true;
-    constexpr auto NO_COARSEN       = false;
+    // constexpr auto NO_COARSEN       = false;
     constexpr auto BORDER_INCLUSIVE = true;
     constexpr auto BORDER_EXCLUSIVE = false;
 
@@ -1755,16 +1755,20 @@ __global__ void cusz::c_spline_profiling_data(
  
 
     {
-        __shared__ struct {
-            T data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z][PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X];
-            T local_errs[2];
-           // T global_errs[6];
-        } shmem;
-        c_reset_scratch_profiling_data<T, SPLINE_DIM, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem.data, 0.0);
         
-        global2shmem_profiling_data<T, T, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data);
+        __shared__    T shmem_data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z][PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X];
+        __shared__    T shmem_local_errs[2];
+           
+        // __shared__ struct {
+        //     T data[PROFILE_BLOCK_SIZE_Z * PROFILE_NUM_BLOCK_Z][PROFILE_BLOCK_SIZE_Y * PROFILE_NUM_BLOCK_Y][PROFILE_BLOCK_SIZE_X * PROFILE_NUM_BLOCK_X];
+        //     T local_errs[2];
+        //    // T global_errs[6];
+        // } shmem;
+        c_reset_scratch_profiling_data<T, SPLINE_DIM, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem_data, 0.0);
+        
+        global2shmem_profiling_data<T, T, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem_data);
 
-        cusz::device_api::auto_tuning<T, SPLINE_DIM, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem.data, shmem.local_errs, data_size, errors);
+        cusz::device_api::auto_tuning<T, SPLINE_DIM, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem_data, shmem_local_errs, data_size, errors);
 
     }
 }
@@ -1781,23 +1785,31 @@ __global__ void cusz::c_spline_profiling_data_2(
  
 
     {
-        __shared__ struct {
-            T data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z];
-            T neighbor_x [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
-            T neighbor_y [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
-            T neighbor_z [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
-            T local_errs[6];
+        
+        __shared__ T shmem_data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z];
+        __shared__ T shmem_neighbor_x [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+        __shared__ T shmem_neighbor_y [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+        __shared__ T shmem_neighbor_z [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+        __shared__ T shmem_local_errs[6];
            // T global_errs[6];
-        } shmem;
+        
+        // __shared__ struct {
+        //     T data[PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z];
+        //     T neighbor_x [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+        //     T neighbor_y [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+        //     T neighbor_z [PROFILE_NUM_BLOCK_X * PROFILE_NUM_BLOCK_Y * PROFILE_NUM_BLOCK_Z][4];
+        //     T local_errs[6];
+        //    // T global_errs[6];
+        // } shmem;
 
 
-        c_reset_scratch_profiling_data_2<T, SPLINE_DIM, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z,0.0);
-        global2shmem_profiling_data_2<T, T, SPLINE_DIM, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(data, data_size, data_leap,shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z);
+        c_reset_scratch_profiling_data_2<T, SPLINE_DIM, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(shmem_data, shmem_neighbor_x, shmem_neighbor_y, shmem_neighbor_z,0.0);
+        global2shmem_profiling_data_2<T, T, SPLINE_DIM, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(data, data_size, data_leap,shmem_data, shmem_neighbor_x, shmem_neighbor_y, shmem_neighbor_z);
 
         if (TIX < 6 and BIX==0 and BIY==0 and BIZ==0) errors[TIX] = 0.0;//risky
 
         cusz::device_api::auto_tuning_2<T, SPLINE_DIM, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, LINEAR_BLOCK_SIZE>(
-            shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z, shmem.local_errs, data_size, errors);
+            shmem_data, shmem_neighbor_x, shmem_neighbor_y, shmem_neighbor_z, shmem_local_errs, data_size, errors);
 
         
     }
@@ -1851,29 +1863,29 @@ __global__ void cusz::c_spline_infprecis_data(
     using E = typename std::remove_pointer<EITER>::type;
 
     {
-        __shared__ struct {
-            T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+        // __shared__ struct {
+            __shared__ T shmem_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
              [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
              [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
-            T ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+             __shared__ T shmem_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
                     [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
                     [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
-            STRIDE3 grid_leaps[LEVEL + 1];
-            size_t prefix_nums[LEVEL + 1];
-        } shmem;
+                __shared__ STRIDE3 shmem_grid_leaps[LEVEL + 1];
+                __shared__ size_t shmem_prefix_nums[LEVEL + 1];
+        // } shmem;
 
    
-        pre_compute<LEVEL>(ectrl_size, shmem.grid_leaps, shmem.prefix_nums);
+        pre_compute<LEVEL>(ectrl_size, shmem_grid_leaps, shmem_prefix_nums);
 
-        c_reset_scratch_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.data, shmem.ectrl, radius);
+        c_reset_scratch_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem_data, shmem_ectrl, radius);
 
-        global2shmem_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data);
+        global2shmem_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem_data);
 
         c_gather_anchor<T, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ>(data, data_size, data_leap, anchor, anchor_leap);
         cusz::device_api::spline_layout_interpolate<T, T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_COMPR, false>(
-            shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
+            shmem_data, shmem_ectrl, data_size, eb_r, ebx2, radius, intp_param);
 
-        shmem2global_data_with_compaction<T, E, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY,  numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.ectrl, ectrl, ectrl_size, ectrl_leap, radius, shmem.grid_leaps,shmem.prefix_nums, compact_val, compact_idx, compact_num);
+        shmem2global_data_with_compaction<T, E, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY,  numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem_ectrl, ectrl, ectrl_size, ectrl_leap, radius, shmem_grid_leaps,shmem_prefix_nums, compact_val, compact_idx, compact_num);
     }
 }
 
@@ -1908,25 +1920,34 @@ __global__ void cusz::x_spline_infprecis_data(
     using E = typename std::remove_pointer<EITER>::type;
     using T = typename std::remove_pointer<TITER>::type;
 
-    __shared__ struct {
-        T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
-        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
-        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
-        T ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
-        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
-        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
-        STRIDE3 grid_leaps[LEVEL + 1];
-        size_t prefix_nums[LEVEL + 1];
-    } shmem;
+    // __shared__ struct {
+    //     T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+    //     [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+    //     [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+    //     T ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+    //     [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+    //     [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+    //     STRIDE3 grid_leaps[LEVEL + 1];
+    //     size_t prefix_nums[LEVEL + 1];
+    // } shmem;
 
-    pre_compute<LEVEL>(ectrl_size, shmem.grid_leaps, shmem.prefix_nums);
+    __shared__ T shmem_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+    [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+    [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+    __shared__ T shmem_ectrl[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+           [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+           [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+    __shared__ STRIDE3 shmem_grid_leaps[LEVEL + 1];
+    __shared__ size_t shmem_prefix_nums[LEVEL + 1];
 
-    x_reset_scratch_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.data, shmem.ectrl, anchor, anchor_size, anchor_leap);
-    global2shmem_fuse<T, E, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(ectrl, ectrl_size, ectrl_leap, outlier_tmp, shmem.ectrl, shmem.grid_leaps, shmem.prefix_nums);
+    pre_compute<LEVEL>(ectrl_size, shmem_grid_leaps, shmem_prefix_nums);
+
+    x_reset_scratch_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem_data, shmem_ectrl, anchor, anchor_size, anchor_leap);
+    global2shmem_fuse<T, E, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(ectrl, ectrl_size, ectrl_leap, outlier_tmp, shmem_ectrl, shmem_grid_leaps, shmem_prefix_nums);
 
     cusz::device_api::spline_layout_interpolate<T, T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_DECOMPR, false>(
-        shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
-    shmem2global_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem.data, data, data_size, data_leap);
+        shmem_data, shmem_ectrl, data_size, eb_r, ebx2, radius, intp_param);
+    shmem2global_data<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE>(shmem_data, data, data_size, data_leap);
 }
 
 
@@ -2100,14 +2121,14 @@ __forceinline__ __device__ void interpolate_stage_att(
 
             auto global_x=global_starts.x+x, global_y=global_starts.y+y, global_z=global_starts.z+z;
             auto input_x = x;
-            auto input_BI = BIX;
-            auto input_GD = GDX;
+            // auto input_BI = BIX;
+            // auto input_GD = GDX;
             auto input_gx = global_x;
             auto input_gs = data_size.x;
             auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
             auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
             auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
-            auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+            // auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
             int global_start_ = global_starts.x;
             int p1 = -1, p2 = 9, p3 = 9, p4 = -1, p5 = 16;
             if(interpolator==0){
@@ -2115,8 +2136,8 @@ __forceinline__ __device__ void interpolate_stage_att(
            }
            if CONSTEXPR (BLUE){
                input_x = z;
-               input_BI = BIZ;
-               input_GD = GDZ;
+            //    input_BI = BIZ;
+            //    input_GD = GDZ;
                input_gx = global_z;
                input_gs = data_size.z;
                global_start_ = global_starts.z;
@@ -2124,8 +2145,8 @@ __forceinline__ __device__ void interpolate_stage_att(
            }
            if CONSTEXPR (YELLOW){
                input_x = y;
-               input_BI = BIY;
-               input_GD = GDY;
+            //    input_BI = BIY;
+            //    input_GD = GDY;
                input_gx = global_y;
                input_gs = data_size.y;
                global_start_ = global_starts.y;
@@ -2162,7 +2183,6 @@ __forceinline__ __device__ void interpolate_stage_att(
             s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
            }
            
-           T tmp_[4];
            
            bool case1 = (global_start_ + AnchorBlockSizeX * numAnchorBlockX < input_gs);
            bool case2 = (input_x >= 3 * unit);
@@ -2285,7 +2305,7 @@ __forceinline__ __device__ void interpolate_stage_md_att(
             T pred = 0;
 
             auto global_x=global_starts.x+x, global_y=global_starts.y+y, global_z=global_starts.z+z;
-           T tmp_z[4], tmp_y[4], tmp_x[4];
+        //    T tmp_z[4], tmp_y[4], tmp_x[4];
            int id_z[4], id_y[4], id_x[4];
            id_z[0] = (z - 3 * unit >= 0) ? z - 3 * unit : 0;
            id_z[1] = (z - unit >= 0) ? z - unit : 0;
@@ -2315,7 +2335,7 @@ __forceinline__ __device__ void interpolate_stage_md_att(
                 auto right_bound = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
                 auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
                 auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
-                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                // auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
                 int global_start_ = global_starts.x;
                 if (I_Z){
                     input_x = z;
@@ -2366,7 +2386,6 @@ __forceinline__ __device__ void interpolate_stage_md_att(
                     s_id[3] = x_size * y_size * z + x_size * id_[3] + x;
                 }
 
-                T tmp_[4];
             
                 bool case1 = (global_start_ + AnchorBlockSizeX * numAnchorBlockX < input_gs);
                 bool case2 = (input_x >= 3 * unit);
@@ -2417,7 +2436,7 @@ __forceinline__ __device__ void interpolate_stage_md_att(
                 int s_id_1[4], s_id_2[4];
                 auto x_size = AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1);
                 auto y_size = AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2);
-                auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
+                // auto z_size = AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3);
                 if (I_YZ){
                    
                  x_1 = z,BI_1 = BIZ, GD_1 = GDZ, gx_1 = global_z,gs_1 = data_size.z;
@@ -2527,6 +2546,7 @@ __forceinline__ __device__ void interpolate_stage_md_att(
             }
 
             if CONSTEXPR (CUBE) {  //
+                T tmp_z[4], tmp_y[4], tmp_x[4];
                 auto interp_z = get_interp_order(z,global_z,data_size.z);
                 auto interp_y = get_interp_order(y,global_y,data_size.y);
                 auto interp_x = get_interp_order(x,global_x,data_size.x);
@@ -2661,9 +2681,9 @@ __device__ void cusz::device_api::spline_layout_interpolate_att(
         return (-3*a+23*b+23*c-3*d) / 40;
     };
     constexpr auto COARSEN          = true;
-    constexpr auto NO_COARSEN       = false;
+    // constexpr auto NO_COARSEN       = false;
     constexpr auto BORDER_INCLUSIVE = true;
-    constexpr auto BORDER_EXCLUSIVE = false;
+    // constexpr auto BORDER_EXCLUSIVE = false;
 
 
     int unit;
@@ -2854,12 +2874,18 @@ __global__ void cusz::pa_spline_infprecis_data(
 
     {
         // if CONSTEXPR (SPLINE_DIM == 3)
-        __shared__ struct {
-            T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
-            [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
-            [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
-            T err[6];
-        } shmem;
+        // __shared__ struct {
+        //     T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+        //     [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+        //     [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+        //     T err[6];
+        // } shmem;
+        
+        __shared__    T shmem_data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
+        [AnchorBlockSizeY * numAnchorBlockY + (SPLINE_DIM >= 2)]
+        [AnchorBlockSizeX * numAnchorBlockX + (SPLINE_DIM >= 1)];
+        __shared__    T shmem_err[6];
+        
         // if CONSTEXPR (SPLINE_DIM == 2)
         // __shared__ struct {
         //     T data[AnchorBlockSizeZ * numAnchorBlockZ + (SPLINE_DIM >= 3)]
@@ -2871,9 +2897,9 @@ __global__ void cusz::pa_spline_infprecis_data(
         DIM3 global_starts;
         uint8_t level = 0;
         uint8_t unit = 1;
-        pre_compute_att<T, SPLINE_DIM, LEVEL>(sample_starts, sample_block_grid_sizes, sample_strides, global_starts, intp_param, level, unit, shmem.err, workflow);
+        pre_compute_att<T, SPLINE_DIM, LEVEL>(sample_starts, sample_block_grid_sizes, sample_strides, global_starts, intp_param, level, unit, shmem_err, workflow);
         
-        global2shmem_data_att<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ,LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data,global_starts,unit);
+        global2shmem_data_att<T, T, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ,LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem_data,global_starts,unit);
         
         if CONSTEXPR (SPLINE_DIM == 3){
             if(workflow){
@@ -2883,63 +2909,63 @@ __global__ void cusz::pa_spline_infprecis_data(
                     intp_param.use_natural[2] = false;
                     intp_param.use_md[3] = false;
                     intp_param.reverse[3] = false;
-                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err);
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem_data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem_err);
                     intp_param.reverse[3] = true;
-                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err+1);
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem_data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem_err+1);
                     intp_param.use_md[3] = true;
-                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err+2);
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem_data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem_err+2);
 
 
                     intp_param.use_md[2] = false;
                     intp_param.reverse[2] = false;
-                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+3);
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem_data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem_err+3);
                     intp_param.reverse[2] = true;
-                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+4);
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem_data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem_err+4);
                     intp_param.use_md[2] = true;
-                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+5);
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem_data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem_err+5);
                     if(TIX<6){
-                        atomicAdd(const_cast<T*>(errors+TIX),shmem.err[TIX]);
+                        atomicAdd(const_cast<T*>(errors+TIX),shmem_err[TIX]);
                     }
                 }
                 else if (level == 1){
                     intp_param.use_md[1] = false;
                     intp_param.reverse[1] = false;
-                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem_data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem_err);
                     intp_param.reverse[1] = true;
-                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+1);
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem_data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem_err+1);
                     intp_param.use_md[1] = true;
-                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+2);
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem_data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem_err+2);
 
                     if(TIX<3){
-                    atomicAdd(const_cast<T*>(errors + 3 + BIY * 3 + TIX),shmem.err[TIX]);
+                    atomicAdd(const_cast<T*>(errors + 3 + BIY * 3 + TIX),shmem_err[TIX]);
                     }
                 }
                 else{
-                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size, global_starts, eb_r, eb_x2, level, intp_param, shmem.err);
+                    cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem_data, data_size, global_starts, eb_r, eb_x2, level, intp_param, shmem_err);
                     if(TIX==0){
-                        atomicAdd(const_cast<T*>(errors + 9 + BIY), shmem.err[0]);
+                        atomicAdd(const_cast<T*>(errors + 9 + BIY), shmem_err[0]);
                     }
                 }
                 
             }
             else{
-                cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_AB_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+                cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_AB_ATT>(shmem_data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem_err);
                 if(TIX==0)
-                    atomicAdd(const_cast<T*>(errors+BIY),shmem.err[0]);
+                    atomicAdd(const_cast<T*>(errors+BIY),shmem_err[0]);
             
             }
         }
         if CONSTEXPR (SPLINE_DIM == 2){
             if(workflow){
-                cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem.data, data_size, global_starts, eb_r, eb_x2, level, intp_param, shmem.err);
+                cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_PRED_ATT>(shmem_data, data_size, global_starts, eb_r, eb_x2, level, intp_param, shmem_err);
                 if(TIX==0){
-                    atomicAdd(const_cast<T*>(errors + BIY), shmem.err[0]);
+                    atomicAdd(const_cast<T*>(errors + BIY), shmem_err[0]);
                 }
             }
             else{
-                cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_AB_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+                cusz::device_api::spline_layout_interpolate_att<T, FP, LEVEL, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, LINEAR_BLOCK_SIZE, SPLINE3_AB_ATT>(shmem_data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem_err);
                 if(TIX==0)
-                    atomicAdd(const_cast<T*>(errors+BIY),shmem.err[0]);
+                    atomicAdd(const_cast<T*>(errors+BIY),shmem_err[0]);
             
             }
         }

--- a/src/kernel/detail/spline3_old.inl
+++ b/src/kernel/detail/spline3_old.inl
@@ -1,0 +1,4701 @@
+ /**
+ * @file spline3.inl
+ * @author Jinyang Liu, Shixun Wu, Jiannan Tian
+ * @brief
+ * @version 0.2
+ * @date 2021-05-15
+ *
+ * (copyright to be updated)
+ * (C) 2021 by Washington State University, Argonne National Laboratory
+ *
+ */
+
+ #ifndef CUSZ_KERNEL_SPLINE3_CUH
+ #define CUSZ_KERNEL_SPLINE3_CUH
+ 
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <type_traits>
+ #include "cusz/type.h"
+ #include "utils/err.hh"
+ #include "utils/timer.hh"
+ 
+ #define SPLINE3_COMPR true
+ #define SPLINE3_DECOMPR false
+ 
+ #define SPLINE3_PRED_ATT true
+ #define SPLINE3_AB_ATT false
+ 
+ #if __cplusplus >= 201703L
+ #define CONSTEXPR constexpr
+ #else
+ #define CONSTEXPR
+ #endif
+ 
+ #define TIX threadIdx.x
+ #define TIY threadIdx.y
+ #define TIZ threadIdx.z
+ #define BIX blockIdx.x
+ #define BIY blockIdx.y
+ #define BIZ blockIdx.z
+ #define BDX blockDim.x
+ #define BDY blockDim.y
+ #define BDZ blockDim.z
+ #define GDX gridDim.x
+ #define GDY gridDim.y
+ #define GDZ gridDim.z
+ 
+ using DIM     = u4;
+ using STRIDE  = u4;
+ using DIM3    = dim3;
+ using STRIDE3 = dim3;
+ 
+ //constexpr int BLOCK8  = 8;
+ //constexpr int BLOCK32 = 32;
+ constexpr int BLOCK16 = 16;
+ constexpr int BLOCK17 = 17;
+ constexpr int DEFAULT_LINEAR_BLOCK_SIZE = 384;
+ 
+ #define SHM_ERROR s_ectrl
+ 
+ namespace cusz {
+ 
+ /********************************************************************************
+  * host API
+  ********************************************************************************/
+ template <typename TITER, int LINEAR_BLOCK_SIZE>
+ __global__ void c_spline3d_profiling_16x16x16data(
+     TITER   data,
+     DIM3    data_size,
+     STRIDE3 data_leap,
+     TITER errors);
+ 
+ template <typename TITER, int LINEAR_BLOCK_SIZE>
+ __global__ void c_spline3d_profiling_data_2(
+     TITER   data,
+     DIM3    data_size,
+     STRIDE3 data_leap,
+     TITER errors);
+ 
+ template <
+     typename TITER,
+     typename EITER,
+     typename FP            = float,
+     int  LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE, 
+     typename CompactVal = TITER,
+     typename CompactIdx = uint32_t*,
+     typename CompactNum = uint32_t*>
+ __global__ void c_spline3d_infprecis_16x16x16data(
+     TITER   data,
+     DIM3    data_size,
+     STRIDE3 data_leap,
+     EITER   ectrl,
+     DIM3    ectrl_size,
+     STRIDE3 ectrl_leap,
+     TITER   anchor,
+     STRIDE3 anchor_leap,
+     CompactVal cval,
+     CompactIdx cidx,
+     CompactNum cn,
+     FP      eb_r,
+     FP      ebx2,
+     int     radius,
+     INTERPOLATION_PARAMS intp_param,
+     TITER errors);
+ 
+ template <
+     typename EITER,
+     typename TITER,
+     typename FP           = float,
+     int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __global__ void x_spline3d_infprecis_16x16x16data(
+     EITER   ectrl,        // input 1
+     DIM3    ectrl_size,   //
+     STRIDE3 ectrl_leap,   //
+     TITER   anchor,       // input 2
+     DIM3    anchor_size,  //
+     STRIDE3 anchor_leap,  //
+     TITER   data,         // output
+     DIM3    data_size,    //
+     STRIDE3 data_leap,    //
+     FP      eb_r,
+     FP      ebx2,
+     int     radius,
+     INTERPOLATION_PARAMS intp_param);
+ 
+ template <typename TITER>
+ __global__ void reset_errors(TITER errors);
+ 
+ template <typename TITER, typename FP, int LINEAR_BLOCK_SIZE>
+ __global__ void pa_spline3d_infprecis_16x16x16data(
+     TITER   data,
+     DIM3    data_size,
+     STRIDE3 data_leap,
+     DIM3 sample_starts,
+     DIM3 sample_block_grid_sizes,
+     DIM3 sample_strides,
+     FP      eb_r,
+     FP      ebx2,
+     INTERPOLATION_PARAMS intp_param,
+     TITER errors,
+     bool workflow = SPLINE3_PRED_ATT
+     );
+ 
+ 
+ namespace device_api {
+ /********************************************************************************
+  * device API
+  ********************************************************************************/
+ 
+     template <typename T,int  LINEAR_BLOCK_SIZE>
+ __device__ void auto_tuning(volatile T s_data[17][17][17],  volatile T local_errs[6], DIM3  data_size, volatile T* count);
+ 
+  template <typename T,int  LINEAR_BLOCK_SIZE>
+ __device__ void auto_tuning_2(volatile T s_data[17][17][17],  volatile T local_errs[6], DIM3  data_size, volatile T* count);
+ 
+ template <
+     typename T1,
+     typename T2,
+     typename FP,
+     int  LINEAR_BLOCK_SIZE,
+     bool WORKFLOW         = SPLINE3_COMPR,
+     bool PROBE_PRED_ERROR = false>
+ __device__ void
+ spline3d_layout2_interpolate(volatile T1 s_data[17][17][17], volatile T2 s_ectrl[17][17][17],  DIM3  data_size,FP eb_r, FP ebx2, int radius, INTERPOLATION_PARAMS intp_param);
+ 
+ template <typename T, typename FP,int LINEAR_BLOCK_SIZE, bool WORKFLOW>
+ __device__ void spline3d_layout2_interpolate_att(
+     volatile T s_data[17][17][17],
+      DIM3    data_size,
+     DIM3 global_starts,FP eb_r, FP ebx2,uint8_t level,INTERPOLATION_PARAMS intp_param,volatile T *error);
+ 
+ 
+ }  // namespace device_api
+ 
+ 
+ 
+ 
+ }  // namespace cusz
+ 
+ /********************************************************************************
+  * helper function
+  ********************************************************************************/
+ 
+ namespace {
+ 
+ template <bool INCLUSIVE = true>
+ __forceinline__ __device__ bool xyz17x17x17_predicate(unsigned int x, unsigned int y, unsigned int z,const DIM3 &data_size)
+ {
+     if CONSTEXPR (INCLUSIVE) {  //
+ 
+         
+             return (x <= BLOCK16 and y <= BLOCK16 and z <= BLOCK16) and BIX*BLOCK16+x<data_size.x and BIY*BLOCK16+y<data_size.y and BIZ*BLOCK16+z<data_size.z;
+     }
+     else {
+         return x < BLOCK16+(BIX==GDX-1) and y < BLOCK16+(BIY==GDY-1) and z < BLOCK16+(BIZ==GDZ-1) and BIX*BLOCK16+x<data_size.x and BIY*BLOCK16+y<data_size.y and BIZ*BLOCK16+z<data_size.z;
+     }
+ }
+ 
+ template <bool INCLUSIVE = true>
+ __forceinline__ __device__ bool xyz17x17x17_predicate_att(unsigned int x, unsigned int y, unsigned int z,const DIM3 &data_size, const DIM3 & global_starts)
+ {
+     if CONSTEXPR (INCLUSIVE) {  //
+ 
+         
+             return (x <= BLOCK16 and y <= BLOCK16 and z <= BLOCK16) and global_starts.x+x<data_size.x and global_starts.y+y<data_size.y and global_starts.z+z<data_size.z;
+     }
+     else {
+         return x < BLOCK16+(BIX==GDX-1) and y < BLOCK16+(BIY==GDY-1) and z < BLOCK16+(BIZ==GDZ-1) and global_starts.x+x<data_size.x and global_starts.y+y<data_size.y and global_starts.z+z<data_size.z;
+     }
+ }
+ 
+ 
+ 
+ // control block_id3 in function call
+ template <typename T, bool PRINT_FP = true, int XEND = BLOCK17, int YEND = BLOCK17, int ZEND = BLOCK17>
+ __device__ void
+ spline3d_print_block_from_GPU(T volatile a[17][17][17], int radius = 512, bool compress = true, bool print_ectrl = true)
+ {
+     for (auto z = 0; z < ZEND; z++) {
+         printf("\nprint from GPU, z=%d\n", z);
+         printf("    ");
+         for (auto i = 0; i < BLOCK17; i++) printf("%3d", i);
+         printf("\n");
+ 
+         for (auto y = 0; y < YEND; y++) {
+             printf("y=%d ", y);
+             for (auto x = 0; x < XEND; x++) {  //
+                 if CONSTEXPR (PRINT_FP) { printf("%.2e\t", (float)a[z][y][x]); }
+                 else {
+                     T c = print_ectrl ? a[z][y][x] - radius : a[z][y][x];
+                     if (compress) {
+                         if (c == 0) { printf("%3c", '.'); }
+                         else {
+                             if (abs(c) >= 10) { printf("%3c", '*'); }
+                             else {
+                                 if (print_ectrl) { printf("%3d", c); }
+                                 else {
+                                     printf("%4.2f", c);
+                                 }
+                             }
+                         }
+                     }
+                     else {
+                         if (print_ectrl) { printf("%3d", c); }
+                         else {
+                             printf("%4.2f", c);
+                         }
+                     }
+                 }
+             }
+             printf("\n");
+         }
+     }
+     printf("\nGPU print end\n\n");
+ }
+ 
+ template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void c_reset_scratch_17x17x17data(volatile T1 s_data[17][17][17], volatile T2 s_ectrl[17][17][17], int radius)
+ {
+     // alternatively, reinterprete cast volatile T?[][][] to 1D
+     for (auto _tix = TIX; _tix < BLOCK17 * BLOCK17 * BLOCK17; _tix += LINEAR_BLOCK_SIZE) {
+         auto x = (_tix % BLOCK17);
+         auto y = (_tix / BLOCK17) % BLOCK17;
+         auto z = (_tix / BLOCK17) / BLOCK17;
+ 
+         s_data[z][y][x] = 0;
+         /*****************************************************************************
+          okay to use
+          ******************************************************************************/
+         if (x % 16 == 0 and y % 16 == 0 and z % 16 == 0) s_ectrl[z][y][x] = radius;
+         /*****************************************************************************
+          alternatively
+          ******************************************************************************/
+         // s_ectrl[z][y][x] = radius;
+     }
+     __syncthreads();
+ }
+ 
+ 
+ template <typename T, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void c_reset_scratch_profiling_16x16x16data(volatile T s_data[16][16][16], T default_value)
+ {
+     for (auto _tix = TIX; _tix < 16 * 16 * 16; _tix += LINEAR_BLOCK_SIZE) {
+         auto x = (_tix % 16);
+         auto y = (_tix / 16) % 16;
+         auto z = (_tix / 16) / 16;
+ 
+         s_data[z][y][x] = default_value;
+ 
+     }
+ }
+ 
+ template <typename T, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void c_reset_scratch_profiling_data_2(volatile T s_data[64], T nx[64][4], T ny[64][4], T nz[64][4],T default_value)
+ {
+     for (auto _tix = TIX; _tix < 64 * 4; _tix += LINEAR_BLOCK_SIZE) {
+         auto x = (_tix % 4);
+         auto yz=_tix/4;
+ 
+         
+ 
+         nx[yz][x]=ny[yz][x]=nz[yz][x]=default_value;
+         s_data[TIX] = default_value;
+ 
+     }
+ }
+ 
+ template <typename T1, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void c_gather_anchor_old(T1* data, DIM3 data_size, STRIDE3 data_leap, T1* anchor, STRIDE3 anchor_leap)
+ {
+     auto x = (TIX % BLOCK16) + BIX * BLOCK16;
+     auto y = (TIX / BLOCK16) % BLOCK16 + BIY * BLOCK16;
+     auto z = (TIX / BLOCK16) / BLOCK16 + BIZ * BLOCK16;
+ 
+     bool pred1 = x % 8 == 0 and y % 8 == 0 and z % 8 == 0;
+     bool pred2 = x < data_size.x and y < data_size.y and z < data_size.z;
+ 
+     if (pred1 and pred2) {
+         auto data_id      = x + y * data_leap.y + z * data_leap.z;
+         auto anchor_id    = (x / 8) + (y / 8) * anchor_leap.y + (z / 8) * anchor_leap.z;
+         anchor[anchor_id] = data[data_id];
+     }
+     __syncthreads();
+ }
+ 
+ template <typename T1, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void c_gather_anchor(T1* data, DIM3 data_size, STRIDE3 data_leap, T1* anchor, STRIDE3 anchor_leap)
+ {
+     auto ax =  BIX;//1 is block16 by anchor stride
+     auto ay = BIY ;
+     auto az = BIZ ;
+ 
+     auto x = 16*ax;
+     auto y = 16*ay;
+     auto z = 16*az;
+ 
+     bool pred1 = TIX < 1;//1 is num of anchor
+     bool pred2 = x < data_size.x and y < data_size.y and z < data_size.z;
+ 
+     if (pred1 and pred2) {
+         auto data_id      = x + y * data_leap.y + z * data_leap.z;
+         auto anchor_id    = ax + ay * anchor_leap.y + az * anchor_leap.z;
+         anchor[anchor_id] = data[data_id];
+         /*
+         if(TIX == 7 and BIX == 12 and BIY == 12 and BIZ == 8){
+             printf("anchor: %d, %d, %.2e, %.2e,%d,%d,%d,%d\n", anchor_id,data_id,anchor[anchor_id],data[data_id],data_leap.y,data_leap.z,anchor_leap.y,anchor_leap.z);
+         }
+         if(TIX == 0 and BIX == 13 and BIY == 13 and BIZ == 9){
+             printf("13139anchor: %d, %d, %.2e, %.2e\n", anchor_id,data_id,anchor[anchor_id],data[data_id]);
+         }*/
+     }
+     __syncthreads();
+ }
+ 
+ 
+ /*
+  * use shmem, erroneous
+ template <typename T1, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void c_gather_anchor(volatile T1 s_data[9][9][33], T1* anchor, STRIDE3 anchor_leap)
+ {
+     constexpr auto NUM_ITERS = 33 * 9 * 9 / LINEAR_BLOCK_SIZE + 1;  // 11 iterations
+     for (auto i = 0; i < NUM_ITERS; i++) {
+         auto _tix = i * LINEAR_BLOCK_SIZE + TIX;
+ 
+         if (_tix < 33 * 9 * 9) {
+             auto x = (_tix % 33);
+             auto y = (_tix / 33) % 9;
+             auto z = (_tix / 33) / 9;
+ 
+             if (x % 8 == 0 and y % 8 == 0 and z % 8 == 0) {
+                 auto aid = ((x / 8) + BIX * 4) +             //
+                            ((y / 8) + BIY) * anchor_leap.y +  //
+                            ((z / 8) + BIZ) * anchor_leap.z;   //
+                 anchor[aid] = s_data[z][y][x];
+             }
+         }
+     }
+     __syncthreads();
+ }
+ */
+ 
+ template <typename T1, typename T2 = T1, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void x_reset_scratch_17x17x17data(
+     volatile T1 s_xdata[17][17][17],
+     volatile T2 s_ectrl[17][17][17],
+     T1*         anchor,       //
+     DIM3        anchor_size,  //
+     STRIDE3     anchor_leap)
+ {
+     for (auto _tix = TIX; _tix < BLOCK17 * BLOCK17 * BLOCK17; _tix += LINEAR_BLOCK_SIZE) {
+         auto x = (_tix % BLOCK17);
+         auto y = (_tix / BLOCK17) % BLOCK17;
+         auto z = (_tix / BLOCK17) / BLOCK17;
+ 
+         s_ectrl[z][y][x] = 0;  // TODO explicitly handle zero-padding
+         /*****************************************************************************
+          okay to use
+          ******************************************************************************/
+         if (x % 16 == 0 and y % 16 == 0 and z % 16 == 0) {
+             s_xdata[z][y][x] = 0;
+ 
+             auto ax = ((x / 16) + BIX );
+             auto ay = ((y / 16) + BIY );
+             auto az = ((z / 16) + BIZ );
+ 
+             if (ax < anchor_size.x and ay < anchor_size.y and az < anchor_size.z)
+                 s_xdata[z][y][x] = anchor[ax + ay * anchor_leap.y + az * anchor_leap.z];
+             /*
+             if(BIX == 11 and BIY == 12 and BIZ == 8){
+                 printf("anchor: %d, %d, %d, %.2e\n", x, y,z,s_xdata[z][y][x]);
+             if(BIX == 13 and BIY == 13 and BIZ == 9 and x==0 and y==0 and z==0)
+                 printf("13139anchor: %d, %d, %d, %.2e\n", x, y,z,s_xdata[z][y][x]);
+             */
+         }
+         /*****************************************************************************
+          alternatively
+          ******************************************************************************/
+         // s_ectrl[z][y][x] = radius;
+     }
+ 
+     __syncthreads();
+ }
+ 
+ template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void global2shmem_17x17x17data(T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[17][17][17])
+ {
+     constexpr auto TOTAL = BLOCK17 * BLOCK17 * BLOCK17;
+ 
+     for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+         auto x   = (_tix % BLOCK17);
+         auto y   = (_tix / BLOCK17) % BLOCK17;
+         auto z   = (_tix / BLOCK17) / BLOCK17;
+         auto gx  = (x + BIX * BLOCK16);
+         auto gy  = (y + BIY * BLOCK16);
+         auto gz  = (z + BIZ * BLOCK16);
+         auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+ 
+         if (gx < data_size.x and gy < data_size.y and gz < data_size.z) s_data[z][y][x] = data[gid];
+ /*
+         if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and z==4){
+             printf("g2s1084 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
+         }
+ 
+         if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and z==8){
+             printf("g2s1048 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
+         }*/
+     }
+     __syncthreads();
+ }
+ 
+ template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void global2shmem_profiling_16x16x16data(T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[16][16][16])
+ {
+     constexpr auto TOTAL = 16 * 16 * 16;
+ 
+     for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+         auto x   = (_tix % 16);
+         auto y   = (_tix / 16) % 16;
+         auto z   = (_tix / 16) / 16;
+         auto gx_1=x/4;
+         auto gx_2=x%4;
+         auto gy_1=y/4;
+         auto gy_2=y%4;
+         auto gz_1=z/4;
+         auto gz_2=z%4;
+         auto gx=(data_size.x/4)*gx_1+gx_2;
+         auto gy=(data_size.y/4)*gy_1+gy_2;
+         auto gz=(data_size.z/4)*gz_1+gz_2;
+ 
+         auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+ 
+         if (gx < data_size.x and gy < data_size.y and gz < data_size.z) s_data[z][y][x] = data[gid];
+ /*
+         if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and z==4){
+             printf("g2s1084 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
+         }
+ 
+         if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and z==8){
+             printf("g2s1048 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
+         }*/
+     }
+     __syncthreads();
+ }
+ 
+ template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void global2shmem_profiling_data_2(T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[64], volatile T2 s_nx[64][4], volatile T2 s_ny[64][4], volatile T2 s_nz[64][4])
+ {
+     constexpr auto TOTAL = 64 * 4;
+     int factors[4]={-3,-1,1,3};
+     for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+         auto offset   = (_tix % 4);
+         auto idx = _tix /4;
+         auto x = idx%4;
+         auto y   = (idx / 4) % 4;
+         auto z   = (idx / 4) / 4;
+         auto gx=(data_size.x/4)*x+data_size.x/8;
+         auto gy=(data_size.y/4)*y+data_size.y/8;
+         auto gz=(data_size.z/4)*z+data_size.z/8;
+ 
+         auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+ 
+         if (gx>=3 and gy>=3 and gz>=3 and gx+3 < data_size.x and gy+3 < data_size.y and gz+3 < data_size.z) {
+             s_data[idx] = data[gid];
+             
+             auto factor=factors[offset];
+             s_nx[idx][offset]=data[gid+factor];
+             s_ny[idx][offset]=data[gid+factor*data_leap.y];
+             s_nz[idx][offset]=data[gid+factor*data_leap.z];
+            
+         }
+ /*
+         if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and z==4){
+             printf("g2s1084 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
+         }
+ 
+         if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and z==8){
+             printf("g2s1048 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
+         }*/
+     }
+     __syncthreads();
+ }
+ 
+ template <typename T = float, typename E = u4, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void global2shmem_fuse(E* ectrl, dim3 ectrl_size, dim3 ectrl_leap, T* scattered_outlier, volatile T s_ectrl[17][17][17],volatile STRIDE3 grid_leaps[5],volatile size_t prefix_nums[5])
+ {
+     constexpr auto TOTAL = BLOCK17 * BLOCK17 * BLOCK17;
+ 
+     for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+         auto x   = (_tix % BLOCK17);
+         auto y   = (_tix / BLOCK17) % BLOCK17;
+         auto z   = (_tix / BLOCK17) / BLOCK17;
+         auto gx  = (x + BIX * BLOCK16);
+         auto gy  = (y + BIY * BLOCK16);
+         auto gz  = (z + BIZ * BLOCK16);
+         //auto gid = gx + gy * ectrl_leap.y + gz * ectrl_leap.z;
+ 
+         if (gx < ectrl_size.x and gy < ectrl_size.y and gz < ectrl_size.z) {
+             //todo: pre-compute the leaps and their halves
+ 
+             int level = 0;
+             auto data_gid = gx + gy * ectrl_leap.y + gz * ectrl_leap.z;
+             while(gx%2==0 and gy%2==0 and gz%2==0 and level <= 3){
+                 
+                 gx=gx>>1;
+                 gy=gy>>1;
+                 gz=gz>>1;
+                 level ++;
+             }
+             auto gid = gx + gy*grid_leaps[level].y+gz*grid_leaps[level].z;
+ 
+             if(level < 4){//non-anchor
+                 gid += prefix_nums[level]-((gz+1)>>1)*grid_leaps[level+1].z-(gz%2==0)*((gy+1)>>1)*grid_leaps[level+1].y-(gz%2==0 && gy%2==0)*((gx+1)>>1);
+             }
+ 
+             s_ectrl[z][y][x] = static_cast<T>(ectrl[gid]) + scattered_outlier[data_gid];
+         }
+     }
+     __syncthreads();
+ }
+ 
+ // dram_outlier should be the same in type with shared memory buf
+ template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void
+ shmem2global_17x17x17data(volatile T1 s_buf[17][17][17], T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap)
+ {
+     auto x_size=BLOCK16+(BIX==GDX-1);
+     auto y_size=BLOCK16+(BIY==GDY-1);
+     auto z_size=BLOCK16+(BIZ==GDZ-1);
+     //constexpr auto TOTAL = 32 * 8 * 8;
+     auto TOTAL = x_size * y_size * z_size;
+ 
+     for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+         auto x   = (_tix % x_size);
+         auto y   = (_tix / x_size) % y_size;
+         auto z   = (_tix / x_size) / y_size;
+         auto gx  = (x + BIX * BLOCK16);
+         auto gy  = (y + BIY * BLOCK16);
+         auto gz  = (z + BIZ * BLOCK16);
+         auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+ 
+         if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z) dram_buf[gid] = s_buf[z][y][x];
+         /*
+         if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and z==4){
+             printf("s2g1084 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_buf[z][y][x],dram_buf[gid]);
+         }
+ 
+         if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and z==8){
+             printf("s2g1048 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_buf[z][y][x],dram_buf[gid]);
+         }*/
+     }
+     __syncthreads();
+ }
+ 
+ 
+ // dram_outlier should be the same in type with shared memory buf
+ template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void
+ shmem2global_17x17x17data_with_compaction(volatile T1 s_buf[17][17][17], T2* dram_buf, DIM3 buf_size, STRIDE3 buf_leap, int radius,volatile STRIDE3 grid_leaps[5],volatile size_t prefix_nums[5], T1* dram_compactval = nullptr, uint32_t* dram_compactidx = nullptr, uint32_t* dram_compactnum = nullptr)
+ {
+     auto x_size = BLOCK16 + (BIX == GDX-1);
+     auto y_size = BLOCK16 + (BIY == GDY-1);
+     auto z_size = BLOCK16 + (BIZ == GDZ-1);
+     auto TOTAL = x_size * y_size * z_size;
+ 
+     for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+         auto x   = (_tix % x_size);
+         auto y   = (_tix / x_size) % y_size;
+         auto z   = (_tix / x_size) / y_size;
+         auto gx  = (x + BIX * BLOCK16);
+         auto gy  = (y + BIY * BLOCK16);
+         auto gz  = (z + BIZ * BLOCK16);
+         //auto gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+ 
+         auto candidate = s_buf[z][y][x];
+         bool quantizable = (candidate >= 0) and (candidate < 2*radius);
+ 
+         if (gx < buf_size.x and gy < buf_size.y and gz < buf_size.z) {
+ 
+             
+ 
+             if (not quantizable) {
+                 auto data_gid = gx + gy * buf_leap.y + gz * buf_leap.z;
+                 auto cur_idx = atomicAdd(dram_compactnum, 1);
+                 dram_compactidx[cur_idx] = data_gid;
+                 dram_compactval[cur_idx] = candidate;
+             }
+             int level = 0;
+             //todo: pre-compute the leaps and their halves
+             while(gx%2==0 and gy%2==0 and gz%2==0 and level <= 3){
+                 
+                 gx=gx>>1;
+                 gy=gy>>1;
+                 gz=gz>>1;
+                 level ++;
+             }
+             auto gid = gx + gy*grid_leaps[level].y+gz*grid_leaps[level].z;
+ 
+             if(level < 4){//non-anchor
+                 gid += prefix_nums[level]-((gz+1)>>1)*grid_leaps[level+1].z-(gz%2==0)*((gy+1)>>1)*grid_leaps[level+1].y-(gz%2==0 && gy%2==0)*((gx+1)>>1);
+             }
+ 
+             // TODO this is for algorithmic demo by reading from shmem
+             // For performance purpose, it can be inlined in quantization
+             dram_buf[gid] = quantizable * static_cast<T2>(candidate);
+ 
+ 
+         }
+     }
+     __syncthreads();
+ }
+ 
+ 
+ 
+ template <
+     typename T1,
+     typename T2,
+     typename FP,
+     typename LAMBDAX,
+     typename LAMBDAY,
+     typename LAMBDAZ,
+     bool BLUE,
+     bool YELLOW,
+     bool HOLLOW,
+     int  LINEAR_BLOCK_SIZE,
+     int  BLOCK_DIMX,
+     int  BLOCK_DIMY,
+     bool COARSEN,
+     int  BLOCK_DIMZ,
+     bool BORDER_INCLUSIVE,
+     bool WORKFLOW>
+ __forceinline__ __device__ void interpolate_stage(
+     volatile T1 s_data[17][17][17],
+     volatile T2 s_ectrl[17][17][17],
+     DIM3    data_size,
+     LAMBDAX     xmap,
+     LAMBDAY     ymap,
+     LAMBDAZ     zmap,
+     int         unit,
+     FP          eb_r,
+     FP          ebx2,
+     int         radius,
+     bool interpolator)
+ {
+     static_assert(BLOCK_DIMX * BLOCK_DIMY * (COARSEN ? 1 : BLOCK_DIMZ) <= 384, "block oversized");
+     static_assert((BLUE or YELLOW or HOLLOW) == true, "must be one hot");
+     static_assert((BLUE and YELLOW) == false, "must be only one hot (1)");
+     static_assert((BLUE and YELLOW) == false, "must be only one hot (2)");
+     static_assert((YELLOW and HOLLOW) == false, "must be only one hot (3)");
+ 
+     auto run = [&](auto x, auto y, auto z) {
+ 
+         
+ 
+         if (xyz17x17x17_predicate<BORDER_INCLUSIVE>(x, y, z,data_size)) {
+             T1 pred = 0;
+ 
+             //if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and (CONSTEXPR (YELLOW)) )
+             //    printf("%d %d %d\n",x,y,z);
+             /*
+              if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==4)
+                         printf("444 %.2e %.2e \n",s_data[z - unit][y][x],s_data[z + unit][y][x]);
+ 
+             if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==0)
+                         printf("440 %.2e %.2e \n",s_data[z][y - unit][x],s_data[z][y + unit][x]);
+             if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==8 and z==0)
+                         printf("480 %.2e %.2e \n",s_data[z][y ][x- unit],s_data[z][y ][x+ unit]);*/
+                   //  }
+             auto global_x=BIX*BLOCK16+x, global_y=BIY*BLOCK16+y, global_z=BIZ*BLOCK16+z;
+             /*
+             int interpolation_coeff_set1[2]={-1,-3};
+             int interpolation_coeff_set2[2]={9,23};
+             int interpolation_coeff_set3[2]={16,40};
+             auto a=interpolation_coeff_set1[interpolator];
+             auto b=interpolation_coeff_set2[interpolator];
+             auto c=interpolation_coeff_set3[interpolator];
+             */
+             if(interpolator==0){
+                 if CONSTEXPR (BLUE) {  //
+ 
+                     if(BIZ!=GDZ-1){
+ 
+                         if(z>=3*unit and z+3*unit<=BLOCK16  )
+                             pred = (-s_data[z - 3*unit][y][x]+9*s_data[z - unit][y][x] + 9*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 16;
+                         else if (z+3*unit<=BLOCK16)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                         else if (z>=3*unit)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                         else
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(z>=3*unit){
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = (-s_data[z - 3*unit][y][x]+9*s_data[z - unit][y][x] + 9*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 16;
+                             else if (global_z+unit<data_size.z)
+                                 pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+                             else
+                                 pred=s_data[z - unit][y][x];
+ 
+                         }
+                         else{
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                             else if (global_z+unit<data_size.z)
+                                 pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                             else
+                                 pred=s_data[z - unit][y][x];
+                         } 
+                     }
+                 }
+                 if CONSTEXPR (YELLOW) {  //
+                    // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and y==7 and z==0){
+                    //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
+                   //  }
+                     if(BIY!=GDY-1){
+                         if(y>=3*unit and y+3*unit<=BLOCK16 )
+                             pred = (-s_data[z ][y- 3*unit][x]+9*s_data[z ][y- unit][x] + 9*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 16;
+                         else if (y+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (y>=3*unit)
+                             pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                     }
+                     else{
+                         if(y>=3*unit){
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = (-s_data[z ][y- 3*unit][x]+9*s_data[z][y - unit][x] + 9*s_data[z ][y+ unit][x]-s_data[z ][y+ 3*unit][x]) / 16;
+                             else if (global_y+unit<data_size.y)
+                                 pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 8;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+ 
+                         }
+                         else{
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                             else if (global_y+unit<data_size.y)
+                                 pred = (s_data[z ][y- unit][x] + s_data[z][y + unit][x]) / 2;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+                         } 
+                     }
+                 }
+ 
+                 if CONSTEXPR (HOLLOW) {  //
+                     //if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1)
+                     //    printf("%d %d %d\n",x,y,z);
+                     if(BIX!=GDX-1){
+                         if(x>=3*unit and x+3*unit<=BLOCK16 )
+                             pred = (-s_data[z ][y][x- 3*unit]+9*s_data[z ][y][x- unit] + 9*s_data[z ][y][x+ unit]-s_data[z ][y][x + 3*unit]) / 16;
+                         else if (x+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y][x- unit] + 6*s_data[z ][y][x + unit]-s_data[z][y][x + 3*unit]) / 8;
+                         else if (x>=3*unit)
+                             pred = (-s_data[z][y][x - 3*unit]+6*s_data[z][y][x - unit] + 3*s_data[z ][y][x + unit]) / 8;
+                         else
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                     }
+                     else{
+                         if(x>=3*unit){
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = (-s_data[z ][y][x- 3*unit]+9*s_data[z][y ][x- unit] + 9*s_data[z ][y][x+ unit]-s_data[z ][y][x+ 3*unit]) / 16;
+                             else if (global_x+unit<data_size.x)
+                                 pred = (-s_data[z ][y][x- 3*unit]+6*s_data[z ][y][x- unit] + 3*s_data[z ][y][x+ unit]) / 8;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+ 
+                         }
+                         else{
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = (3*s_data[z][y ][x- unit] + 6*s_data[z ][y][x+ unit]-s_data[z][y ][x+ 3*unit]) / 8;
+                             else if (global_x+unit<data_size.x)
+                                 pred = (s_data[z ][y][x- unit] + s_data[z][y ][x+ unit]) / 2;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+                         } 
+                     }
+                 }
+ 
+             }
+             else{
+                 if CONSTEXPR (BLUE) {  //
+ 
+                     if(BIZ!=GDZ-1){
+ 
+                         if(z>=3*unit and z+3*unit<=BLOCK16  )
+                             pred = (-3*s_data[z - 3*unit][y][x]+23*s_data[z - unit][y][x] + 23*s_data[z + unit][y][x]-3*s_data[z + 3*unit][y][x]) / 40;
+                         else if (z+3*unit<=BLOCK16)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                         else if (z>=3*unit)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                         else
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(z>=3*unit){
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = (-3*s_data[z - 3*unit][y][x]+23*s_data[z - unit][y][x] + 23*s_data[z + unit][y][x]-3*s_data[z + 3*unit][y][x]) / 40;
+                             else if (global_z+unit<data_size.z)
+                                 pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+                             else
+                                 pred=s_data[z - unit][y][x];
+ 
+                         }
+                         else{
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                             else if (global_z+unit<data_size.z)
+                                 pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                             else
+                                 pred=s_data[z - unit][y][x];
+                         } 
+                     }
+                 }
+                 if CONSTEXPR (YELLOW) {  //
+                    // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and y==7 and z==0){
+                    //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
+                   //  }
+                     if(BIY!=GDY-1){
+                         if(y>=3*unit and y+3*unit<=BLOCK16 )
+                             pred = (-3*s_data[z ][y- 3*unit][x]+23*s_data[z ][y- unit][x] + 23*s_data[z ][y+ unit][x]-3*s_data[z][y + 3*unit][x]) / 40;
+                         else if (y+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (y>=3*unit)
+                             pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                     }
+                     else{
+                         if(y>=3*unit){
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = (-3*s_data[z ][y- 3*unit][x]+23*s_data[z][y - unit][x] + 23*s_data[z ][y+ unit][x]-3*s_data[z ][y+ 3*unit][x]) / 40;
+                             else if (global_y+unit<data_size.y)
+                                 pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 8;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+ 
+                         }
+                         else{
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                             else if (global_y+unit<data_size.y)
+                                 pred = (s_data[z ][y- unit][x] + s_data[z][y + unit][x]) / 2;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+                         } 
+                     }
+                 }
+ 
+                 if CONSTEXPR (HOLLOW) {  //
+                     //if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1)
+                     //    printf("%d %d %d\n",x,y,z);
+                     if(BIX!=GDX-1){
+                         if(x>=3*unit and x+3*unit<=BLOCK16 )
+                             pred = (-3*s_data[z ][y][x- 3*unit]+23*s_data[z ][y][x- unit] + 23*s_data[z ][y][x+ unit]-3*s_data[z ][y][x + 3*unit]) / 40;
+                         else if (x+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y][x- unit] + 6*s_data[z ][y][x + unit]-s_data[z][y][x + 3*unit]) / 8;
+                         else if (x>=3*unit)
+                             pred = (-s_data[z][y][x - 3*unit]+6*s_data[z][y][x - unit] + 3*s_data[z ][y][x + unit]) / 8;
+                         else
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                     }
+                     else{
+                         if(x>=3*unit){
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = (-3*s_data[z ][y][x- 3*unit]+23*s_data[z][y ][x- unit] + 23*s_data[z ][y][x+ unit]-3*s_data[z ][y][x+ 3*unit]) / 40;
+                             else if (global_x+unit<data_size.x)
+                                 pred = (-s_data[z ][y][x- 3*unit]+6*s_data[z ][y][x- unit] + 3*s_data[z ][y][x+ unit]) / 8;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+ 
+                         }
+                         else{
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = (3*s_data[z][y ][x- unit] + 6*s_data[z ][y][x+ unit]-s_data[z][y ][x+ 3*unit]) / 8;
+                             else if (global_x+unit<data_size.x)
+                                 pred = (s_data[z ][y][x- unit] + s_data[z][y ][x+ unit]) / 2;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+                         } 
+                     }
+                 }
+             }
+                 
+             
+             
+ 
+             if CONSTEXPR (WORKFLOW == SPLINE3_COMPR) {
+                 
+                 auto          err = s_data[z][y][x] - pred;
+                 decltype(err) code;
+                 // TODO unsafe, did not deal with the out-of-cap case
+                 {
+                     code = fabs(err) * eb_r + 1;
+                     code = err < 0 ? -code : code;
+                     code = int(code / 2) + radius;
+                 }
+                 s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
+                 /*
+                  if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==0 and y==0 and z==4)
+                         printf("004pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[0][0][0],s_data[0][0][8],s_data[0][0][16]);
+                     if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==8 and y==8 and z==4)
+                         printf("884pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[8][8][0],s_data[8][8][8],s_data[8][8][16]);
+                   */      
+                // if(fabs(pred)>=3)
+                //     printf("%d %d %d %d %d %d %d %d %d %d %.2e %.2e %.2e\n",unit,CONSTEXPR (BLUE),CONSTEXPR (YELLOW),CONSTEXPR (HOLLOW),BIX,BIY,BIZ,x,y,z,pred,code,s_data[z][y][x]);
+               
+                 s_data[z][y][x]  = pred + (code - radius) * ebx2;
+                 
+ 
+             }
+             else {  // TODO == DECOMPRESSS and static_assert
+                 auto code       = s_ectrl[z][y][x];
+                 s_data[z][y][x] = pred + (code - radius) * ebx2;
+                 /*
+                 if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==0 and y==0 and z==4)
+                         printf("004pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[0][0][0],s_data[0][0][8],s_data[0][0][16]);
+                     if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==8 and y==8 and z==4)
+                         printf("884pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[8][8][0],s_data[8][8][8],s_data[8][8][16]);
+                         
+                 */
+                 //if(BIX == 4 and BIY == 20 and BIZ == 20 and unit==1 and CONSTEXPR (BLUE)){
+                //     if(fabs(s_data[z][y][x])>=3)
+ 
+               //      printf("%d %d %d %d %d %d %d %d %d %d %.2e %.2e %.2e\n",unit,CONSTEXPR (BLUE),CONSTEXPR (YELLOW),CONSTEXPR (HOLLOW),BIX,BIY,BIZ,x,y,z,pred,code,s_data[z][y][x]);
+                // }
+             }
+         }
+     };
+     // -------------------------------------------------------------------------------- //
+ 
+     if CONSTEXPR (COARSEN) {
+         constexpr auto TOTAL = BLOCK_DIMX * BLOCK_DIMY * BLOCK_DIMZ;
+         //if( BLOCK_DIMX *BLOCK_DIMY<= LINEAR_BLOCK_SIZE){
+             for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                 auto itix = (_tix % BLOCK_DIMX);
+                 auto itiy = (_tix / BLOCK_DIMX) % BLOCK_DIMY;
+                 auto itiz = (_tix / BLOCK_DIMX) / BLOCK_DIMY;
+                 auto x    = xmap(itix, unit);
+                 auto y    = ymap(itiy, unit);
+                 auto z    = zmap(itiz, unit);
+                 
+                 run(x, y, z);
+             }
+         //}
+         //may have bug    
+         /*
+         else{
+             for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                 auto itix = (_tix % BLOCK_DIMX);
+                 auto itiz = (_tix / BLOCK_DIMX) % BLOCK_DIMZ;
+                 auto itiy = (_tix / BLOCK_DIMX) / BLOCK_DIMZ;
+                 auto x    = xmap(itix, unit);
+                 auto y    = ymap(itiy, unit);
+                 auto z    = zmap(itiz, unit);
+                 run(x, y, z);
+             }
+         }*/
+         //may have bug  end
+         
+     }
+     else {
+         auto itix = (TIX % BLOCK_DIMX);
+         auto itiy = (TIX / BLOCK_DIMX) % BLOCK_DIMY;
+         auto itiz = (TIX / BLOCK_DIMX) / BLOCK_DIMY;
+         auto x    = xmap(itix, unit);
+         auto y    = ymap(itiy, unit);
+         auto z    = zmap(itiz, unit);
+ 
+         
+ 
+      //   printf("%d %d %d\n", x,y,z);
+         run(x, y, z);
+     }
+     __syncthreads();
+ }
+ 
+ template <
+     typename T1,
+     typename T2,
+     typename FP,
+     //typename LAMBDAX,
+     //typename LAMBDAY,
+     //typename LAMBDAZ,
+     typename LAMBDA,
+     bool LINE,
+     bool FACE,
+     bool CUBE,
+     int  LINEAR_BLOCK_SIZE,
+     int NUM_ELE,
+     //int  BLOCK_DIMX,
+     //int  BLOCK_DIMY,
+     bool COARSEN,
+     //int  BLOCK_DIMZ,
+     bool BORDER_INCLUSIVE,
+     bool WORKFLOW,
+     typename INTERP>
+ __forceinline__ __device__ void interpolate_stage_md(
+     volatile T1 s_data[17][17][17],
+     volatile T2 s_ectrl[17][17][17],
+     DIM3    data_size,
+     //LAMBDAX     xmap,
+     //LAMBDAY     ymap,
+     //LAMBDAZ     zmap,
+     LAMBDA xyzmap,
+     int         unit,
+     FP          eb_r,
+     FP          ebx2,
+     int         radius,
+     INTERP cubic_interpolator)
+ {
+     static_assert(COARSEN or (NUM_ELE <= 384), "block oversized");
+     static_assert((LINE or FACE or CUBE) == true, "must be one hot");
+     static_assert((LINE and FACE) == false, "must be only one hot (1)");
+     static_assert((LINE and CUBE) == false, "must be only one hot (2)");
+     static_assert((FACE and CUBE) == false, "must be only one hot (3)");
+ 
+     auto run = [&](auto x, auto y, auto z) {
+ 
+         
+ 
+         if (xyz17x17x17_predicate<BORDER_INCLUSIVE>(x, y, z,data_size)) {
+             T1 pred = 0;
+ 
+             //if(BIX == 23 and BIY == 23 and BIZ == 15 and unit==2)
+             //    printf("%d %d %d\n",x,y,z);
+             /*
+              if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==4)
+                         printf("444 %.2e %.2e \n",s_data[z - unit][y][x],s_data[z + unit][y][x]);
+ 
+             if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==0)
+                         printf("440 %.2e %.2e \n",s_data[z][y - unit][x],s_data[z][y + unit][x]);
+             if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==8 and z==0)
+                         printf("480 %.2e %.2e \n",s_data[z][y ][x- unit],s_data[z][y ][x+ unit]);*/
+                   //  }
+             auto global_x=BIX*BLOCK16+x, global_y=BIY*BLOCK16+y, global_z=BIZ*BLOCK16+z;
+             /*
+             int interpolation_coeff_set1[2]={-1,-3};
+             int interpolation_coeff_set2[2]={9,23};
+             int interpolation_coeff_set3[2]={16,40};
+             auto a=interpolation_coeff_set1[interpolator];
+             auto b=interpolation_coeff_set2[interpolator];
+             auto c=interpolation_coeff_set3[interpolator];
+             */
+            
+             if CONSTEXPR (LINE) {  //
+                 //bool I_X = x&1; 
+                 bool I_Y = (y % (2*unit) )> 0; 
+                 bool I_Z = (z % (2*unit) )> 0; 
+                 if (I_Z){
+                     //assert(x&1==0 and y&1==0);
+ 
+                     if(BIZ!=GDZ-1){
+ 
+                         if(z>=3*unit and z+3*unit<=BLOCK16  )
+                             pred = cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x],s_data[z + unit][y][x],s_data[z + 3*unit][y][x]);
+                         else if (z+3*unit<=BLOCK16)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                         else if (z>=3*unit)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                         else
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(z>=3*unit){
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x] ,s_data[z + unit][y][x],s_data[z + 3*unit][y][x]);
+                             else if (global_z+unit<data_size.z)
+                                 pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+                             else
+                                 pred=s_data[z - unit][y][x];
+ 
+                         }
+                         else{
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                             else if (global_z+unit<data_size.z)
+                                 pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                             else
+                                 pred=s_data[z - unit][y][x];
+                         } 
+                     }
+ 
+                 }
+                 else if (I_Y){
+                     //assert(x&1==0 and z&1==0);
+                     if(BIY!=GDY-1){
+                         if(y>=3*unit and y+3*unit<=BLOCK16 )
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]) ;
+                         else if (y+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (y>=3*unit)
+                             pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                     }
+                     else{
+                         if(y>=3*unit){
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z][y - unit][x],s_data[z ][y+ unit][x],s_data[z ][y+ 3*unit][x]);
+                             else if (global_y+unit<data_size.y)
+                                 pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 8;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+ 
+                         }
+                         else{
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                             else if (global_y+unit<data_size.y)
+                                 pred = (s_data[z ][y- unit][x] + s_data[z][y + unit][x]) / 2;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+                         } 
+                     }
+                 }
+                 else{//I_X
+                     //assert(y&1==0 and z&1==0);
+                     if(BIX!=GDX-1){
+                         if(x>=3*unit and x+3*unit<=BLOCK16 )
+                             pred = cubic_interpolator(s_data[z ][y][x- 3*unit],s_data[z ][y][x- unit],s_data[z ][y][x+ unit],s_data[z ][y][x + 3*unit]);
+                         else if (x+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y][x- unit] + 6*s_data[z ][y][x + unit]-s_data[z][y][x + 3*unit]) / 8;
+                         else if (x>=3*unit)
+                             pred = (-s_data[z][y][x - 3*unit]+6*s_data[z][y][x - unit] + 3*s_data[z ][y][x + unit]) / 8;
+                         else
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                     }
+                     else{
+                         if(x>=3*unit){
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = cubic_interpolator(s_data[z ][y][x- 3*unit],s_data[z][y ][x- unit],s_data[z ][y][x+ unit],s_data[z ][y][x+ 3*unit]);
+                             else if (global_x+unit<data_size.x)
+                                 pred = (-s_data[z ][y][x- 3*unit]+6*s_data[z ][y][x- unit] + 3*s_data[z ][y][x+ unit]) / 8;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+ 
+                         }
+                         else{
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = (3*s_data[z][y ][x- unit] + 6*s_data[z ][y][x+ unit]-s_data[z][y ][x+ 3*unit]) / 8;
+                             else if (global_x+unit<data_size.x)
+                                 pred = (s_data[z ][y][x- unit] + s_data[z][y ][x+ unit]) / 2;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+                         } 
+                     }
+ 
+                 }
+             }
+             auto get_interp_order = [&](auto x, auto BI, auto GD, auto gx, auto gs){
+                 int b = x >= 3*unit ? 3 : 1;
+                 int f = 0;
+                 if(x+3*unit<=BLOCK16 and (BI != GD-1 or gx+3*unit < gs) )
+                     f = 3;
+                 else if (BI != GD-1 or gx+unit < gs)
+                     f = 1;
+                 if (b==3){
+                     if(f==3)
+                         return 4;
+                     else if (f==1)
+                         return 3;
+                     else
+                         return 0;
+                 }
+                 else{//b==1
+                     if(f==3)
+                         return 2;
+                     else if (f==1)
+                         return 1;
+                     else
+                         return 0;
+                 }
+             };
+             if CONSTEXPR (FACE) {  //
+                // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and y==7 and z==0){
+                //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
+               //  }
+ 
+                 bool I_YZ = (x % (2*unit) ) == 0;
+                 bool I_XZ = (y % (2*unit ) )== 0;
+ 
+                 //if(BIX == 10 and BIY == 12 and BIZ == 0 and x==13 and y==6 and z==9)
+                //     printf("face %d %d\n", I_YZ,I_XZ);
+ 
+                  
+                 if (I_YZ){
+ 
+ 
+                     auto interp_z = get_interp_order(z,BIZ,GDZ,global_z,data_size.z);
+                     auto interp_y = get_interp_order(y,BIY,GDY,global_y,data_size.y);
+ 
+                     if(interp_z==4){
+                         if(interp_y==4){
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x],s_data[z + unit][y][x],s_data[z + 3*unit][y][x])+
+                                     cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]) ) / 2;
+                         }
+                         else
+                             pred = cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x],s_data[z + unit][y][x],s_data[z + 3*unit][y][x]);
+ 
+                     }
+                     else if (interp_z == 3){
+                         if(interp_y==4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x] - s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 16;
+                         else if (interp_y == 2)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x] + 3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 16;
+                         else
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                     }
+ 
+                     else if (interp_z == 2){
+                         if(interp_y==4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x] - s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 16;
+                         else if (interp_y == 2)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x] + 3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 16;
+                         else
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+ 
+                     }
+                     else if (interp_z == 1){
+                         if(interp_y == 4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (-s_data[z ][y- 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else if (interp_y == 2)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (interp_y == 1)
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x] + s_data[z ][y - unit][x] + s_data[z][y + unit][x]) / 4;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(interp_y == 4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (-s_data[z ][y- 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else if (interp_y == 2)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (interp_y == 1)
+                             pred = (s_data[z ][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z ][y - unit][x] - s_data[z - unit][y - unit][x]);
+ 
+                     }
+ 
+                 }
+                 else if (I_XZ){
+                     auto interp_z = get_interp_order(z,BIZ,GDZ,global_z,data_size.z);
+                     auto interp_x = get_interp_order(x,BIX,GDX,global_x,data_size.x);
+ 
+                     //if(BIX == 10 and BIY == 12 and BIZ == 0 and x==13 and y==6 and z==9)
+                     //printf("ixz %d %d\n", interp_x,interp_z);
+ 
+                     if(interp_z==4){
+                         if(interp_x==4){
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z + 3*unit][y][x]) +
+                                     cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                          s_data[z][y][x - unit],
+                                                          s_data[z][y][x + unit],
+                                                          s_data[z][y][x + 3*unit])
+                                    ) / 2;
+                         }
+                         else
+                             pred = cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                       s_data[z - unit][y][x],
+                                                       s_data[z + unit][y][x],
+                                                       s_data[z + 3*unit][y][x]);
+ 
+                     }
+                     else if (interp_z == 3){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z - 3*unit][y][x] + 6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (-s_data[z - 3*unit][y][x] + 6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (-s_data[z - 3*unit][y][x] + 6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                     }
+                     else if (interp_z == 2){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x] - s_data[z + 3*unit][y][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x] - s_data[z + 3*unit][y][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x] - s_data[z + 3*unit][y][x]) / 8;
+ 
+                     }
+                     else if (interp_z == 1){
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]
+                                     + s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 4;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z][y][x - unit] - s_data[z - unit][y][x - unit]);
+                     }
+ 
+                 }
+                 else{//I_XY
+                     //assert(z&1==0);
+ 
+                     auto interp_y = get_interp_order(y,BIY,GDY,global_y,data_size.y);
+                     auto interp_x = get_interp_order(x,BIX,GDX,global_x,data_size.x);
+ 
+                     if(interp_y==4){
+                         if(interp_x==4){
+                             pred = (cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y + 3*unit][x]) +
+                                     cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                          s_data[z][y][x - unit],
+                                                          s_data[z][y][x + unit],
+                                                          s_data[z][y][x + 3*unit])
+                                    ) / 2;
+                         }
+                         else
+                             pred = cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                       s_data[z][y - unit][x],
+                                                       s_data[z][y + unit][x],
+                                                       s_data[z][y + 3*unit][x]);
+                     }
+                     else if (interp_y == 3){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y - 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (-s_data[z][y - 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (-s_data[z][y - 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                     }
+                     else if (interp_y == 2){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z][y + unit][x] - s_data[z][y + 3*unit][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z][y + unit][x] - s_data[z][y + 3*unit][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z][y + unit][x] - s_data[z][y + 3*unit][x]) / 8;
+                     }
+                     else if (interp_y == 1){
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]
+                                     + s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 4;
+                         else 
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                     }
+                     else{
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                         else 
+                             pred = (s_data[z][y - unit][x] + s_data[z][y][x - unit] - s_data[z][y - unit][x - unit]);
+                     }
+                 }
+             }
+ 
+             if CONSTEXPR (CUBE) {  //
+                 auto interp_z = get_interp_order(z,BIZ,GDZ,global_z,data_size.z);
+                 auto interp_y = get_interp_order(y,BIY,GDY,global_y,data_size.y);
+                 auto interp_x = get_interp_order(x,BIX,GDX,global_x,data_size.x);
+ 
+                 if(interp_z == 4){
+                     if(interp_y == 4){
+                         if(interp_x == 4){
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]) +
+                                     cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y + 3*unit][x]) +
+                                     cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                          s_data[z][y][x - unit],
+                                                          s_data[z][y][x + unit],
+                                                          s_data[z][y][x + 3*unit])
+                                     ) / 3;
+                         }
+                         else{
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]) +
+                                     cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y + 3*unit][x])
+                                     ) / 2;
+                         }
+                     }
+                     else if(interp_x == 4){
+                         pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]) +
+                                 cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                      s_data[z][y][x - unit],
+                                                      s_data[z][y][x + unit],
+                                                      s_data[z][y][x + 3*unit])
+                                 ) / 2;
+ 
+                     }
+                     else{
+                         pred = cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]);
+                     }
+                 }
+ 
+                 else if(interp_y == 4){
+                     
+                     if(interp_x == 4){
+                         pred = (cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y+ 3*unit][x]) +
+                                 cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                      s_data[z][y][x - unit],
+                                                      s_data[z][y][x + unit],
+                                                      s_data[z][y][x + 3*unit])
+                                 ) / 2;
+ 
+                     }
+                     else{
+                         pred = cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y+ 3*unit][x]);
+                     }
+                 }
+                 else{
+                     if(interp_x == 4)
+                         pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                   s_data[z][y][x - unit],
+                                                   s_data[z][y][x + unit],
+                                                   s_data[z][y][x + 3*unit]);
+                     else if (interp_x == 3)
+                         pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                     else if (interp_x == 2)
+                         pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                     else if (interp_x == 1)
+                         pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                     else 
+                         pred = s_data[z][y][x - unit];///to revise;
+ 
+ 
+                 }
+ 
+             }
+ 
+ 
+                 
+             
+             
+ 
+             if CONSTEXPR (WORKFLOW == SPLINE3_COMPR) {
+                 
+                 auto          err = s_data[z][y][x] - pred;
+                 decltype(err) code;
+                 // TODO unsafe, did not deal with the out-of-cap case
+                 {
+                     code = fabs(err) * eb_r + 1;
+                     code = err < 0 ? -code : code;
+                     code = int(code / 2) + radius;
+                 }
+                 s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
+                 /*
+                  if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==0 and y==0 and z==4)
+                         printf("004pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[0][0][0],s_data[0][0][8],s_data[0][0][16]);
+                     if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==8 and y==8 and z==4)
+                         printf("884pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[8][8][0],s_data[8][8][8],s_data[8][8][16]);
+                   */      
+                // if(fabs(pred)>=3)
+                //     printf("%d %d %d %d %d %d %d %d %d %d %.2e %.2e %.2e\n",unit,CONSTEXPR (BLUE),CONSTEXPR (YELLOW),CONSTEXPR (HOLLOW),BIX,BIY,BIZ,x,y,z,pred,code,s_data[z][y][x]);
+               
+                 s_data[z][y][x]  = pred + (code - radius) * ebx2;
+ 
+                 //if(BIX == 10 and BIY == 12 and BIZ == 0 and x==13 and y==6 and z==9)
+                 //    printf("cmp\n");
+                 
+ 
+             }
+             else {  // TODO == DECOMPRESSS and static_assert
+ 
+                 //if(BIX == 10 and BIY == 12 and BIZ == 0 and x==13 and y==6 and z==9)
+                 //    printf("dcmp\n");
+                 auto code       = s_ectrl[z][y][x];
+                 s_data[z][y][x] = pred + (code - radius) * ebx2;
+                // if(isnan(s_data[z][y][x])){
+                 //    printf("nan %d %d %d %d %d %d %d %d %d %.6e %.2e\n",BIX,BIY,BIZ,x,y,z,LINE,FACE,CUBE,pred,code);
+                 //}
+                 //  
+                 //    printf("NAN: %.6e %.2e %.6e %.6e %.6e %.6e %.6e %.6e\n",pred,code,s_data[z][y][x-3*unit],s_data[z][y][x+3*unit],s_data[z][y-3*unit][x],s_data[z][y+3*unit][x],s_data[z-3*unit][y][x],s_data[z+3*unit][y][x] );
+                 //if(BIX == 23 and BIY == 15 and BIZ == 0 and x==13 and y==7 and z==11)
+                 //    printf("NAN: %.6e %.2e %.6e %.6e %.6e %.6e %.6e %.6e %.6e %.6e\n",pred,code,s_data[z][y][x-3*unit],s_data[z][y][x-unit],s_data[z][y][x+unit],s_data[z][y][x+3*unit],s_data[z-3*unit][y][x],s_data[z-unit][y][x],s_data[z+unit][y][x],s_data[z+3*unit][y][x] );
+                 /*
+ 
+ 
+                 if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==0 and y==0 and z==4)
+                         printf("004pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[0][0][0],s_data[0][0][8],s_data[0][0][16]);
+                     if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==8 and y==8 and z==4)
+                         printf("884pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[8][8][0],s_data[8][8][8],s_data[8][8][16]);
+                         
+                 */
+                 //if(BIX == 4 and BIY == 20 and BIZ == 20 and unit==1 and CONSTEXPR (BLUE)){
+                //     if(fabs(s_data[z][y][x])>=3)
+ 
+               //      printf("%d %d %d %d %d %d %d %d %d %d %.2e %.2e %.2e\n",unit,CONSTEXPR (BLUE),CONSTEXPR (YELLOW),CONSTEXPR (HOLLOW),BIX,BIY,BIZ,x,y,z,pred,code,s_data[z][y][x]);
+                // }
+             }
+         }
+     };
+     // -------------------------------------------------------------------------------- //
+ 
+     if CONSTEXPR (COARSEN) {
+         constexpr auto TOTAL = NUM_ELE;
+         //if( BLOCK_DIMX *BLOCK_DIMY<= LINEAR_BLOCK_SIZE){
+             for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                 auto [x,y,z]    = xyzmap(_tix, unit);
+                 run(x, y, z);
+             }
+         //}
+         //may have bug    
+         /*
+         else{
+             for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                 auto itix = (_tix % BLOCK_DIMX);
+                 auto itiz = (_tix / BLOCK_DIMX) % BLOCK_DIMZ;
+                 auto itiy = (_tix / BLOCK_DIMX) / BLOCK_DIMZ;
+                 auto x    = xmap(itix, unit);
+                 auto y    = ymap(itiy, unit);
+                 auto z    = zmap(itiz, unit);
+                 run(x, y, z);
+             }
+         }*/
+         //may have bug  end
+         
+     }
+     else {
+         if(TIX<NUM_ELE){
+             auto [x,y,z]    = xyzmap(TIX, unit);
+             
+ 
+          //   printf("%d %d %d\n", x,y,z);
+             run(x, y, z);
+         }
+     }
+     __syncthreads();
+ }
+ 
+ 
+ 
+ }  // namespace
+ 
+ /********************************************************************************/
+ /*
+ template <typename T,typename FP,int  LINEAR_BLOCK_SIZE>
+ __device__ void cusz::device_api::auto_tuning(volatile T s_data[9][9][33],  DIM3  data_size, FP eb_r, FP ebx2){
+     //current design: 4 points: (4,4,4), (12,4,4), (20,4,4), (28,4,4). 6 configs (3 directions, lin/cubic)
+     auto itix=TIX % 4;//follow the warp
+     auto c=TIX/4;//follow the warp
+     bool predicate=(c<6);
+     if(predicate){
+         auto x=4+8*itix;
+         auto y=4;
+         auto z=4;
+         T pred=0;
+         auto unit = 1;
+ 
+         bool cubic=c%2;
+         bool axis=c/2;
+         bool flag_cub[2]={0,1};
+         bool flag_axis_z[3]={1,0,0};
+         bool flag_axis_y[3]={0,1,0};
+         bool flag_axis_x[3]={0,0,1};
+         T adjust_rate[2]={8.0/9.0,1};
+ 
+         pred=(-flag_cub[cubic]*s_data[z - 3*unit*flag_axis_z[axis]][y- 3*unit*flag_axis_y[axis]][x- 3*unit*flag_axis_x[axis]]
+             +9*s_data[z -unit*flag_axis_z[axis]][y-unit*flag_axis_y[axis]][x- unit*flag_axis_x[axis]]
+             +9*s_data[z +unit*flag_axis_z[axis]][y+unit*flag_axis_y[axis]][x+ unit*flag_axis_x[axis]]
+             -flag_cub[cubic]*s_data[z + 3*unit*flag_axis_z[axis]][y+ 3*unit*flag_axis_y[axis]][x+ 3*unit*flag_axis_x[axis]])/16;
+ 
+         pred*=adjust_rate[cubic];
+         T abs_error=fabs(pred-s_data[z][y][x]);
+ 
+     } 
+     
+ }
+ */
+ template <typename T,int  LINEAR_BLOCK_SIZE>
+ __device__ void cusz::device_api::auto_tuning(volatile T s_data[16][16][16],  volatile T local_errs[2], DIM3  data_size,  T * errs){
+  
+     if(TIX<2)
+         local_errs[TIX]=0;
+     __syncthreads(); 
+ 
+     auto local_idx=TIX%2;
+     auto temp=TIX/2;
+     
+ 
+     auto block_idx_x =  temp % 4;
+     auto block_idx_y = ( temp / 4) % 4;
+     auto block_idx_z = ( ( temp  / 4) / 4) % 4;
+     auto dir = ( ( temp  / 4) / 4) / 4;
+ 
+ 
+ 
+     bool predicate=  dir<2;
+     // __shared__ T local_errs[6];
+ 
+ 
+ 
+     
+     if(predicate){
+ 
+        
+         
+         auto x=4*block_idx_x+1+local_idx;
+         //auto x =16;
+         auto y=4*block_idx_y+1+local_idx;
+         auto z=4*block_idx_z+1+local_idx;
+ 
+         
+         T pred=0;
+ 
+         //auto unit = 1;
+         switch(dir){
+             case 0:
+                 pred = (s_data[z - 1][y][x] + s_data[z + 1][y][x]) / 2;
+                 break;
+ 
+             
+             case 1:
+                  pred = (s_data[z][y][x - 1] + s_data[z][y][x + 1]) / 2;
+                 break;
+ 
+             default:
+             break;
+         }
+         
+         T abs_error=fabs(pred-s_data[z][y][x]);
+         atomicAdd(const_cast<T*>(local_errs) + dir, abs_error);
+         
+ 
+     } 
+     __syncthreads(); 
+     if(TIX<2)
+         errs[TIX]=local_errs[TIX];
+     __syncthreads(); 
+        
+ }
+ 
+ 
+ template <typename T,int  LINEAR_BLOCK_SIZE>
+ __device__ void cusz::device_api::auto_tuning_2(volatile T s_data[64], volatile T s_nx[64][4], volatile T s_ny[64][4], volatile T s_nz[64][4],  volatile T local_errs[6], DIM3  data_size,  T * errs){
+  
+     if(TIX<6)
+         local_errs[TIX]=0;
+     __syncthreads(); 
+ 
+     auto point_idx=TIX%64;
+     auto c=TIX/64;
+ 
+ 
+     bool predicate=  c<6;
+     // __shared__ T local_errs[6];
+ 
+     
+     if(predicate){
+ 
+        
+     
+         
+         T pred=0;
+ 
+         //auto unit = 1;
+         switch(c){
+                 case 0:
+                     pred = (-s_nz[point_idx][0]+9*s_nz[point_idx][1] + 9*s_nz[point_idx][2]-s_nz[point_idx][3]) / 16;
+                     break;
+ 
+                 case 1:
+                     pred = (-3*s_nz[point_idx][0]+23*s_nz[point_idx][1] + 23*s_nz[point_idx][2]-3*s_nz[point_idx][3]) / 40;
+                     break;
+                 case 2:
+                     pred = (-s_ny[point_idx][0]+9*s_ny[point_idx][1] + 9*s_ny[point_idx][2]-s_ny[point_idx][3]) / 16;
+                     break;
+                 case 3:
+                     pred = (-3*s_ny[point_idx][0]+23*s_ny[point_idx][1] + 23*s_ny[point_idx][2]-3*s_ny[point_idx][3]) / 40;
+                     break;
+ 
+                 case 4:
+                     pred = (-s_nx[point_idx][0]+9*s_nx[point_idx][1] + 9*s_nx[point_idx][2]-s_nx[point_idx][3]) / 16;
+                     break;
+                 case 5:
+                     pred = (-3*s_nx[point_idx][0]+23*s_nx[point_idx][1] + 23*s_nx[point_idx][2]-3*s_nx[point_idx][3]) / 40;
+                     break;
+ 
+ 
+ 
+                 default:
+                 break;
+             }
+         
+         T abs_error=fabs(pred-s_data[point_idx]);
+         atomicAdd(const_cast<T*>(local_errs) + c, abs_error);
+         
+ 
+     } 
+     __syncthreads(); 
+     if(TIX<6)
+         errs[TIX]=local_errs[TIX];
+     __syncthreads(); 
+        
+ }
+ 
+ 
+ 
+ template <typename T1, typename T2, typename FP,int LINEAR_BLOCK_SIZE, bool WORKFLOW, bool PROBE_PRED_ERROR>
+ __device__ void cusz::device_api::spline3d_layout2_interpolate(
+     volatile T1 s_data[17][17][17],
+     volatile T2 s_ectrl[17][17][17],
+      DIM3    data_size,
+     FP          eb_r,
+     FP          ebx2,
+     int         radius,
+     INTERPOLATION_PARAMS intp_param
+     )
+ {
+     auto xblue = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+     auto yblue = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+     auto zblue = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+ 
+     auto xblue_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+     auto yblue_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy ); };
+     auto zblue_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+ 
+     auto xyellow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+     auto yyellow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
+     auto zyellow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+ 
+     auto xyellow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+     auto yyellow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
+     auto zyellow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2); };
+ 
+ 
+     auto xhollow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
+     auto yhollow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy); };
+     auto zhollow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+ 
+     auto xhollow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
+     auto yhollow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+     auto zhollow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz *2); };
+ 
+     auto xyzmap_line_16b_1u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 8;
+         constexpr auto L = N*(N+1)*(N+1); 
+         constexpr auto Q = (N+1)*(N+1); 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / (N+1);
+         auto k = (m % Q) % (N+1);
+         if(group==0)
+             return std::make_tuple(2*i+1,2*j,2*k);
+         else if (group==1)
+             return std::make_tuple(2*k,2*i+1,2*j);
+         else
+             return std::make_tuple(2*j,2*k,2*i+1);
+ 
+     };
+ 
+     auto xyzmap_face_16b_1u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 8;
+         constexpr auto L = N*N*(N+1);
+         constexpr auto Q = N*N; 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / N;
+         auto k = (m % Q) % N;
+         if(group==0)
+             return std::make_tuple(2*i,2*j+1,2*k+1);
+         else if (group==1)
+             return std::make_tuple(2*k+1,2*i,2*j+1);
+         else
+             return std::make_tuple(2*j+1,2*k+1,2*i);
+ 
+     };
+ 
+      auto xyzmap_cube_16b_1u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 8;
+         constexpr auto Q = N * N; 
+         auto i = _tix / Q;
+         auto j = (_tix % Q) / N;
+         auto k = (_tix % Q) % N;
+         return std::make_tuple(2*i+1,2*j+1,2*k+1);
+ 
+     };
+ 
+     auto xyzmap_line_16b_2u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 4;
+         constexpr auto L = N*(N+1)*(N+1); 
+         constexpr auto Q = (N+1)*(N+1); 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / (N+1);
+         auto k = (m % Q) % (N+1);
+         if(group==0)
+             return std::make_tuple(4*i+2,4*j,4*k);
+         else if (group==1)
+             return std::make_tuple(4*k,4*i+2,4*j);
+         else
+             return std::make_tuple(4*j,4*k,4*i+2);
+ 
+     };
+ 
+     auto xyzmap_face_16b_2u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 4;
+         constexpr auto L = N*N*(N+1);
+         constexpr auto Q = N*N; 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / N;
+         auto k = (m % Q) % N;
+         if(group==0)
+             return std::make_tuple(4*i,4*j+2,4*k+2);
+         else if (group==1)
+             return std::make_tuple(4*k+2,4*i,4*j+2);
+         else
+             return std::make_tuple(4*j+2,4*k+2,4*i);
+ 
+     };
+ 
+      auto xyzmap_cube_16b_2u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 4;
+         constexpr auto Q = N * N; 
+         auto i = _tix / Q;
+         auto j = (_tix % Q) / N;
+         auto k = (_tix % Q) % N;
+         return std::make_tuple(4*i+2,4*j+2,4*k+2);
+ 
+     };
+ 
+     auto xyzmap_line_16b_4u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 2;
+         constexpr auto L = N*(N+1)*(N+1); 
+         constexpr auto Q = (N+1)*(N+1); 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / (N+1);
+         auto k = (m % Q) % (N+1);
+         if(group==0)
+             return std::make_tuple(8*i+4,8*j,8*k);
+         else if (group==1)
+             return std::make_tuple(8*k,8*i+4,8*j);
+         else
+             return std::make_tuple(8*j,8*k,8*i+4);
+ 
+     };
+ 
+     auto xyzmap_face_16b_4u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 2;
+         constexpr auto L = N*N*(N+1);
+         constexpr auto Q = N*N; 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / N;
+         auto k = (m % Q) % N;
+         if(group==0)
+             return std::make_tuple(8*i,8*j+4,8*k+4);
+         else if (group==1)
+             return std::make_tuple(8*k+4,8*i,8*j+4);
+         else
+             return std::make_tuple(8*j+4,8*k+4,8*i);
+ 
+     };
+ 
+      auto xyzmap_cube_16b_4u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 2;
+         constexpr auto Q = N * N; 
+         auto i = _tix / Q;
+         auto j = (_tix % Q) / N;
+         auto k = (_tix % Q) % N;
+         return std::make_tuple(8*i+4,8*j+4,8*k+4);
+ 
+     };
+ 
+     auto xyzmap_line_16b_8u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 1;
+         constexpr auto L = N*(N+1)*(N+1); 
+         constexpr auto Q = (N+1)*(N+1); 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / (N+1);
+         auto k = (m % Q) % (N+1);
+         if(group==0)
+             return std::make_tuple(16*i+8,16*j,16*k);
+         else if (group==1)
+             return std::make_tuple(16*k,16*i+8,16*j);
+         else
+             return std::make_tuple(16*j,16*k,16*i+8);
+ 
+     };
+ 
+     auto xyzmap_face_16b_8u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 1;
+         constexpr auto L = N*N*(N+1);
+         constexpr auto Q = N*N; 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / N;
+         auto k = (m % Q) % N;
+         if(group==0)
+             return std::make_tuple(16*i,16*j+8,16*k+8);
+         else if (group==1)
+             return std::make_tuple(16*k+8,16*i,16*j+8);
+         else
+             return std::make_tuple(16*j+8,16*k+8,16*i);
+ 
+     };
+ 
+      auto xyzmap_cube_16b_8u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 1;
+         constexpr auto Q = N * N; 
+         auto i = _tix / Q;
+         auto j = (_tix % Q) / N;
+         auto k = (_tix % Q) % N;
+         return std::make_tuple(16*i+8,16*j+8,16*k+8);
+ 
+     };
+ 
+ 
+     auto nan_cubic_interp = [] __device__ (T1 a, T1 b, T1 c, T1 d) -> T1{
+         return (-a+9*b+9*c-d) / 16;
+     };
+ 
+     auto nat_cubic_interp = [] __device__ (T1 a, T1 b, T1 c, T1 d) -> T1{
+         return (-3*a+23*b+23*c-3*d) / 40;
+     };
+ 
+ 
+ 
+ 
+     constexpr auto COARSEN          = true;
+     constexpr auto NO_COARSEN       = false;
+     constexpr auto BORDER_INCLUSIVE = true;
+     constexpr auto BORDER_EXCLUSIVE = false;
+ 
+     
+     FP cur_ebx2=ebx2,cur_eb_r=eb_r;
+ 
+ 
+     auto calc_eb = [&](auto unit) {
+         cur_ebx2=ebx2,cur_eb_r=eb_r;
+         int temp=1;
+         while(temp<unit){
+             temp*=2;
+             cur_eb_r *= intp_param.alpha;
+             cur_ebx2 /= intp_param.alpha;
+ 
+         }
+         if(cur_ebx2 < ebx2 / intp_param.beta){
+             cur_ebx2 = ebx2 / intp_param.beta;
+             cur_eb_r = eb_r * intp_param.beta;
+ 
+         }
+     };
+     
+     int unit = 8;
+     //int m = 2, n = 2, p = 2;//block8 nums;
+     calc_eb(unit);
+     //set_orders(reverse[2]);
+     if(intp_param.use_md[3]){
+ 
+ 
+         if(intp_param.use_natural[3]==0){
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_line_16b_8u), //
+                 true, false, false, LINEAR_BLOCK_SIZE,12 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_line_16b_8u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_face_16b_8u), //
+                 false, true, false, LINEAR_BLOCK_SIZE,6 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_face_16b_8u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_cube_16b_8u), //
+                 false, false, true, LINEAR_BLOCK_SIZE,1 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_cube_16b_8u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+         }
+         else{
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_line_16b_8u), //
+                 true, false, false, LINEAR_BLOCK_SIZE,12 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_line_16b_8u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_face_16b_8u), //
+                 false, true, false, LINEAR_BLOCK_SIZE,6 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_face_16b_8u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_cube_16b_8u), //
+                 false, false, true, LINEAR_BLOCK_SIZE,1 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_cube_16b_8u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+             
+ 
+         }
+ 
+     }
+     else{
+ 
+         if(intp_param.reverse[3]){
+             interpolate_stage<
+                 T1, T2, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
+                 false, false, true, LINEAR_BLOCK_SIZE, 1, 2, NO_COARSEN, 2, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3]);
+ 
+             interpolate_stage<
+                 T1, T2, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
+                 false, true, false, LINEAR_BLOCK_SIZE, 3, 1, NO_COARSEN, 2, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3]);
+             interpolate_stage<
+                 T1, T2, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
+                 true, false, false, LINEAR_BLOCK_SIZE, 3, 3, NO_COARSEN, 1, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xblue_reverse, yblue_reverse, zblue_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3]);
+ 
+ 
+         }
+         else{
+             //if( BIX==0 and BIY==0 and BIZ==0)
+            // printf("lv3s0\n");
+             interpolate_stage<
+                 T1, T2, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+                 true, false, false, LINEAR_BLOCK_SIZE, 2, 2, NO_COARSEN, 1, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xblue, yblue, zblue, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3]);
+            // if(BIX==0 and BIY==0 and BIZ==0)
+            // printf("lv3s1\n");
+             interpolate_stage<
+                 T1, T2, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
+                 false, true, false, LINEAR_BLOCK_SIZE, 2, 1, NO_COARSEN, 3, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyellow, yyellow, zyellow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3]);
+             //if(BIX==0 and BIY==0 and BIZ==0)
+           //  printf("lv3s2\n");
+             interpolate_stage<
+                 T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
+                 false, false, true, LINEAR_BLOCK_SIZE, 1, 3, NO_COARSEN, 3, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xhollow, yhollow, zhollow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[3]);
+         }
+     }
+ 
+ 
+     unit = 4;
+     //int m = 2, n = 2, p = 2;//block8 nums;
+     calc_eb(unit);
+     //set_orders(reverse[2]);
+ 
+ 
+     if(intp_param.use_md[2]){
+ 
+ 
+         if(intp_param.use_natural[2]==0){
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_line_16b_4u), //
+                 true, false, false, LINEAR_BLOCK_SIZE,54 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_line_16b_4u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_face_16b_4u), //
+                 false, true, false, LINEAR_BLOCK_SIZE,36 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_face_16b_4u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_cube_16b_4u), //
+                 false, false, true, LINEAR_BLOCK_SIZE,8 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_cube_16b_4u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+         }
+         else{
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_line_16b_4u), //
+                 true, false, false, LINEAR_BLOCK_SIZE,54 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_line_16b_4u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_face_16b_4u), //
+                 false, true, false, LINEAR_BLOCK_SIZE,36 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_face_16b_4u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_cube_16b_4u), //
+                 false, false, true, LINEAR_BLOCK_SIZE,8 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_cube_16b_4u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+             
+ 
+         }
+ 
+     }
+ 
+ 
+     else{
+         if(intp_param.reverse[2]){
+             interpolate_stage<
+                 T1, T2, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
+                 false, false, true, LINEAR_BLOCK_SIZE, 2, 3, NO_COARSEN, 3, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[2]);
+ 
+             interpolate_stage<
+                 T1, T2, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
+                 false, true, false, LINEAR_BLOCK_SIZE, 5, 2, NO_COARSEN, 3, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[2]);
+             interpolate_stage<
+                 T1, T2, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
+                 true, false, false, LINEAR_BLOCK_SIZE, 5, 5, NO_COARSEN, 2, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xblue_reverse, yblue_reverse, zblue_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[2]);
+ 
+ 
+         }
+         else{
+             //if( BIX==0 and BIY==0 and BIZ==0)
+            // printf("lv3s0\n");
+             interpolate_stage<
+                 T1, T2, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+                 true, false, false, LINEAR_BLOCK_SIZE, 3, 3, NO_COARSEN, 2, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xblue, yblue, zblue, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[2]);
+            // if(BIX==0 and BIY==0 and BIZ==0)
+            // printf("lv3s1\n");
+             interpolate_stage<
+                 T1, T2, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
+                 false, true, false, LINEAR_BLOCK_SIZE, 3, 2, NO_COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyellow, yyellow, zyellow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[2]);
+             //if(BIX==0 and BIY==0 and BIZ==0)
+           //  printf("lv3s2\n");
+             interpolate_stage<
+                 T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
+                 false, false, true, LINEAR_BLOCK_SIZE, 2, 5, NO_COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xhollow, yhollow, zhollow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[2]);
+         }
+     }
+    // if(BIX==0 and BIY==0 and BIZ==0)
+    // printf("lv3\n");
+ 
+     unit = 2;
+     //m*=2;
+     //n*=2;
+     //p*=2;
+     calc_eb(unit);
+     //set_orders(reverse[1]);
+ 
+     // iteration 2, TODO switch y-z order
+     /*
+    */
+ 
+     if(intp_param.use_md[1]){
+ 
+ 
+         if(intp_param.use_natural[1]==0){
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_line_16b_2u), //
+                 true, false, false, LINEAR_BLOCK_SIZE,300 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_line_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_face_16b_2u), //
+                 false, true, false, LINEAR_BLOCK_SIZE,240 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_face_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_cube_16b_2u), //
+                 false, false, true, LINEAR_BLOCK_SIZE,64 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_cube_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+         }
+         else{
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_line_16b_2u), //
+                 true, false, false, LINEAR_BLOCK_SIZE,300 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_line_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_face_16b_2u), //
+                 false, true, false, LINEAR_BLOCK_SIZE,240 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_face_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_cube_16b_2u), //
+                 false, false, true, LINEAR_BLOCK_SIZE,64 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_cube_16b_2u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+             
+ 
+         }
+     }
+     else{
+          if(intp_param.reverse[1]){
+             interpolate_stage<
+                 T1, T2, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
+                 false, false, true, LINEAR_BLOCK_SIZE, 4, 5, NO_COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[1]);
+             interpolate_stage<
+                 T1, T2, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
+                 false, true, false, LINEAR_BLOCK_SIZE, 9, 4, NO_COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[1]);
+             interpolate_stage<
+                 T1, T2, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
+                 true, false, false, LINEAR_BLOCK_SIZE, 9, 9, NO_COARSEN, 4, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xblue_reverse, yblue_reverse, zblue_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[1]);
+         }
+         else{
+             interpolate_stage<
+                 T1, T2, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+                 true, false, false, LINEAR_BLOCK_SIZE, 5, 5, NO_COARSEN, 4, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xblue, yblue, zblue, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[1]);
+             interpolate_stage<
+                 T1, T2, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
+                 false, true, false, LINEAR_BLOCK_SIZE, 5, 4, NO_COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyellow, yyellow, zyellow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[1]);
+             interpolate_stage<
+                 T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
+                 false, false, true, LINEAR_BLOCK_SIZE, 4, 9, NO_COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xhollow, yhollow, zhollow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[1]);
+ 
+         }
+ 
+     }
+ 
+ 
+     //if(TIX==0 and TIY==0 and TIZ==0 and BIX==0 and BIY==0 and BIZ==0)
+     //printf("lv2\n");
+     unit = 1;
+     //m*=2;
+     //n*=2;
+     //p*=2;
+     calc_eb(unit);
+    // set_orders(reverse[0]);
+     if(intp_param.use_md[0]){
+         if(intp_param.use_natural[0]==0){
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_line_16b_1u), //
+                 true, false, false, LINEAR_BLOCK_SIZE,1944 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_line_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_face_16b_1u), //
+                 false, true, false, LINEAR_BLOCK_SIZE,1728 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_face_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_cube_16b_1u), //
+                 false, false, true, LINEAR_BLOCK_SIZE,512 ,COARSEN, BORDER_EXCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_cube_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nan_cubic_interp);
+ 
+         }
+         else{
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_line_16b_1u), //
+                 true, false, false, LINEAR_BLOCK_SIZE,1944 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_line_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_face_16b_1u), //
+                 false, true, false, LINEAR_BLOCK_SIZE,1728 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_face_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+ 
+             interpolate_stage_md<
+                 T1, T2, FP, decltype(xyzmap_cube_16b_1u), //
+                 false, false, true, LINEAR_BLOCK_SIZE,512 ,COARSEN, BORDER_EXCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyzmap_cube_16b_1u, unit, cur_eb_r, cur_ebx2, radius, nat_cubic_interp);
+             
+ 
+         }
+     }
+     else{
+         if(intp_param.reverse[0]){
+             //may have bug 
+             interpolate_stage<
+                 T1, T2, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
+                 false, false, true, LINEAR_BLOCK_SIZE, 8, 9, COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[0]);
+             interpolate_stage<
+                 T1, T2, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
+                 false, true, false, LINEAR_BLOCK_SIZE, 17, 8, COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[0]);
+             interpolate_stage<
+                 T1, T2, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
+                 true, false, false, LINEAR_BLOCK_SIZE, 17, 17, COARSEN, 8, BORDER_EXCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xblue_reverse, yblue_reverse, zblue_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[0]);
+ 
+             //may have bug end
+         }
+         else{
+             interpolate_stage<
+                 T1, T2, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+                 true, false, false, LINEAR_BLOCK_SIZE, 9, 9, COARSEN, 8, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xblue, yblue, zblue, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[0]);
+             interpolate_stage<
+                 T1, T2, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
+                 false, true, false, LINEAR_BLOCK_SIZE, 9, 8, COARSEN, 17, BORDER_INCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xyellow, yyellow, zyellow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[0]);
+            
+             interpolate_stage<
+                 T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
+                 false, false, true, LINEAR_BLOCK_SIZE, 8, 17, COARSEN, 17, BORDER_EXCLUSIVE, WORKFLOW>(
+                 s_data, s_ectrl,data_size, xhollow, yhollow, zhollow, unit, cur_eb_r, cur_ebx2, radius, intp_param.use_natural[0]);
+ 
+         }
+     }
+ 
+     // iteration 3
+     /*
+     */
+   //  if(TIX==0 and TIY==0 and TIZ==0 and BIX==0 and BIY==0 and BIZ==0)
+    // printf("lv1\n");
+     
+ 
+ 
+      /******************************************************************************
+      test only: last step inclusive
+      ******************************************************************************/
+     // interpolate_stage<
+     //     T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
+     //     false, false, true, LINEAR_BLOCK_SIZE, 33, 4, COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+     //     s_data, s_ectrl, xhollow, yhollow, zhollow, unit, eb_r, ebx2, radius);
+     /******************************************************************************
+      production
+      ******************************************************************************/
+ 
+     /******************************************************************************
+      test only: print a block
+      ******************************************************************************/
+     // if (TIX == 0 and BIX == 7 and BIY == 47 and BIZ == 15) { spline3d_print_block_from_GPU(s_ectrl); }
+    //  if (TIX == 0 and BIX == 4 and BIY == 20 and BIZ == 20) { spline3d_print_block_from_GPU(s_data); }
+ }
+ 
+ /********************************************************************************
+  * host API/kernel
+  ********************************************************************************/
+ template <typename TITER, int LINEAR_BLOCK_SIZE>
+ __global__ void cusz::c_spline3d_profiling_16x16x16data(
+     TITER   data,
+     DIM3    data_size,
+     STRIDE3 data_leap,
+     TITER errors)
+ {
+     // compile time variables
+     using T = typename std::remove_pointer<TITER>::type;
+  
+ 
+     {
+         __shared__ struct {
+             T data[16][16][16];
+             T local_errs[2];
+            // T global_errs[6];
+         } shmem;
+ 
+ 
+         c_reset_scratch_profiling_16x16x16data<T, LINEAR_BLOCK_SIZE>(shmem.data, 0.0);
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("reset\n");
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
+ 
+         global2shmem_profiling_16x16x16data<T, T, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data);
+ 
+ 
+ 
+      
+ 
+         //if (TIX < 6 and BIX==0 and BIY==0 and BIZ==0) errors[TIX] = 0.0;//risky
+ 
+         //__syncthreads();
+        
+ 
+         cusz::device_api::auto_tuning<T,LINEAR_BLOCK_SIZE>(
+             shmem.data, shmem.local_errs, data_size, errors);
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("device %.4f %.4f\n",errors[0],errors[1]);
+ 
+         
+     }
+ }
+ 
+ template <typename TITER, int LINEAR_BLOCK_SIZE>
+ __global__ void cusz::c_spline3d_profiling_data_2(
+     TITER   data,
+     DIM3    data_size,
+     STRIDE3 data_leap,
+     TITER errors)
+ {
+     // compile time variables
+     using T = typename std::remove_pointer<TITER>::type;
+  
+ 
+     {
+         __shared__ struct {
+             T data[64];
+             T neighbor_x [64][4];
+             T neighbor_y [64][4];
+             T neighbor_z [64][4];
+             T local_errs[6];
+            // T global_errs[6];
+         } shmem;
+ 
+ 
+         c_reset_scratch_profiling_data_2<T, LINEAR_BLOCK_SIZE>(shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z,0.0);
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("reset\n");
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
+ 
+         global2shmem_profiling_data_2<T, T, LINEAR_BLOCK_SIZE>(data, data_size, data_leap,shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z);
+ 
+ 
+ 
+      
+ 
+         if (TIX < 6 and BIX==0 and BIY==0 and BIZ==0) errors[TIX] = 0.0;//risky
+ 
+         //__syncthreads();
+        
+ 
+         cusz::device_api::auto_tuning_2<T,LINEAR_BLOCK_SIZE>(
+             shmem.data, shmem.neighbor_x, shmem.neighbor_y, shmem.neighbor_z, shmem.local_errs, data_size, errors);
+ 
+         
+     }
+ }
+ 
+ 
+ __forceinline__ __device__ void pre_compute(DIM3 data_size, volatile STRIDE3 grid_leaps[5], volatile size_t prefix_nums[5]){
+     if(TIX==0){
+         auto d_size = data_size;
+         
+         int level = 0;
+         while(level<=4){
+             //grid_sizes[level]=d_size;
+             grid_leaps[level].x=1;
+             grid_leaps[level].y=d_size.x;
+             grid_leaps[level].z=d_size.x*d_size.y;
+             if(level<4){
+ 
+                 d_size.x= (d_size.x+1)>>1;
+                 d_size.y = (d_size.y+1)>>1;
+                 d_size.z = (d_size.z+1)>>1;
+                 prefix_nums[level] = d_size.x*d_size.y*d_size.z;
+             }
+             level++;
+         }   
+         prefix_nums[4]=0;
+     }
+     __syncthreads(); 
+     
+ }
+ 
+ template <typename TITER, typename EITER, typename FP, int LINEAR_BLOCK_SIZE, typename CompactVal, typename CompactIdx, typename CompactNum>
+ __global__ void cusz::c_spline3d_infprecis_16x16x16data(
+     TITER   data,
+     DIM3    data_size,
+     STRIDE3 data_leap,
+     EITER   ectrl,
+     DIM3    ectrl_size,
+     STRIDE3 ectrl_leap,
+     TITER   anchor,
+     STRIDE3 anchor_leap,
+     CompactVal compact_val,
+     CompactIdx compact_idx,
+     CompactNum compact_num,
+     FP      eb_r,
+     FP      ebx2,
+     int     radius,
+     INTERPOLATION_PARAMS intp_param//,
+     //TITER errors
+     )
+ {
+     // compile time variables
+     using T = typename std::remove_pointer<TITER>::type;
+     using E = typename std::remove_pointer<EITER>::type;
+ 
+     {
+         __shared__ struct {
+             T data[17][17][17];
+             T ectrl[17][17][17];
+             //DIM3 grid_sizes[5];
+             STRIDE3 grid_leaps[5];
+             size_t prefix_nums[5];
+ 
+            // T global_errs[6];
+         } shmem;
+ 
+        // T cubic_errors=errors[0]+errors[2]+errors[4];
+        // T linear_errors=errors[1]+errors[3]+errors[5];
+      // bool do_cubic=(cubic_errors<=linear_errors);
+       //intp_param.interpolators[0]=(errors[0]>errors[1]);
+       //intp_param.interpolators[1]=(errors[2]>errors[3]);
+       //intp_param.interpolators[2]=(errors[4]>errors[5]);
+       
+       //bool do_reverse=(errors[4+intp_param.interpolators[2]]>errors[intp_param.interpolators[0]]);
+         /*
+         if(intp_param.auto_tuning){
+             bool do_reverse=(errors[1]>3*errors[0]);
+            intp_param.reverse[0]=intp_param.reverse[1]=intp_param.reverse[2]=do_reverse;
+        }
+        */
+     /*
+        if(TIX==0 and BIX==0 and BIY==0 and BIZ==0){
+         printf("Errors: %.6f %.6f \n",errors[0],errors[1]);
+         printf("Cubic: %d %d %d\n",intp_param.interpolators[0],intp_param.interpolators[1],intp_param.interpolators[2]);
+         printf("reverse: %d %d %d\n",intp_param.reverse[0],intp_param.reverse[1],intp_param.reverse[2]);
+        }
+        */
+         /*
+          if(TIX==0 and BIX==0 and BIY==0 and BIZ==0){
+              printf("NAT: %d %d %d %d\n",intp_param.use_natural[3],intp_param.use_natural[2],intp_param.use_natural[1],intp_param.use_natural[0]);
+           printf("MD: %d %d %d %d\n",intp_param.use_md[3],intp_param.use_md[2],intp_param.use_md[1],intp_param.use_md[0]);
+           printf("REVERSE: %d %d %d %d\n",intp_param.reverse[3],intp_param.reverse[2],intp_param.reverse[1],intp_param.reverse[0]);
+       }*/
+        
+    
+         pre_compute(ectrl_size,shmem.grid_leaps,shmem.prefix_nums);
+ 
+         c_reset_scratch_17x17x17data<T, T, LINEAR_BLOCK_SIZE>(shmem.data, shmem.ectrl, radius);
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("reset\n");
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
+ 
+         global2shmem_17x17x17data<T, T, LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data);
+ 
+        // if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("g2s\n");
+         // version 1, use shmem, erroneous
+         // c_gather_anchor<T>(shmem.data, anchor, anchor_leap);
+         // version 2, use global mem, correct
+         c_gather_anchor<T>(data, data_size, data_leap, anchor, anchor_leap);
+ 
+ 
+        
+ 
+ 
+         cusz::device_api::spline3d_layout2_interpolate<T, T, FP,LINEAR_BLOCK_SIZE, SPLINE3_COMPR, false>(
+             shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
+         
+         
+ 
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("interp\n");
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+          //   printf("esz: %d %d %d\n",ectrl_size.x,ectrl_size.y,ectrl_size.z);
+ 
+ 
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+ 
+         shmem2global_17x17x17data_with_compaction<T, E, LINEAR_BLOCK_SIZE>(shmem.ectrl, ectrl, ectrl_size, ectrl_leap, radius, shmem.grid_leaps,shmem.prefix_nums, compact_val, compact_idx, compact_num);
+ 
+         // shmem2global_32x8x8data<T, E, LINEAR_BLOCK_SIZE>(shmem.ectrl, ectrl, ectrl_size, ectrl_leap);
+ 
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("s2g\n");
+     }
+ }
+ 
+ 
+ 
+ 
+ 
+ template <
+     typename EITER,
+     typename TITER,
+     typename FP,
+     int LINEAR_BLOCK_SIZE>
+ __global__ void cusz::x_spline3d_infprecis_16x16x16data(
+     EITER   ectrl,        // input 1
+     DIM3    ectrl_size,   //
+     STRIDE3 ectrl_leap,   //
+     TITER   anchor,       // input 2
+     DIM3    anchor_size,  //
+     STRIDE3 anchor_leap,  //
+     TITER   data,         // output
+     DIM3    data_size,    //
+     STRIDE3 data_leap,    //
+     FP      eb_r,
+     FP      ebx2,
+     int     radius,
+     INTERPOLATION_PARAMS intp_param)
+ {
+     // compile time variables
+     using E = typename std::remove_pointer<EITER>::type;
+     using T = typename std::remove_pointer<TITER>::type;
+ 
+     __shared__ struct {
+         T data[17][17][17];
+         T ectrl[17][17][17];
+         STRIDE3 grid_leaps[5];
+         size_t prefix_nums[5];
+         //uint64_t L16_num;
+         //uint64_t L8_num;
+         //uint64_t L4_num;
+         //uint64_t L2_num;
+     } shmem;
+ 
+     pre_compute(ectrl_size,shmem.grid_leaps,shmem.prefix_nums);
+ 
+     x_reset_scratch_17x17x17data<T, T, LINEAR_BLOCK_SIZE>(shmem.data, shmem.ectrl, anchor, anchor_size, anchor_leap);
+ 
+     //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+     //        printf("esz: %d %d %d\n",ectrl_size.x,ectrl_size.y,ectrl_size.z);
+ 
+     // global2shmem_33x9x9data<E, T, LINEAR_BLOCK_SIZE>(ectrl, ectrl_size, ectrl_leap, shmem.ectrl);
+     global2shmem_fuse<T, E, LINEAR_BLOCK_SIZE>(ectrl, ectrl_size, ectrl_leap, data, shmem.ectrl, shmem.grid_leaps,shmem.prefix_nums);
+ 
+     cusz::device_api::spline3d_layout2_interpolate<T, T, FP, LINEAR_BLOCK_SIZE, SPLINE3_DECOMPR, false>(
+         shmem.data, shmem.ectrl, data_size, eb_r, ebx2, radius, intp_param);
+     //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+     //        printf("dsz: %d %d %d\n",data_size.x,data_size.y,data_size.z);
+     shmem2global_17x17x17data<T, T, LINEAR_BLOCK_SIZE>(shmem.data, data, data_size, data_leap);
+ }
+ 
+ 
+ template <typename TITER>
+ __global__ void cusz::reset_errors(TITER errors)
+ {
+     if(TIX<18)
+         errors[TIX]=0;
+ }
+ 
+ template <typename T>
+ __forceinline__ __device__ void pre_compute_att(DIM3 sam_starts, DIM3 sam_bgs, DIM3 sam_strides, DIM3 &global_starts,INTERPOLATION_PARAMS &intp_param,uint8_t &level,uint8_t &unit,volatile T err[6],bool workflow){
+ 
+     if(TIX<6)
+         err[TIX] = 0.0;
+ 
+     auto grid_idx_x = BIX % sam_bgs.x;
+     auto grid_idx_y = (BIX / sam_bgs.x) % sam_bgs.y;
+     auto grid_idx_z = (BIX / sam_bgs.x) / sam_bgs.y;
+     global_starts.x = sam_starts.x + grid_idx_x * sam_strides.x;
+     global_starts.y = sam_starts.y + grid_idx_y * sam_strides.y;
+     global_starts.z = sam_starts.z + grid_idx_z * sam_strides.z;
+     if(workflow==SPLINE3_PRED_ATT){
+         bool use_natural=false,use_md=false,reverse=false;
+         if (BIY==0){
+             level = 2;
+             //use_natural= false;
+             //use_md = BIY == 2;
+             //reverse = BIY % 3;
+ 
+         }
+         else if (BIY <3){
+             level = 1;
+             use_natural= (BIY==2);
+             //use_md = BIY == 5;
+             //reverse = BIY % 3;
+ 
+         }
+         else{
+             level = 0;
+             use_natural = BIY > 5;
+             use_md = (BIY == 5 or BIY == 8);
+             reverse = BIY % 3;
+         }
+        
+         intp_param.use_natural[level]=use_natural;
+         intp_param.use_md[level]=use_md;
+         intp_param.reverse[level]=reverse;
+     }
+     else{
+         level = 0;
+         if(BIY==0){
+             intp_param.alpha = 1.0;
+             intp_param.beta = 2.0;
+         }
+         else if (BIY==1){
+             intp_param.alpha = 1.25;
+             intp_param.beta = 2.0;
+         }
+         else{
+             intp_param.alpha = 1.5+0.25*((BIY-2)/3);
+             intp_param.beta = 2.0+((BIY-2)%3);
+         }
+     }
+     unit = 1<<level;
+ 
+         //printf("%d %d %d %d %d %d %d\n",global_starts.x,global_starts.y,global_starts.z,level,use_natural,use_md,reverse);
+     
+     __syncthreads(); 
+     
+ }
+ 
+ template <typename T1, typename T2, int LINEAR_BLOCK_SIZE = DEFAULT_LINEAR_BLOCK_SIZE>
+ __device__ void global2shmem_17x17x17data_att(T1* data, DIM3 data_size, STRIDE3 data_leap, volatile T2 s_data[17][17][17], DIM3 global_starts, uint8_t unit)
+ {
+     constexpr auto TOTAL = BLOCK17 * BLOCK17 * BLOCK17;
+ 
+     //if(TIX==0){
+     //    printf("%d %d %d %d %d %d\n",data_size.x,data_size.y,data_size.z,data_leap.x,data_leap.y,data_leap.z);
+     //}
+ 
+     for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+         auto x   = (_tix % BLOCK17);
+         auto y   = (_tix / BLOCK17) % BLOCK17;
+         auto z   = (_tix / BLOCK17) / BLOCK17;
+         auto gx  = (x + global_starts.x);
+         auto gy  = (y + global_starts.y);
+         auto gz  = (z + global_starts.z);
+         auto gid = gx + gy * data_leap.y + gz * data_leap.z;
+ 
+         if (gx < data_size.x and gy < data_size.y and gz < data_size.z  ) s_data[z][y][x] = data[gid];
+ /*
+         if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==8 and z==4){
+             printf("g2s1084 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
+         }
+ 
+         if(BIX == 7 and BIY == 47 and BIZ == 15 and x==10 and y==4 and z==8){
+             printf("g2s1048 %d %d %d %d %.2e %.2e \n",gx,gy,gz,gid,s_data[z][y][x],data[gid]);
+         }*/
+     }
+     //if(TIX==0){
+    //     printf("%d %d Done\n",BIX,BIY);
+    // }
+     __syncthreads();
+ }
+ 
+ 
+ template <
+     typename T,
+     typename FP,
+     typename LAMBDAX,
+     typename LAMBDAY,
+     typename LAMBDAZ,
+     bool BLUE,
+     bool YELLOW,
+     bool HOLLOW,
+     int  LINEAR_BLOCK_SIZE,
+     int  BLOCK_DIMX,
+     int  BLOCK_DIMY,
+     bool COARSEN,
+     int  BLOCK_DIMZ,
+     bool BORDER_INCLUSIVE,
+     bool WORKFLOW
+     >
+ __forceinline__ __device__ void interpolate_stage_att(
+     volatile T s_data[17][17][17],
+     DIM3    data_size,
+      DIM3    global_starts,
+     LAMBDAX     xmap,
+     LAMBDAY     ymap,
+     LAMBDAZ     zmap,
+     int         unit,
+     FP eb_r,
+     FP ebx2,
+     bool interpolator,
+     volatile T* error)
+ {
+     static_assert(BLOCK_DIMX * BLOCK_DIMY * (COARSEN ? 1 : BLOCK_DIMZ) <= 384, "block oversized");
+     static_assert((BLUE or YELLOW or HOLLOW) == true, "must be one hot");
+     static_assert((BLUE and YELLOW) == false, "must be only one hot (1)");
+     static_assert((BLUE and YELLOW) == false, "must be only one hot (2)");
+     static_assert((YELLOW and HOLLOW) == false, "must be only one hot (3)");
+     //DIM3 global_starts (global_starts_v.x,global_starts_v.y, global_starts_v.z);
+     auto run = [&](auto x, auto y, auto z) {
+ 
+         
+ 
+         if (xyz17x17x17_predicate_att<BORDER_INCLUSIVE>(x, y, z,data_size, global_starts)) {
+             T pred = 0;
+ 
+             //if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and (CONSTEXPR (YELLOW)) )
+             //    printf("%d %d %d\n",x,y,z);
+             /*
+              if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==4)
+                         printf("444 %.2e %.2e \n",s_data[z - unit][y][x],s_data[z + unit][y][x]);
+ 
+             if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==0)
+                         printf("440 %.2e %.2e \n",s_data[z][y - unit][x],s_data[z][y + unit][x]);
+             if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==8 and z==0)
+                         printf("480 %.2e %.2e \n",s_data[z][y ][x- unit],s_data[z][y ][x+ unit]);*/
+                   //  }
+             auto global_x=global_starts.x+x, global_y=global_starts.y+y, global_z=global_starts.z+z;
+             /*
+             int interpolation_coeff_set1[2]={-1,-3};
+             int interpolation_coeff_set2[2]={9,23};
+             int interpolation_coeff_set3[2]={16,40};
+             auto a=interpolation_coeff_set1[interpolator];
+             auto b=interpolation_coeff_set2[interpolator];
+             auto c=interpolation_coeff_set3[interpolator];
+             */
+             if(interpolator==0){
+                 if CONSTEXPR (BLUE) {  //
+ 
+                     if(global_starts.z+BLOCK16<data_size.z){
+ 
+                         if(z>=3*unit and z+3*unit<=BLOCK16  )
+                             pred = (-s_data[z - 3*unit][y][x]+9*s_data[z - unit][y][x] + 9*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 16;
+                         else if (z+3*unit<=BLOCK16)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                         else if (z>=3*unit)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                         else
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(z>=3*unit){
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = (-s_data[z - 3*unit][y][x]+9*s_data[z - unit][y][x] + 9*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 16;
+                             else if (global_z+unit<data_size.z)
+                                 pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+                             else
+                                 pred=s_data[z - unit][y][x];
+ 
+                         }
+                         else{
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                             else if (global_z+unit<data_size.z)
+                                 pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                             else
+                                 pred=s_data[z - unit][y][x];
+                         } 
+                     }
+                 }
+                 if CONSTEXPR (YELLOW) {  //
+                    // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and y==7 and z==0){
+                    //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
+                   //  }
+                     if(global_starts.y+BLOCK16<data_size.y){
+                         if(y>=3*unit and y+3*unit<=BLOCK16 )
+                             pred = (-s_data[z ][y- 3*unit][x]+9*s_data[z ][y- unit][x] + 9*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 16;
+                         else if (y+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (y>=3*unit)
+                             pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                     }
+                     else{
+                         if(y>=3*unit){
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = (-s_data[z ][y- 3*unit][x]+9*s_data[z][y - unit][x] + 9*s_data[z ][y+ unit][x]-s_data[z ][y+ 3*unit][x]) / 16;
+                             else if (global_y+unit<data_size.y)
+                                 pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 8;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+ 
+                         }
+                         else{
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                             else if (global_y+unit<data_size.y)
+                                 pred = (s_data[z ][y- unit][x] + s_data[z][y + unit][x]) / 2;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+                         } 
+                     }
+                 }
+ 
+                 if CONSTEXPR (HOLLOW) {  //
+                     //if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1)
+                     //    printf("%d %d %d\n",x,y,z);
+                     if(global_starts.x+BLOCK16<data_size.x){
+                         if(x>=3*unit and x+3*unit<=BLOCK16 )
+                             pred = (-s_data[z ][y][x- 3*unit]+9*s_data[z ][y][x- unit] + 9*s_data[z ][y][x+ unit]-s_data[z ][y][x + 3*unit]) / 16;
+                         else if (x+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y][x- unit] + 6*s_data[z ][y][x + unit]-s_data[z][y][x + 3*unit]) / 8;
+                         else if (x>=3*unit)
+                             pred = (-s_data[z][y][x - 3*unit]+6*s_data[z][y][x - unit] + 3*s_data[z ][y][x + unit]) / 8;
+                         else
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                     }
+                     else{
+                         if(x>=3*unit){
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = (-s_data[z ][y][x- 3*unit]+9*s_data[z][y ][x- unit] + 9*s_data[z ][y][x+ unit]-s_data[z ][y][x+ 3*unit]) / 16;
+                             else if (global_x+unit<data_size.x)
+                                 pred = (-s_data[z ][y][x- 3*unit]+6*s_data[z ][y][x- unit] + 3*s_data[z ][y][x+ unit]) / 8;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+ 
+                         }
+                         else{
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = (3*s_data[z][y ][x- unit] + 6*s_data[z ][y][x+ unit]-s_data[z][y ][x+ 3*unit]) / 8;
+                             else if (global_x+unit<data_size.x)
+                                 pred = (s_data[z ][y][x- unit] + s_data[z][y ][x+ unit]) / 2;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+                         } 
+                     }
+                 }
+ 
+             }
+             else{
+                 if CONSTEXPR (BLUE) {  //
+ 
+                     if(global_starts.z+BLOCK16<data_size.z){
+ 
+                         if(z>=3*unit and z+3*unit<=BLOCK16  )
+                             pred = (-3*s_data[z - 3*unit][y][x]+23*s_data[z - unit][y][x] + 23*s_data[z + unit][y][x]-3*s_data[z + 3*unit][y][x]) / 40;
+                         else if (z+3*unit<=BLOCK16)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                         else if (z>=3*unit)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                         else
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(z>=3*unit){
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = (-3*s_data[z - 3*unit][y][x]+23*s_data[z - unit][y][x] + 23*s_data[z + unit][y][x]-3*s_data[z + 3*unit][y][x]) / 40;
+                             else if (global_z+unit<data_size.z)
+                                 pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+                             else
+                                 pred=s_data[z - unit][y][x];
+ 
+                         }
+                         else{
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                             else if (global_z+unit<data_size.z)
+                                 pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                             else
+                                 pred=s_data[z - unit][y][x];
+                         } 
+                     }
+                 }
+                 if CONSTEXPR (YELLOW) {  //
+                    // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and y==7 and z==0){
+                    //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
+                   //  }
+                     if(global_starts.y+BLOCK16<data_size.y){
+                         if(y>=3*unit and y+3*unit<=BLOCK16 )
+                             pred = (-3*s_data[z ][y- 3*unit][x]+23*s_data[z ][y- unit][x] + 23*s_data[z ][y+ unit][x]-3*s_data[z][y + 3*unit][x]) / 40;
+                         else if (y+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (y>=3*unit)
+                             pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                     }
+                     else{
+                         if(y>=3*unit){
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = (-3*s_data[z ][y- 3*unit][x]+23*s_data[z][y - unit][x] + 23*s_data[z ][y+ unit][x]-3*s_data[z ][y+ 3*unit][x]) / 40;
+                             else if (global_y+unit<data_size.y)
+                                 pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 8;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+ 
+                         }
+                         else{
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                             else if (global_y+unit<data_size.y)
+                                 pred = (s_data[z ][y- unit][x] + s_data[z][y + unit][x]) / 2;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+                         } 
+                     }
+                 }
+ 
+                 if CONSTEXPR (HOLLOW) {  //
+                     //if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1)
+                     //    printf("%d %d %d\n",x,y,z);
+                     if(global_starts.x+BLOCK16<data_size.x){
+                         if(x>=3*unit and x+3*unit<=BLOCK16 )
+                             pred = (-3*s_data[z ][y][x- 3*unit]+23*s_data[z ][y][x- unit] + 23*s_data[z ][y][x+ unit]-3*s_data[z ][y][x + 3*unit]) / 40;
+                         else if (x+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y][x- unit] + 6*s_data[z ][y][x + unit]-s_data[z][y][x + 3*unit]) / 8;
+                         else if (x>=3*unit)
+                             pred = (-s_data[z][y][x - 3*unit]+6*s_data[z][y][x - unit] + 3*s_data[z ][y][x + unit]) / 8;
+                         else
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                     }
+                     else{
+                         if(x>=3*unit){
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = (-3*s_data[z ][y][x- 3*unit]+23*s_data[z][y ][x- unit] + 23*s_data[z ][y][x+ unit]-3*s_data[z ][y][x+ 3*unit]) / 40;
+                             else if (global_x+unit<data_size.x)
+                                 pred = (-s_data[z ][y][x- 3*unit]+6*s_data[z ][y][x- unit] + 3*s_data[z ][y][x+ unit]) / 8;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+ 
+                         }
+                         else{
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = (3*s_data[z][y ][x- unit] + 6*s_data[z ][y][x+ unit]-s_data[z][y ][x+ 3*unit]) / 8;
+                             else if (global_x+unit<data_size.x)
+                                 pred = (s_data[z ][y][x- unit] + s_data[z][y ][x+ unit]) / 2;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+                         } 
+                     }
+                 }
+             }
+ 
+              if CONSTEXPR (WORKFLOW == SPLINE3_AB_ATT) {
+                 
+                 auto          err = s_data[z][y][x] - pred;
+                 decltype(err) code;
+                 // TODO unsafe, did not deal with the out-of-cap case
+                 {
+                     code = fabs(err) * eb_r + 1;
+                     code = err < 0 ? -code : code;
+                     code = int(code / 2) ;
+                 }
+                 //s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
+                 /*
+                  if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==0 and y==0 and z==4)
+                         printf("004pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[0][0][0],s_data[0][0][8],s_data[0][0][16]);
+                     if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==8 and y==8 and z==4)
+                         printf("884pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[8][8][0],s_data[8][8][8],s_data[8][8][16]);
+                   */      
+                // if(fabs(pred)>=3)
+                //     printf("%d %d %d %d %d %d %d %d %d %d %.2e %.2e %.2e\n",unit,CONSTEXPR (BLUE),CONSTEXPR (YELLOW),CONSTEXPR (HOLLOW),BIX,BIY,BIZ,x,y,z,pred,code,s_data[z][y][x]);
+               
+                 s_data[z][y][x]  = pred + code * ebx2;
+                 atomicAdd(const_cast<T*>(error),code!=0);
+                 
+ 
+             }
+ 
+ 
+             else{
+                 atomicAdd(const_cast<T*>(error),fabs(s_data[z][y][x]-pred));
+                 /*
+                 auto          err = s_data[z][y][x] - pred;
+                 atomicAdd(const_cast<T*>(error),fabs(err));
+                 auto delta = ebx2 * int((fabs(err) * eb_r + 1) / 2) - err;
+                 s_data[z][y][x] += delta;
+                 */
+             }
+            // if(BIX ==30 and BIY>=0 and BIY < 3 and x == 8 and y ==8 and z ==8){
+            //     printf("888 %d %.4e %.4e\n",BIY,s_data[z][y][x],pred);
+            // }
+             //atomicAdd(const_cast<T*>(error),1.0);
+         }
+     };
+     // -------------------------------------------------------------------------------- //
+ 
+     if CONSTEXPR (COARSEN) {
+         constexpr auto TOTAL = BLOCK_DIMX * BLOCK_DIMY * BLOCK_DIMZ;
+         //if( BLOCK_DIMX *BLOCK_DIMY<= LINEAR_BLOCK_SIZE){
+             for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                 auto itix = (_tix % BLOCK_DIMX);
+                 auto itiy = (_tix / BLOCK_DIMX) % BLOCK_DIMY;
+                 auto itiz = (_tix / BLOCK_DIMX) / BLOCK_DIMY;
+                 auto x    = xmap(itix, unit);
+                 auto y    = ymap(itiy, unit);
+                 auto z    = zmap(itiz, unit);
+                 
+                 run(x, y, z);
+             }
+         //}
+         //may have bug    
+         /*
+         else{
+             for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                 auto itix = (_tix % BLOCK_DIMX);
+                 auto itiz = (_tix / BLOCK_DIMX) % BLOCK_DIMZ;
+                 auto itiy = (_tix / BLOCK_DIMX) / BLOCK_DIMZ;
+                 auto x    = xmap(itix, unit);
+                 auto y    = ymap(itiy, unit);
+                 auto z    = zmap(itiz, unit);
+                 run(x, y, z);
+             }
+         }*/
+         //may have bug  end
+         
+     }
+     else {
+         auto itix = (TIX % BLOCK_DIMX);
+         auto itiy = (TIX / BLOCK_DIMX) % BLOCK_DIMY;
+         auto itiz = (TIX / BLOCK_DIMX) / BLOCK_DIMY;
+         auto x    = xmap(itix, unit);
+         auto y    = ymap(itiy, unit);
+         auto z    = zmap(itiz, unit);
+ 
+         
+ 
+      //   printf("%d %d %d\n", x,y,z);
+         run(x, y, z);
+     }
+     __syncthreads();
+ }
+ 
+ template <
+     typename T,
+     typename FP,
+     //typename LAMBDAX,
+     //typename LAMBDAY,
+     //typename LAMBDAZ,
+     typename LAMBDA,
+     bool LINE,
+     bool FACE,
+     bool CUBE,
+     int  LINEAR_BLOCK_SIZE,
+     int NUM_ELE,
+     //int  BLOCK_DIMX,
+     //int  BLOCK_DIMY,
+     bool COARSEN,
+     //int  BLOCK_DIMZ,
+     bool BORDER_INCLUSIVE,
+     bool WORKFLOW,
+     typename INTERP>
+ __forceinline__ __device__ void interpolate_stage_md_att(
+     volatile T s_data[17][17][17],
+     DIM3    data_size,
+     DIM3    global_starts,
+     //LAMBDAX     xmap,
+     //LAMBDAY     ymap,
+     //LAMBDAZ     zmap,
+     LAMBDA xyzmap,
+     int         unit,
+     FP eb_r,
+     FP ebx2,
+     INTERP cubic_interpolator,
+     volatile T* error)
+ {
+     static_assert(COARSEN or (NUM_ELE <= 384), "block oversized");
+     static_assert((LINE or FACE or CUBE) == true, "must be one hot");
+     static_assert((LINE and FACE) == false, "must be only one hot (1)");
+     static_assert((LINE and CUBE) == false, "must be only one hot (2)");
+     static_assert((FACE and CUBE) == false, "must be only one hot (3)");
+     //DIM3 global_starts (global_starts_v.x,global_starts_v.y, global_starts_v.z);
+     auto run = [&](auto x, auto y, auto z) {
+ 
+         
+ 
+         if (xyz17x17x17_predicate_att<BORDER_INCLUSIVE>(x, y, z,data_size, global_starts)) {
+             T pred = 0;
+ 
+             //if(BIX == 23 and BIY == 23 and BIZ == 15 and unit==2)
+             //    printf("%d %d %d\n",x,y,z);
+             /*
+              if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==4)
+                         printf("444 %.2e %.2e \n",s_data[z - unit][y][x],s_data[z + unit][y][x]);
+ 
+             if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==4 and z==0)
+                         printf("440 %.2e %.2e \n",s_data[z][y - unit][x],s_data[z][y + unit][x]);
+             if(BIX == 7 and BIY == 47 and BIZ == 15 and unit==4 and x==4 and y==8 and z==0)
+                         printf("480 %.2e %.2e \n",s_data[z][y ][x- unit],s_data[z][y ][x+ unit]);*/
+                   //  }
+             auto global_x=global_starts.x+x, global_y=global_starts.y+y, global_z=global_starts.z+z;
+             /*
+             int interpolation_coeff_set1[2]={-1,-3};
+             int interpolation_coeff_set2[2]={9,23};
+             int interpolation_coeff_set3[2]={16,40};
+             auto a=interpolation_coeff_set1[interpolator];
+             auto b=interpolation_coeff_set2[interpolator];
+             auto c=interpolation_coeff_set3[interpolator];
+             */
+            
+             if CONSTEXPR (LINE) {  //
+                 //bool I_X = x&1; 
+                 bool I_Y = (y % (2*unit) )> 0; 
+                 bool I_Z = (z % (2*unit) )> 0; 
+                 if (I_Z){
+                     //assert(x&1==0 and y&1==0);
+ 
+                     if(global_starts.z+BLOCK16 < data_size.z){
+ 
+                         if(z>=3*unit and z+3*unit<=BLOCK16  )
+                             pred = cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x],s_data[z + unit][y][x],s_data[z + 3*unit][y][x]);
+                         else if (z+3*unit<=BLOCK16)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                         else if (z>=3*unit)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                         else
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(z>=3*unit){
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x] ,s_data[z + unit][y][x],s_data[z + 3*unit][y][x]);
+                             else if (global_z+unit<data_size.z)
+                                 pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+                             else
+                                 pred=s_data[z - unit][y][x];
+ 
+                         }
+                         else{
+                             if(z+3*unit<=BLOCK16 and global_z+3*unit<data_size.z)
+                                 pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+                             else if (global_z+unit<data_size.z)
+                                 pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                             else
+                                 pred=s_data[z - unit][y][x];
+                         } 
+                     }
+ 
+                 }
+                 else if (I_Y){
+                     //assert(x&1==0 and z&1==0);
+                     if(global_starts.y+BLOCK16 < data_size.y){
+                         if(y>=3*unit and y+3*unit<=BLOCK16 )
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]) ;
+                         else if (y+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (y>=3*unit)
+                             pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                     }
+                     else{
+                         if(y>=3*unit){
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z][y - unit][x],s_data[z ][y+ unit][x],s_data[z ][y+ 3*unit][x]);
+                             else if (global_y+unit<data_size.y)
+                                 pred = (-s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 8;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+ 
+                         }
+                         else{
+                             if(y+3*unit<=BLOCK16 and global_y+3*unit<data_size.y)
+                                 pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                             else if (global_y+unit<data_size.y)
+                                 pred = (s_data[z ][y- unit][x] + s_data[z][y + unit][x]) / 2;
+                             else
+                                 pred=s_data[z ][y- unit][x];
+                         } 
+                     }
+                 }
+                 else{//I_X
+                     //assert(y&1==0 and z&1==0);
+                     if(global_starts.x+BLOCK16 < data_size.x){
+                         if(x>=3*unit and x+3*unit<=BLOCK16 )
+                             pred = cubic_interpolator(s_data[z ][y][x- 3*unit],s_data[z ][y][x- unit],s_data[z ][y][x+ unit],s_data[z ][y][x + 3*unit]);
+                         else if (x+3*unit<=BLOCK16)
+                             pred = (3*s_data[z ][y][x- unit] + 6*s_data[z ][y][x + unit]-s_data[z][y][x + 3*unit]) / 8;
+                         else if (x>=3*unit)
+                             pred = (-s_data[z][y][x - 3*unit]+6*s_data[z][y][x - unit] + 3*s_data[z ][y][x + unit]) / 8;
+                         else
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                     }
+                     else{
+                         if(x>=3*unit){
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = cubic_interpolator(s_data[z ][y][x- 3*unit],s_data[z][y ][x- unit],s_data[z ][y][x+ unit],s_data[z ][y][x+ 3*unit]);
+                             else if (global_x+unit<data_size.x)
+                                 pred = (-s_data[z ][y][x- 3*unit]+6*s_data[z ][y][x- unit] + 3*s_data[z ][y][x+ unit]) / 8;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+ 
+                         }
+                         else{
+                             if(x+3*unit<=BLOCK16 and global_x+3*unit<data_size.x)
+                                 pred = (3*s_data[z][y ][x- unit] + 6*s_data[z ][y][x+ unit]-s_data[z][y ][x+ 3*unit]) / 8;
+                             else if (global_x+unit<data_size.x)
+                                 pred = (s_data[z ][y][x- unit] + s_data[z][y ][x+ unit]) / 2;
+                             else
+                                 pred=s_data[z ][y][x- unit];
+                         } 
+                     }
+ 
+                 }
+             }
+             auto get_interp_order = [&](auto x, auto gx, auto gs){
+                 int b = x >= 3*unit ? 3 : 1;
+                 int f = 0;
+                 if(x+3*unit<=BLOCK16 and gx+3*unit < gs )
+                     f = 3;
+                 else if (gx+unit < gs)
+                     f = 1;
+                 if (b==3){
+                     if(f==3)
+                         return 4;
+                     else if (f==1)
+                         return 3;
+                     else
+                         return 0;
+                 }
+                 else{//b==1
+                     if(f==3)
+                         return 2;
+                     else if (f==1)
+                         return 1;
+                     else
+                         return 0;
+                 }
+             };
+             if CONSTEXPR (FACE) {  //
+                // if(BIX == 5 and BIY == 22 and BIZ == 6 and unit==1 and x==29 and y==7 and z==0){
+                //     printf("%.2e %.2e %.2e %.2e\n",s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x],s_data[z ][y+ unit][x]);
+               //  }
+ 
+                 bool I_YZ = (x % (2*unit) ) == 0;
+                 bool I_XZ = (y % (2*unit ) )== 0;
+ 
+                 //if(BIX == 10 and BIY == 12 and BIZ == 0 and x==13 and y==6 and z==9)
+                //     printf("face %d %d\n", I_YZ,I_XZ);
+ 
+                  
+                 if (I_YZ){
+ 
+ 
+                     auto interp_z = get_interp_order(z,global_z,data_size.z);
+                     auto interp_y = get_interp_order(y,global_y,data_size.y);
+ 
+                     if(interp_z==4){
+                         if(interp_y==4){
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x],s_data[z + unit][y][x],s_data[z + 3*unit][y][x])+
+                                     cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]) ) / 2;
+                         }
+                         else
+                             pred = cubic_interpolator(s_data[z - 3*unit][y][x],s_data[z - unit][y][x],s_data[z + unit][y][x],s_data[z + 3*unit][y][x]);
+ 
+                     }
+                     else if (interp_z == 3){
+                         if(interp_y==4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x] - s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 16;
+                         else if (interp_y == 2)
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x] + 3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 16;
+                         else
+                             pred = (-s_data[z - 3*unit][y][x]+6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                     }
+ 
+                     else if (interp_z == 2){
+                         if(interp_y==4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x] - s_data[z ][y- 3*unit][x]+6*s_data[z ][y- unit][x] + 3*s_data[z ][y+ unit][x]) / 16;
+                         else if (interp_y == 2)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x] + 3*s_data[z ][y - unit][x] + 6*s_data[z][y + unit][x]-s_data[z][y + 3*unit][x]) / 16;
+                         else
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x]-s_data[z + 3*unit][y][x]) / 8;
+ 
+                     }
+                     else if (interp_z == 1){
+                         if(interp_y == 4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (-s_data[z ][y- 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else if (interp_y == 2)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (interp_y == 1)
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x] + s_data[z ][y - unit][x] + s_data[z][y + unit][x]) / 4;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(interp_y == 4)
+                             pred = cubic_interpolator(s_data[z ][y- 3*unit][x],s_data[z ][y- unit][x] ,s_data[z ][y+ unit][x],s_data[z][y + 3*unit][x]);
+                         else if (interp_y == 3)
+                             pred = (-s_data[z ][y- 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                         else if (interp_y == 2)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z ][y+ unit][x]-s_data[z][y + 3*unit][x]) / 8;
+                         else if (interp_y == 1)
+                             pred = (s_data[z ][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z ][y - unit][x] - s_data[z - unit][y - unit][x]);
+ 
+                     }
+ 
+                 }
+                 else if (I_XZ){
+                     auto interp_z = get_interp_order(z,global_z,data_size.z);
+                     auto interp_x = get_interp_order(x,global_x,data_size.x);
+ 
+                     //if(BIX == 10 and BIY == 12 and BIZ == 0 and x==13 and y==6 and z==9)
+                     //printf("ixz %d %d\n", interp_x,interp_z);
+ 
+                     if(interp_z==4){
+                         if(interp_x==4){
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z + 3*unit][y][x]) +
+                                     cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                          s_data[z][y][x - unit],
+                                                          s_data[z][y][x + unit],
+                                                          s_data[z][y][x + 3*unit])
+                                    ) / 2;
+                         }
+                         else
+                             pred = cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                       s_data[z - unit][y][x],
+                                                       s_data[z + unit][y][x],
+                                                       s_data[z + 3*unit][y][x]);
+ 
+                     }
+                     else if (interp_z == 3){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z - 3*unit][y][x] + 6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (-s_data[z - 3*unit][y][x] + 6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (-s_data[z - 3*unit][y][x] + 6*s_data[z - unit][y][x] + 3*s_data[z + unit][y][x]) / 8;
+ 
+                     }
+                     else if (interp_z == 2){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x] - s_data[z + 3*unit][y][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x] - s_data[z + 3*unit][y][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (3*s_data[z - unit][y][x] + 6*s_data[z + unit][y][x] - s_data[z + 3*unit][y][x]) / 8;
+ 
+                     }
+                     else if (interp_z == 1){
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]
+                                     + s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 4;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z + unit][y][x]) / 2;
+                     }
+                     else{
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                         else 
+                             pred = (s_data[z - unit][y][x] + s_data[z][y][x - unit] - s_data[z - unit][y][x - unit]);
+                     }
+ 
+                 }
+                 else{//I_XY
+                     //assert(z&1==0);
+ 
+                     auto interp_y = get_interp_order(y,global_y,data_size.y);
+                     auto interp_x = get_interp_order(x,global_x,data_size.x);
+ 
+                     if(interp_y==4){
+                         if(interp_x==4){
+                             pred = (cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y + 3*unit][x]) +
+                                     cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                          s_data[z][y][x - unit],
+                                                          s_data[z][y][x + unit],
+                                                          s_data[z][y][x + 3*unit])
+                                    ) / 2;
+                         }
+                         else
+                             pred = cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                       s_data[z][y - unit][x],
+                                                       s_data[z][y + unit][x],
+                                                       s_data[z][y + 3*unit][x]);
+                     }
+                     else if (interp_y == 3){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y - 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (-s_data[z][y - 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (-s_data[z][y - 3*unit][x] + 6*s_data[z][y - unit][x] + 3*s_data[z][y + unit][x]) / 8;
+                     }
+                     else if (interp_y == 2){
+                         if(interp_x==4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z][y + unit][x] - s_data[z][y + 3*unit][x]
+                                     - s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 16;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z][y + unit][x] - s_data[z][y + 3*unit][x]
+                                     + 3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 16;
+                         else
+                             pred = (3*s_data[z][y - unit][x] + 6*s_data[z][y + unit][x] - s_data[z][y + 3*unit][x]) / 8;
+                     }
+                     else if (interp_y == 1){
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]
+                                     + s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 4;
+                         else 
+                             pred = (s_data[z][y - unit][x] + s_data[z][y + unit][x]) / 2;
+                     }
+                     else{
+                         if(interp_x == 4)
+                             pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                       s_data[z][y][x - unit],
+                                                       s_data[z][y][x + unit],
+                                                       s_data[z][y][x + 3*unit]);
+                         else if (interp_x == 3)
+                             pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                         else if (interp_x == 2)
+                             pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                         else if (interp_x == 1)
+                             pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                         else 
+                             pred = (s_data[z][y - unit][x] + s_data[z][y][x - unit] - s_data[z][y - unit][x - unit]);
+                     }
+                 }
+             }
+ 
+             if CONSTEXPR (CUBE) {  //
+                 auto interp_z = get_interp_order(z,global_z,data_size.z);
+                 auto interp_y = get_interp_order(y,global_y,data_size.y);
+                 auto interp_x = get_interp_order(x,global_x,data_size.x);
+ 
+                 if(interp_z == 4){
+                     if(interp_y == 4){
+                         if(interp_x == 4){
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]) +
+                                     cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y + 3*unit][x]) +
+                                     cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                          s_data[z][y][x - unit],
+                                                          s_data[z][y][x + unit],
+                                                          s_data[z][y][x + 3*unit])
+                                     ) / 3;
+                         }
+                         else{
+                             pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]) +
+                                     cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y + 3*unit][x])
+                                     ) / 2;
+                         }
+                     }
+                     else if(interp_x == 4){
+                         pred = (cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]) +
+                                 cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                      s_data[z][y][x - unit],
+                                                      s_data[z][y][x + unit],
+                                                      s_data[z][y][x + 3*unit])
+                                 ) / 2;
+ 
+                     }
+                     else{
+                         pred = cubic_interpolator(s_data[z - 3*unit][y][x],
+                                                          s_data[z - unit][y][x],
+                                                          s_data[z + unit][y][x],
+                                                          s_data[z+ 3*unit][y][x]);
+                     }
+                 }
+ 
+                 else if(interp_y == 4){
+                     
+                     if(interp_x == 4){
+                         pred = (cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y+ 3*unit][x]) +
+                                 cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                      s_data[z][y][x - unit],
+                                                      s_data[z][y][x + unit],
+                                                      s_data[z][y][x + 3*unit])
+                                 ) / 2;
+ 
+                     }
+                     else{
+                         pred = cubic_interpolator(s_data[z][y - 3*unit][x],
+                                                          s_data[z][y - unit][x],
+                                                          s_data[z][y + unit][x],
+                                                          s_data[z][y+ 3*unit][x]);
+                     }
+                 }
+                 else{
+                     if(interp_x == 4)
+                         pred = cubic_interpolator(s_data[z][y][x - 3*unit],
+                                                   s_data[z][y][x - unit],
+                                                   s_data[z][y][x + unit],
+                                                   s_data[z][y][x + 3*unit]);
+                     else if (interp_x == 3)
+                         pred = (-s_data[z][y][x - 3*unit] + 6*s_data[z][y][x - unit] + 3*s_data[z][y][x + unit]) / 8;
+                     else if (interp_x == 2)
+                         pred = (3*s_data[z][y][x - unit] + 6*s_data[z][y][x + unit] - s_data[z][y][x + 3*unit]) / 8;
+                     else if (interp_x == 1)
+                         pred = (s_data[z][y][x - unit] + s_data[z][y][x + unit]) / 2;
+                     else 
+                         pred = s_data[z][y][x - unit];///to revise;
+ 
+ 
+                 }
+ 
+             }
+             if CONSTEXPR (WORKFLOW == SPLINE3_AB_ATT) {
+                 
+                 auto          err = s_data[z][y][x] - pred;
+                 decltype(err) code;
+                 // TODO unsafe, did not deal with the out-of-cap case
+                 {
+                     code = fabs(err) * eb_r + 1;
+                     code = err < 0 ? -code : code;
+                     code = int(code / 2) ;
+                 }
+                 //s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
+                 /*
+                  if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==0 and y==0 and z==4)
+                         printf("004pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[0][0][0],s_data[0][0][8],s_data[0][0][16]);
+                     if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==8 and y==8 and z==4)
+                         printf("884pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[8][8][0],s_data[8][8][8],s_data[8][8][16]);
+                   */      
+                // if(fabs(pred)>=3)
+                //     printf("%d %d %d %d %d %d %d %d %d %d %.2e %.2e %.2e\n",unit,CONSTEXPR (BLUE),CONSTEXPR (YELLOW),CONSTEXPR (HOLLOW),BIX,BIY,BIZ,x,y,z,pred,code,s_data[z][y][x]);
+               
+                 s_data[z][y][x]  = pred + code * ebx2;
+                 atomicAdd(const_cast<T*>(error),code!=0);
+                 
+ 
+             }
+ 
+ 
+             else{
+ 
+                 atomicAdd(const_cast<T*>(error),fabs(s_data[z][y][x]-pred));
+                 /*
+                 auto          err = s_data[z][y][x] - pred;
+                 atomicAdd(const_cast<T*>(error),fabs(err));
+                 auto delta = ebx2 * int((fabs(err) * eb_r + 1) / 2) - err;
+                 s_data[z][y][x] += delta;
+                 */
+                 //s_ectrl[z][y][x] = code;  // TODO double check if unsigned type works
+                 /*
+                  if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==0 and y==0 and z==4)
+                         printf("004pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[0][0][0],s_data[0][0][8],s_data[0][0][16]);
+                     if(BIX == 12 and BIY == 12 and BIZ == 8 and unit==4 and x==8 and y==8 and z==4)
+                         printf("884pred %.2e %.2e %.2e %.2e %.2e %.2e\n",pred,code,s_data[z][y][x],s_data[8][8][0],s_data[8][8][8],s_data[8][8][16]);
+                   */      
+                // if(fabs(pred)>=3)
+                //     printf("%d %d %d %d %d %d %d %d %d %d %.2e %.2e %.2e\n",unit,CONSTEXPR (BLUE),CONSTEXPR (YELLOW),CONSTEXPR (HOLLOW),BIX,BIY,BIZ,x,y,z,pred,code,s_data[z][y][x]);
+               
+                 
+             }
+            // if(BIX == 30 and BIY>=0 and BIY < 3 and x == 8 and y == 8 and z == 8){
+             //    printf("888 %d %.4e %.4e\n",BIY,s_data[z][y][x],pred);
+             //}
+             //atomicAdd(const_cast<T*>(error),1.0);
+         }
+     };
+     // -------------------------------------------------------------------------------- //
+ 
+     if CONSTEXPR (COARSEN) {
+         constexpr auto TOTAL = NUM_ELE;
+         //if( BLOCK_DIMX *BLOCK_DIMY<= LINEAR_BLOCK_SIZE){
+             for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                 auto [x,y,z]    = xyzmap(_tix, unit);
+                 run(x, y, z);
+             }
+         //}
+         //may have bug    
+         /*
+         else{
+             for (auto _tix = TIX; _tix < TOTAL; _tix += LINEAR_BLOCK_SIZE) {
+                 auto itix = (_tix % BLOCK_DIMX);
+                 auto itiz = (_tix / BLOCK_DIMX) % BLOCK_DIMZ;
+                 auto itiy = (_tix / BLOCK_DIMX) / BLOCK_DIMZ;
+                 auto x    = xmap(itix, unit);
+                 auto y    = ymap(itiy, unit);
+                 auto z    = zmap(itiz, unit);
+                 run(x, y, z);
+             }
+         }*/
+         //may have bug  end
+         
+     }
+     else {
+         if(TIX<NUM_ELE){
+             auto [x,y,z]    = xyzmap(TIX, unit);
+             
+ 
+          //   printf("%d %d %d\n", x,y,z);
+             run(x, y, z);
+         }
+     }
+     __syncthreads();
+ }
+ 
+ 
+ template <typename T, typename FP,int LINEAR_BLOCK_SIZE, bool WORKFLOW>
+ __device__ void cusz::device_api::spline3d_layout2_interpolate_att(
+     volatile T s_data[17][17][17],
+      DIM3    data_size,
+     DIM3 global_starts,FP eb_r, FP ebx2,uint8_t level,INTERPOLATION_PARAMS intp_param,volatile T *error)
+ {
+     auto xblue = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+     auto yblue = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+     auto zblue = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+ 
+     auto xblue_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+     auto yblue_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy ); };
+     auto zblue_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2 + 1); };
+ 
+     auto xyellow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2); };
+     auto yyellow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
+     auto zyellow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+ 
+     auto xyellow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix ); };
+     auto yyellow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2+1); };
+     auto zyellow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz * 2); };
+ 
+ 
+     auto xhollow = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
+     auto yhollow = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy); };
+     auto zhollow = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz); };
+ 
+     auto xhollow_reverse = [] __device__(int _tix, int unit) -> int { return unit * (_tix * 2 +1); };
+     auto yhollow_reverse = [] __device__(int _tiy, int unit) -> int { return unit * (_tiy * 2); };
+     auto zhollow_reverse = [] __device__(int _tiz, int unit) -> int { return unit * (_tiz *2); };
+ 
+     auto xyzmap_line_16b_1u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 8;
+         constexpr auto L = N*(N+1)*(N+1); 
+         constexpr auto Q = (N+1)*(N+1); 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / (N+1);
+         auto k = (m % Q) % (N+1);
+         if(group==0)
+             return std::make_tuple(2*i+1,2*j,2*k);
+         else if (group==1)
+             return std::make_tuple(2*k,2*i+1,2*j);
+         else
+             return std::make_tuple(2*j,2*k,2*i+1);
+ 
+     };
+ 
+     auto xyzmap_face_16b_1u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 8;
+         constexpr auto L = N*N*(N+1);
+         constexpr auto Q = N*N; 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / N;
+         auto k = (m % Q) % N;
+         if(group==0)
+             return std::make_tuple(2*i,2*j+1,2*k+1);
+         else if (group==1)
+             return std::make_tuple(2*k+1,2*i,2*j+1);
+         else
+             return std::make_tuple(2*j+1,2*k+1,2*i);
+ 
+     };
+ 
+      auto xyzmap_cube_16b_1u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 8;
+         constexpr auto Q = N * N; 
+         auto i = _tix / Q;
+         auto j = (_tix % Q) / N;
+         auto k = (_tix % Q) % N;
+         return std::make_tuple(2*i+1,2*j+1,2*k+1);
+ 
+     };
+ 
+     auto xyzmap_line_16b_2u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 4;
+         constexpr auto L = N*(N+1)*(N+1); 
+         constexpr auto Q = (N+1)*(N+1); 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / (N+1);
+         auto k = (m % Q) % (N+1);
+         if(group==0)
+             return std::make_tuple(4*i+2,4*j,4*k);
+         else if (group==1)
+             return std::make_tuple(4*k,4*i+2,4*j);
+         else
+             return std::make_tuple(4*j,4*k,4*i+2);
+ 
+     };
+ 
+     auto xyzmap_face_16b_2u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 4;
+         constexpr auto L = N*N*(N+1);
+         constexpr auto Q = N*N; 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / N;
+         auto k = (m % Q) % N;
+         if(group==0)
+             return std::make_tuple(4*i,4*j+2,4*k+2);
+         else if (group==1)
+             return std::make_tuple(4*k+2,4*i,4*j+2);
+         else
+             return std::make_tuple(4*j+2,4*k+2,4*i);
+ 
+     };
+ 
+      auto xyzmap_cube_16b_2u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 4;
+         constexpr auto Q = N * N; 
+         auto i = _tix / Q;
+         auto j = (_tix % Q) / N;
+         auto k = (_tix % Q) % N;
+         return std::make_tuple(4*i+2,4*j+2,4*k+2);
+ 
+     };
+ 
+     auto xyzmap_line_16b_4u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 2;
+         constexpr auto L = N*(N+1)*(N+1); 
+         constexpr auto Q = (N+1)*(N+1); 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / (N+1);
+         auto k = (m % Q) % (N+1);
+         if(group==0)
+             return std::make_tuple(8*i+4,8*j,8*k);
+         else if (group==1)
+             return std::make_tuple(8*k,8*i+4,8*j);
+         else
+             return std::make_tuple(8*j,8*k,8*i+4);
+ 
+     };
+ 
+     auto xyzmap_face_16b_4u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 2;
+         constexpr auto L = N*N*(N+1);
+         constexpr auto Q = N*N; 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / N;
+         auto k = (m % Q) % N;
+         if(group==0)
+             return std::make_tuple(8*i,8*j+4,8*k+4);
+         else if (group==1)
+             return std::make_tuple(8*k+4,8*i,8*j+4);
+         else
+             return std::make_tuple(8*j+4,8*k+4,8*i);
+ 
+     };
+ 
+      auto xyzmap_cube_16b_4u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 2;
+         constexpr auto Q = N * N; 
+         auto i = _tix / Q;
+         auto j = (_tix % Q) / N;
+         auto k = (_tix % Q) % N;
+         return std::make_tuple(8*i+4,8*j+4,8*k+4);
+ 
+     };
+ 
+     auto xyzmap_line_16b_8u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 1;
+         constexpr auto L = N*(N+1)*(N+1); 
+         constexpr auto Q = (N+1)*(N+1); 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / (N+1);
+         auto k = (m % Q) % (N+1);
+         if(group==0)
+             return std::make_tuple(16*i+8,16*j,16*k);
+         else if (group==1)
+             return std::make_tuple(16*k,16*i+8,16*j);
+         else
+             return std::make_tuple(16*j,16*k,16*i+8);
+ 
+     };
+ 
+     auto xyzmap_face_16b_8u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 1;
+         constexpr auto L = N*N*(N+1);
+         constexpr auto Q = N*N; 
+         auto group = _tix / L ;
+         auto m = _tix % L ;
+         auto i = m / Q;
+         auto j = (m % Q) / N;
+         auto k = (m % Q) % N;
+         if(group==0)
+             return std::make_tuple(16*i,16*j+8,16*k+8);
+         else if (group==1)
+             return std::make_tuple(16*k+8,16*i,16*j+8);
+         else
+             return std::make_tuple(16*j+8,16*k+8,16*i);
+ 
+     };
+ 
+      auto xyzmap_cube_16b_8u = [] __device__(int _tix, int unit) -> std::tuple<int,int,int> {
+         constexpr auto N = 1;
+         constexpr auto Q = N * N; 
+         auto i = _tix / Q;
+         auto j = (_tix % Q) / N;
+         auto k = (_tix % Q) % N;
+         return std::make_tuple(16*i+8,16*j+8,16*k+8);
+ 
+     };
+ 
+ 
+     auto nan_cubic_interp = [] __device__ (T a, T b, T c, T d) -> T{
+         return (-a+9*b+9*c-d) / 16;
+     };
+ 
+     auto nat_cubic_interp = [] __device__ (T a, T b, T c, T d) -> T{
+         return (-3*a+23*b+23*c-3*d) / 40;
+     };
+ 
+ 
+ 
+ 
+     constexpr auto COARSEN          = true;
+     constexpr auto NO_COARSEN       = false;
+     constexpr auto BORDER_INCLUSIVE = true;
+     constexpr auto BORDER_EXCLUSIVE = false;
+ 
+     
+ 
+ 
+ 
+     
+ 
+ 
+     int unit;
+ 
+     FP cur_ebx2=ebx2,cur_eb_r=eb_r;
+ 
+ 
+     auto calc_eb = [&](auto unit) {
+         cur_ebx2=ebx2,cur_eb_r=eb_r;
+         int temp=1;
+         while(temp<unit){
+             temp*=2;
+             cur_eb_r *= intp_param.alpha;
+             cur_ebx2 /= intp_param.alpha;
+ 
+         }
+         if(cur_ebx2 < ebx2 / intp_param.beta){
+             cur_ebx2 = ebx2 / intp_param.beta;
+             cur_eb_r = eb_r * intp_param.beta;
+ 
+         }
+     };
+ 
+ 
+     if(WORKFLOW==SPLINE3_AB_ATT or level==3){
+         unit = 8;
+         //int m = 2, n = 2, p = 2;//block8 nums;
+         if(WORKFLOW==SPLINE3_AB_ATT)
+             calc_eb(unit);
+         //set_orders(reverse[2]);
+         if(intp_param.use_md[3]){
+ 
+ 
+             if(intp_param.use_natural[3]==0){
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_line_16b_8u), //
+                     true, false, false, LINEAR_BLOCK_SIZE,12 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_line_16b_8u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_face_16b_8u), //
+                     false, true, false, LINEAR_BLOCK_SIZE,6 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                      s_data,data_size,global_starts, xyzmap_face_16b_8u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_cube_16b_8u), //
+                     false, false, true, LINEAR_BLOCK_SIZE,1 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_cube_16b_8u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+             }
+             else{
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_line_16b_8u), //
+                     true, false, false, LINEAR_BLOCK_SIZE,12 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_line_16b_8u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_face_16b_8u), //
+                     false, true, false, LINEAR_BLOCK_SIZE,6 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_face_16b_8u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_cube_16b_8u), //
+                     false, false, true, LINEAR_BLOCK_SIZE,1 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_cube_16b_8u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+                 
+ 
+             }
+ 
+         }
+         else{
+ 
+             if(intp_param.reverse[3]){
+                 interpolate_stage_att<
+                     T, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
+                     false, false, true, LINEAR_BLOCK_SIZE, 1, 2, NO_COARSEN, 2, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[3],error);
+ 
+                 interpolate_stage_att<
+                     T, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
+                     false, true, false, LINEAR_BLOCK_SIZE, 3, 1, NO_COARSEN, 2, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[3],error);
+                 interpolate_stage_att<
+                     T, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
+                     true, false, false, LINEAR_BLOCK_SIZE, 3, 3, NO_COARSEN, 1, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xblue_reverse, yblue_reverse, zblue_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[3],error);
+ 
+ 
+             }
+             else{
+                 //if( BIX==0 and BIY==0 and BIZ==0)
+                // printf("lv3s0\n");
+                 interpolate_stage_att<
+                     T, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+                     true, false, false, LINEAR_BLOCK_SIZE, 2, 2, NO_COARSEN, 1, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xblue, yblue, zblue, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[3],error);
+                // if(BIX==0 and BIY==0 and BIZ==0)
+                // printf("lv3s1\n");
+                 interpolate_stage_att<
+                     T, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
+                     false, true, false, LINEAR_BLOCK_SIZE, 2, 1, NO_COARSEN, 3, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyellow, yyellow, zyellow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[3],error);
+                 //if(BIX==0 and BIY==0 and BIZ==0)
+               //  printf("lv3s2\n");
+                 interpolate_stage_att<
+                     T, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
+                     false, false, true, LINEAR_BLOCK_SIZE, 1, 3, NO_COARSEN, 3, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xhollow, yhollow, zhollow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[3],error);
+             }
+         }
+     }
+ 
+     
+     if(WORKFLOW==SPLINE3_AB_ATT or level == 2){
+         unit = 4;
+         //int m = 2, n = 2, p = 2;//block8 nums;
+         if(WORKFLOW==SPLINE3_AB_ATT)
+             calc_eb(unit);
+         //set_orders(reverse[2]);
+ 
+ 
+         if(intp_param.use_md[2]){
+ 
+ 
+             if(intp_param.use_natural[2]==0){
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_line_16b_4u), //
+                     true, false, false, LINEAR_BLOCK_SIZE,54 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_line_16b_4u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_face_16b_4u), //
+                     false, true, false, LINEAR_BLOCK_SIZE,36 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_face_16b_4u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_cube_16b_4u), //
+                     false, false, true, LINEAR_BLOCK_SIZE,8 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_cube_16b_4u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+             }
+             else{
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_line_16b_4u), //
+                     true, false, false, LINEAR_BLOCK_SIZE,54 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_line_16b_4u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_face_16b_4u), //
+                     false, true, false, LINEAR_BLOCK_SIZE,36 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_face_16b_4u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_cube_16b_4u), //
+                     false, false, true, LINEAR_BLOCK_SIZE,8 ,NO_COARSEN, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_cube_16b_4u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+                 
+ 
+             }
+ 
+         }
+         else{
+             if(intp_param.reverse[2]){
+                 interpolate_stage_att<
+                     T, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
+                     false, false, true, LINEAR_BLOCK_SIZE, 2, 3, NO_COARSEN, 3, BORDER_INCLUSIVE,WORKFLOW>(
+                     s_data,data_size,global_starts, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[2],error);
+ 
+                 interpolate_stage_att<
+                     T, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
+                     false, true, false, LINEAR_BLOCK_SIZE, 5, 2, NO_COARSEN, 3, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[2],error);
+                 interpolate_stage_att<
+                     T, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
+                     true, false, false, LINEAR_BLOCK_SIZE, 5, 5, NO_COARSEN, 2, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts,  xblue_reverse, yblue_reverse, zblue_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[2],error);
+ 
+ 
+             }
+             else{
+                 //if( BIX==0 and BIY==0 and BIZ==0)
+                // printf("lv3s0\n");
+                 interpolate_stage_att<
+                     T, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+                     true, false, false, LINEAR_BLOCK_SIZE, 3, 3, NO_COARSEN, 2, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xblue, yblue, zblue, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[2],error);
+                // if(BIX==0 and BIY==0 and BIZ==0)
+                // printf("lv3s1\n");
+                 interpolate_stage_att<
+                     T, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
+                     false, true, false, LINEAR_BLOCK_SIZE, 3, 2, NO_COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyellow, yyellow, zyellow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[2],error);
+                 //if(BIX==0 and BIY==0 and BIZ==0)
+               //  printf("lv3s2\n");
+                 interpolate_stage_att<
+                     T, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
+                     false, false, true, LINEAR_BLOCK_SIZE, 2, 5, NO_COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xhollow, yhollow, zhollow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[2],error);
+             }
+         }
+     }
+    // if(BIX==0 and BIY==0 and BIZ==0)
+    // printf("lv3\n");
+      if(WORKFLOW==SPLINE3_AB_ATT or level == 1){
+         unit = 2;
+         //m*=2;
+         //n*=2;
+         //p*=2;
+         if(WORKFLOW==SPLINE3_AB_ATT)
+             calc_eb(unit);
+ 
+         //set_orders(reverse[1]);
+ 
+         // iteration 2, TODO switch y-z order
+        
+         if(intp_param.use_md[1]){
+ 
+ 
+             if(intp_param.use_natural[1]==0){
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_line_16b_2u), //
+                     true, false, false, LINEAR_BLOCK_SIZE,300 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_line_16b_2u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_face_16b_2u), //
+                     false, true, false, LINEAR_BLOCK_SIZE,240 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_face_16b_2u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_cube_16b_2u), //
+                     false, false, true, LINEAR_BLOCK_SIZE,64 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_cube_16b_2u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+             }
+             else{
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_line_16b_2u), //
+                     true, false, false, LINEAR_BLOCK_SIZE,300 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_line_16b_2u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_face_16b_2u), //
+                     false, true, false, LINEAR_BLOCK_SIZE,240 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_face_16b_2u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_cube_16b_2u), //
+                     false, false, true, LINEAR_BLOCK_SIZE,64 ,NO_COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_cube_16b_2u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+                 
+ 
+             }
+         }
+         else{
+              if(intp_param.reverse[1]){
+                 interpolate_stage_att<
+                     T, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
+                     false, false, true, LINEAR_BLOCK_SIZE, 4, 5, NO_COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[1],error);
+                 interpolate_stage_att<
+                     T, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
+                     false, true, false, LINEAR_BLOCK_SIZE, 9, 4, NO_COARSEN, 5, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[1],error);
+                 interpolate_stage_att<
+                     T, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
+                     true, false, false, LINEAR_BLOCK_SIZE, 9, 9, NO_COARSEN, 4, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xblue_reverse, yblue_reverse, zblue_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[1],error);
+             }
+             else{
+                 interpolate_stage_att<
+                     T, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+                     true, false, false, LINEAR_BLOCK_SIZE, 5, 5, NO_COARSEN, 4, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xblue, yblue, zblue, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[1],error);
+                 interpolate_stage_att<
+                     T, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
+                     false, true, false, LINEAR_BLOCK_SIZE, 5, 4, NO_COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyellow, yyellow, zyellow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[1],error);
+                 interpolate_stage_att<
+                     T, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
+                     false, false, true, LINEAR_BLOCK_SIZE, 4, 9, NO_COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xhollow, yhollow, zhollow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[1],error);
+ 
+             }
+ 
+         }
+     }
+ 
+ 
+     //if(TIX==0 and TIY==0 and TIZ==0 and BIX==0 and BIY==0 and BIZ==0)
+     //printf("lv2\n");
+     if(WORKFLOW==SPLINE3_AB_ATT or level ==0){
+         unit = 1;
+         //m*=2;
+         //n*=2;
+         //p*=2;
+        if(WORKFLOW==SPLINE3_AB_ATT)
+             calc_eb(unit);
+        // set_orders(reverse[0]);
+         if(intp_param.use_md[0]){
+             if(intp_param.use_natural[0]==0){
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_line_16b_1u), //
+                     true, false, false, LINEAR_BLOCK_SIZE,1944 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_line_16b_1u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_face_16b_1u), //
+                     false, true, false, LINEAR_BLOCK_SIZE,1728 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_face_16b_1u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_cube_16b_1u), //
+                     false, false, true, LINEAR_BLOCK_SIZE,512 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_cube_16b_1u, unit,cur_eb_r,cur_ebx2, nan_cubic_interp,error);
+ 
+             }
+             else{
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_line_16b_1u), //
+                     true, false, false, LINEAR_BLOCK_SIZE,1944 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_line_16b_1u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_face_16b_1u), //
+                     false, true, false, LINEAR_BLOCK_SIZE,1728 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_face_16b_1u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+ 
+                 interpolate_stage_md_att<
+                     T, FP, decltype(xyzmap_cube_16b_1u), //
+                     false, false, true, LINEAR_BLOCK_SIZE,512 ,COARSEN, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyzmap_cube_16b_1u, unit,cur_eb_r,cur_ebx2, nat_cubic_interp,error);
+                 
+ 
+             }
+         }
+         else{
+             if(intp_param.reverse[0]){
+                 //may have bug 
+                 interpolate_stage_att<
+                     T, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
+                     false, false, true, LINEAR_BLOCK_SIZE, 8, 9, COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[0],error);
+                 interpolate_stage_att<
+                     T, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
+                     false, true, false, LINEAR_BLOCK_SIZE, 17, 8, COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit,cur_eb_r,cur_ebx2,intp_param.use_natural[0],error);
+                 interpolate_stage_att<
+                     T, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
+                     true, false, false, LINEAR_BLOCK_SIZE, 17, 17, COARSEN, 8, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xblue_reverse, yblue_reverse, zblue_reverse, unit,cur_eb_r,cur_ebx2,intp_param.use_natural[0],error);
+ 
+                 //may have bug end
+             }
+             else{
+                 interpolate_stage_att<
+                     T, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+                     true, false, false, LINEAR_BLOCK_SIZE, 9, 9, COARSEN, 8, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xblue, yblue, zblue, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[0],error);
+                 interpolate_stage_att<
+                     T, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
+                     false, true, false, LINEAR_BLOCK_SIZE, 9, 8, COARSEN, 17, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xyellow, yyellow, zyellow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[0],error);
+                
+                 interpolate_stage_att<
+                     T, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
+                     false, false, true, LINEAR_BLOCK_SIZE, 8, 17, COARSEN, 17, BORDER_INCLUSIVE, WORKFLOW>(
+                     s_data,data_size,global_starts, xhollow, yhollow, zhollow, unit,cur_eb_r,cur_ebx2, intp_param.use_natural[0],error);
+ 
+             }
+         }
+     }
+     
+     // iteration 3
+     /*
+     if(intp_param.reverse[0]){
+         //may have bug 
+         interpolate_stage<
+             T1, T2, FP, decltype(xhollow_reverse), decltype(yhollow_reverse), decltype(zhollow_reverse),  //
+             false, false, true, LINEAR_BLOCK_SIZE, 8, 9, COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+             s_data, s_ectrl,data_size, xhollow_reverse, yhollow_reverse, zhollow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[0]);
+         interpolate_stage<
+             T1, T2, FP, decltype(xyellow_reverse), decltype(yyellow_reverse), decltype(zyellow_reverse),  //
+             false, true, false, LINEAR_BLOCK_SIZE, 17, 8, COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+             s_data, s_ectrl,data_size, xyellow_reverse, yyellow_reverse, zyellow_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[1]);
+         interpolate_stage<
+             T1, T2, FP, decltype(xblue_reverse), decltype(yblue_reverse), decltype(zblue_reverse),  //
+             true, false, false, LINEAR_BLOCK_SIZE, 17, 17, COARSEN, 8, BORDER_EXCLUSIVE, WORKFLOW>(
+             s_data, s_ectrl,data_size, xblue_reverse, yblue_reverse, zblue_reverse, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[2]);
+ 
+         //may have bug end
+     }
+     else{
+         interpolate_stage<
+             T1, T2, FP, decltype(xblue), decltype(yblue), decltype(zblue),  //
+             true, false, false, LINEAR_BLOCK_SIZE, 9, 9, COARSEN, 8, BORDER_INCLUSIVE, WORKFLOW>(
+             s_data, s_ectrl,data_size, xblue, yblue, zblue, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[0]);
+         interpolate_stage<
+             T1, T2, FP, decltype(xyellow), decltype(yyellow), decltype(zyellow),  //
+             false, true, false, LINEAR_BLOCK_SIZE, 9, 8, COARSEN, 17, BORDER_INCLUSIVE, WORKFLOW>(
+             s_data, s_ectrl,data_size, xyellow, yyellow, zyellow, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[1]);
+        
+         interpolate_stage<
+             T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
+             false, false, true, LINEAR_BLOCK_SIZE, 8, 17, COARSEN, 17, BORDER_EXCLUSIVE, WORKFLOW>(
+             s_data, s_ectrl,data_size, xhollow, yhollow, zhollow, unit, cur_eb_r, cur_ebx2, radius, intp_param.interpolators[2]);
+ 
+     }*/
+   //  if(TIX==0 and TIY==0 and TIZ==0 and BIX==0 and BIY==0 and BIZ==0)
+    // printf("lv1\n");
+     
+ 
+ 
+      /******************************************************************************
+      test only: last step inclusive
+      ******************************************************************************/
+     // interpolate_stage<
+     //     T1, T2, FP, decltype(xhollow), decltype(yhollow), decltype(zhollow),  //
+     //     false, false, true, LINEAR_BLOCK_SIZE, 33, 4, COARSEN, 9, BORDER_INCLUSIVE, WORKFLOW>(
+     //     s_data, s_ectrl, xhollow, yhollow, zhollow, unit, eb_r, ebx2, radius);
+     /******************************************************************************
+      production
+      ******************************************************************************/
+ 
+     /******************************************************************************
+      test only: print a block
+      ******************************************************************************/
+     // if (TIX == 0 and BIX == 7 and BIY == 47 and BIZ == 15) { spline3d_print_block_from_GPU(s_ectrl); }
+    //  if (TIX == 0 and BIX == 4 and BIY == 20 and BIZ == 20) { spline3d_print_block_from_GPU(s_data); }
+ }
+ 
+ 
+ template <typename TITER, typename FP, int LINEAR_BLOCK_SIZE>
+ __global__ void cusz::pa_spline3d_infprecis_16x16x16data(
+     TITER   data,
+     DIM3    data_size,
+     STRIDE3 data_leap,
+     DIM3 sample_starts,
+     DIM3 sample_block_grid_sizes,
+     DIM3 sample_strides,
+     FP eb_r,
+     FP eb_x2,
+     INTERPOLATION_PARAMS intp_param,
+     TITER errors,
+     bool workflow
+     )
+ {
+     // compile time variables
+     using T = typename std::remove_pointer<TITER>::type;
+ 
+     {
+         __shared__ struct {
+             T data[17][17][17];
+             //DIM3 grid_sizes[5];
+            // DIM3 global_starts;
+             //uint8_t level;
+             //bool use_natural;
+             //bool use_md;
+             //bool reverse;
+             T err[6];
+         } shmem;
+ 
+         /*
+        if(TIX==0 and BIX==0 and BIY==0 and BIZ==0){
+         printf("Errors: %.6f %.6f \n",errors[0],errors[1]);
+         printf("Cubic: %d %d %d\n",intp_param.interpolators[0],intp_param.interpolators[1],intp_param.interpolators[2]);
+         printf("reverse: %d %d %d\n",intp_param.reverse[0],intp_param.reverse[1],intp_param.reverse[2]);
+        }
+        */
+         //if(BIX==0 and TIX==0){
+         //    errors[BIY]=0;//dangerous
+         //}
+         //__syncthreads();
+         DIM3 global_starts;
+         uint8_t level = 0;
+         uint8_t unit = 1;
+         pre_compute_att<T>(sample_starts, sample_block_grid_sizes, sample_strides,global_starts,intp_param,level,unit,shmem.err,workflow);
+          //if(BIX==10 and BIY == 10 and TIX==0){
+          //   printf("%.4e\n",shmem.err);
+         //}
+         
+         global2shmem_17x17x17data_att<T, T,LINEAR_BLOCK_SIZE>(data, data_size, data_leap, shmem.data,global_starts,unit);
+          //if(BIX==30 and BIY >=12 and BIY < 15 and TIX==0){
+          //   printf("%d %.4e %d %d %d %d \n",BIY, shmem.err,shmem.level,shmem.use_natural,shmem.use_md,shmem.reverse);
+         //}
+         //if(TIX==0 and BIX==0 and BIY==0)
+          //   printf("gs\n");
+ 
+         //if(TIX==0 and BIX == 10){
+         //    printf("%d %d %d %d %d %d\n",GDX,BIY,level,intp_param.use_natural[level],intp_param.use_md[level],intp_param.reverse[level]);
+         //}
+         if(workflow){
+ 
+             if(level==2){
+                 uint8_t level3 = 3;
+                 intp_param.use_natural[3]=false;
+                 intp_param.use_natural[2]=false;
+                 
+ 
+ 
+                 intp_param.use_md[3]=false;
+                 intp_param.reverse[3]=false;
+                 cusz::device_api::spline3d_layout2_interpolate_att<T, FP,LINEAR_BLOCK_SIZE,SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err);
+                 intp_param.reverse[3]=true;
+                 cusz::device_api::spline3d_layout2_interpolate_att<T, FP,LINEAR_BLOCK_SIZE,SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err+1);
+                 intp_param.use_md[3]=true;
+                 cusz::device_api::spline3d_layout2_interpolate_att<T, FP,LINEAR_BLOCK_SIZE,SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level3,intp_param,shmem.err+2);
+ 
+ 
+                 intp_param.use_md[2]=false;
+                 intp_param.reverse[2]=false;
+                 cusz::device_api::spline3d_layout2_interpolate_att<T, FP,LINEAR_BLOCK_SIZE,SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+3);
+                 intp_param.reverse[2]=true;
+                 cusz::device_api::spline3d_layout2_interpolate_att<T, FP,LINEAR_BLOCK_SIZE,SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+4);
+                 intp_param.use_md[2]=true;
+                 cusz::device_api::spline3d_layout2_interpolate_att<T, FP,LINEAR_BLOCK_SIZE,SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+5);
+ 
+ 
+                 
+ 
+                 if(TIX<6){
+                     atomicAdd(const_cast<T*>(errors+TIX),shmem.err[TIX]);
+                 }
+             }
+             else if (level==1){
+                 intp_param.use_md[1]=false;
+                 intp_param.reverse[1]=false;
+                 cusz::device_api::spline3d_layout2_interpolate_att<T, FP,LINEAR_BLOCK_SIZE,SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+                 intp_param.reverse[1]=true;
+                 cusz::device_api::spline3d_layout2_interpolate_att<T, FP,LINEAR_BLOCK_SIZE,SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+1);
+                 intp_param.use_md[1]=true;
+                 cusz::device_api::spline3d_layout2_interpolate_att<T, FP,LINEAR_BLOCK_SIZE,SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err+2);
+ 
+                 if(TIX<3){
+                    atomicAdd(const_cast<T*>(errors+3+BIY*3+TIX),shmem.err[TIX]);
+                 }
+ 
+             }
+             else{
+                 cusz::device_api::spline3d_layout2_interpolate_att<T, FP,LINEAR_BLOCK_SIZE,SPLINE3_PRED_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+                 if(TIX==0){
+                     atomicAdd(const_cast<T*>(errors+9+BIY),shmem.err[0]);
+                 }
+             }
+ 
+             //if(TIX==0 and BIX == 10)
+              //   printf("%d %.4e %.4e %.4e %.4e %.4e %.4e\n",BIY,shmem.err[0],shmem.err[1],shmem.err[2],shmem.err[3],shmem.err[4],shmem.err[5]);
+             
+         }
+         else{
+             cusz::device_api::spline3d_layout2_interpolate_att<T, FP,LINEAR_BLOCK_SIZE,SPLINE3_AB_ATT>(shmem.data, data_size,global_starts,eb_r,eb_x2,level,intp_param,shmem.err);
+             if(TIX==0)
+                 atomicAdd(const_cast<T*>(errors+BIY),shmem.err[0]);
+         
+         }
+         
+         //Just a copy back here
+         //__syncthreads();
+         //if(BIX==10 and BIY == 10 and TIX==0){
+         //    printf("%.4e\n",shmem.err);
+         //}
+ 
+         //if(TIX==0 and BIX ==30 and BIY >=0 and BIY < 3){
+         //    printf("%d %.4e\n",BIY,shmem.err);
+         //}
+ 
+ 
+         //if(TIX<6){
+         //    atomicAdd(const_cast<T*>(errors+BIY),shmem.err[TIX]);//BIY 0-17
+         //}
+ 
+         
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("interp\n");
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+          //   printf("esz: %d %d %d\n",ectrl_size.x,ectrl_size.y,ectrl_size.z);
+ 
+ 
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+ 
+         ///shmem2global_17x17x17data_with_compaction<T, E, LINEAR_BLOCK_SIZE>(shmem.ectrl, ectrl, ectrl_size, ectrl_leap, radius, shmem.grid_leaps,shmem.prefix_nums, compact_val, compact_idx, compact_num);
+ 
+         // shmem2global_32x8x8data<T, E, LINEAR_BLOCK_SIZE>(shmem.ectrl, ectrl, ectrl_size, ectrl_leap);
+ 
+         //if(TIX==0 and BIX==0 and BIY==0 and BIZ==0)
+         //    printf("s2g\n");
+     }
+ }
+ 
+ 
+ 
+ #undef TIX
+ #undef TIY
+ #undef TIZ
+ #undef BIX
+ #undef BIY
+ #undef BIZ
+ #undef BDX
+ #undef BDY
+ #undef BDZ
+ #undef GDX
+ #undef GDY
+ #undef GDZ
+ 
+ #endif

--- a/src/kernel/l23r.cu
+++ b/src/kernel/l23r.cu
@@ -106,6 +106,8 @@ pszerror psz_comp_l23r(
       T* const data, dim3 const len3, f8 const eb, int const radius, \
       E* const eq, void* _outlier, f4* time_elapsed, void* stream);
 
+INIT(f4, u1, false)
+INIT(f4, u1, true)
 INIT(f4, u4, false)
 INIT(f4, u4, true)
 INIT(f8, u4, false)

--- a/src/kernel/spline.cu
+++ b/src/kernel/spline.cu
@@ -1,0 +1,194 @@
+/**
+ * @file spline.cu
+ * @author Jinyang Liu, Shixun Wu, Jiannan Tian
+ * @brief A high-level Spline2D wrapper. Allocations are explicitly out of
+ * called functions.
+ * @version 0.3
+ * @date 2021-06-15
+ *
+ * (copyright to be updated)
+ * (C) 2021 by Washington State University, Argonne National Laboratory
+ *
+ */
+
+ #include <cuda_runtime.h>
+
+ #include "busyheader.hh"
+ #include "cusz/type.h"
+ #include "detail/spline.inl"
+ #include "kernel/spline.hh"
+ #include "mem/compact.hh"
+ // #include "mem/memseg_cxx.hh"
+ // #include "mem/memseg.h"
+ // #include "mem/layout.h"
+ // #include "mem/layout_cxx.hh"
+ #define SPLINE_DIM 3
+ #define AnchorBlockSizeX 16
+ #define AnchorBlockSizeY 16
+ #define AnchorBlockSizeZ 16
+ #define numAnchorBlockX 1  // Number of Anchor blocks along X
+ #define numAnchorBlockY 1  // Number of Anchor blocks along Y
+ #define numAnchorBlockZ 1  // Number of Anchor blocks along Z
+ 
+ constexpr int DEFAULT_BLOCK_SIZE = 384;
+ 
+ #define SETUP                                                   \
+   auto div3 = [](dim3 len, dim3 sublen) {                       \
+     return dim3(                                                \
+         (len.x - 1) / sublen.x + 1, (len.y - 1) / sublen.y + 1, \
+         (len.z - 1) / sublen.z + 1);                            \
+   };                                                            \
+   auto ndim = [&]() {                                           \
+     if (len3.z == 1 and len3.y == 1)                            \
+       return 1;                                                 \
+     else if (len3.z == 1 and len3.y != 1)                       \
+       return 2;                                                 \
+     else                                                        \
+       return 3;                                                 \
+   };
+ 
+ template <typename T, typename E, typename FP>
+ int spline_construct(
+     pszmem_cxx<T>* data, pszmem_cxx<T>* anchor, pszmem_cxx<E>* ectrl,
+     void* _outlier, double eb, double rel_eb, uint32_t radius,
+     INTERPOLATION_PARAMS& intp_param, float* time, void* stream,
+     pszmem_cxx<T>* profiling_errors)
+ {
+   auto div = [](auto _l, auto _subl) { return (_l - 1) / _subl + 1; };
+ 
+   auto ebx2 = eb * 2;
+   auto eb_r = 1 / eb;
+ 
+   auto l3 = data->template len3<dim3>();
+   auto grid_dim = dim3(
+       div(l3.x, AnchorBlockSizeX * numAnchorBlockX),
+       div(l3.y, AnchorBlockSizeY * numAnchorBlockY),
+       div(l3.z, AnchorBlockSizeZ * numAnchorBlockZ));
+ 
+   auto auto_tuning_grid_dim = dim3(1, 1, 1);
+ 
+   using Compact = typename CompactDram<PROPER_GPU_BACKEND, T>::Compact;
+   auto ot = (Compact*)_outlier;
+ 
+   CREATE_GPUEVENT_PAIR;
+   START_GPUEVENT_RECORDING(stream);
+   // printf("l3 %d %d %d\n", l3.x, l3.y, l3.z);
+   // printf("grid_dim %d, %d, %d\n", grid_dim.x, grid_dim.y, grid_dim.z);
+   // assert(0);
+   if(intp_param.auto_tuning>0){
+    //std::cout<<"att "<<(int)intp_param.auto_tuning<<std::endl;
+    double a1=2.0 + 1;
+    double a2=1.75 + 1;
+    double a3=1.5 + 1;
+    double a4=1.25 + 1;
+    double a5=1 + 1;
+    double e1=1e-1;
+    double e2=1e-2;
+    double e3=1e-3;
+    double e4=1e-4;
+    double e5=1e-5;
+   
+    intp_param.beta=4.0;
+    if(rel_eb>=e1)
+     intp_param.alpha=a1;
+    else if(rel_eb>=e2)
+     intp_param.alpha=a2+(a1-a2)*(rel_eb-e2)/(e1-e2);
+    else if(rel_eb>=e3)
+     intp_param.alpha=a3+(a2-a3)*(rel_eb-e3)/(e2-e3);
+    else if(rel_eb>=e4)
+     intp_param.alpha=a4+(a3-a4)*(rel_eb-e4)/(e3-e4);
+    else if(rel_eb>=e5)
+     intp_param.alpha=a5+(a4-a5)*(rel_eb-e5)/(e4-e5);
+    else
+     intp_param.alpha=a5;
+   }
+ 
+   intp_param.reverse[0]=intp_param.reverse[1]=intp_param.reverse[2] = true;
+   intp_param.interpolators[0]=intp_param.interpolators[1]=intp_param.interpolators[2] = true;
+   cusz::c_spline_infprecis_data<
+       T*, E*, float, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+       numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, DEFAULT_BLOCK_SIZE>
+       <<<grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>(
+           data->dptr(), data->template len3<dim3>(),
+           data->template st3<dim3>(),  //
+           ectrl->dptr(), ectrl->template len3<dim3>(),
+           ectrl->template st3<dim3>(),  //
+           anchor->dptr(), anchor->template st3<dim3>(), ot->val(), ot->idx(),
+           ot->num(), eb_r, ebx2, radius,
+           intp_param);  //,profiling_errors->dptr());
+ 
+   STOP_GPUEVENT_RECORDING(stream);
+   CHECK_GPU(GpuStreamSync(stream));
+   TIME_ELAPSED_GPUEVENT(time);
+   DESTROY_GPUEVENT_PAIR;
+ 
+   return 0;
+ }
+ 
+ template <typename T, typename E, typename FP>
+ int spline_reconstruct(
+     pszmem_cxx<T>* anchor, pszmem_cxx<E>* ectrl, pszmem_cxx<T>* xdata, T* outlier_tmp,
+     double eb, uint32_t radius, INTERPOLATION_PARAMS intp_param, float* time,
+     void* stream)
+ {
+ 
+   auto div = [](auto _l, auto _subl) { return (_l - 1) / _subl + 1; };
+ 
+   auto ebx2 = eb * 2;
+   auto eb_r = 1 / eb;
+ 
+   auto l3 = xdata->template len3<dim3>();
+   auto grid_dim = dim3(
+       div(l3.x, AnchorBlockSizeX * numAnchorBlockX),
+       div(l3.y, AnchorBlockSizeY * numAnchorBlockY),
+       div(l3.z, AnchorBlockSizeZ * numAnchorBlockZ));
+ 
+   CREATE_GPUEVENT_PAIR;
+   START_GPUEVENT_RECORDING(stream);
+   printf("%d %d %d\n", xdata->template len3<dim3>().x, xdata->template len3<dim3>().y, xdata->template len3<dim3>().z);
+   cusz::x_spline_infprecis_data<
+       E*, T*, float, SPLINE_DIM, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+       numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ,
+       DEFAULT_BLOCK_SIZE>                                                    //
+       <<<grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>  //
+       (ectrl->dptr(), ectrl->template len3<dim3>(),
+        ectrl->template st3<dim3>(),  //
+        anchor->dptr(), anchor->template len3<dim3>(),
+        anchor->template st3<dim3>(),  //
+        xdata->dptr(), xdata->template len3<dim3>(),
+        xdata->template st3<dim3>(),  //
+        outlier_tmp,
+        eb_r, ebx2, radius, intp_param);
+ 
+   STOP_GPUEVENT_RECORDING(stream);
+   CHECK_GPU(GpuStreamSync(stream));
+   TIME_ELAPSED_GPUEVENT(time);
+   DESTROY_GPUEVENT_PAIR;
+ 
+   return 0;
+ }
+ 
+ #define INIT(T, E)                                                          \
+   template int spline_construct<T, E>(                                      \
+       pszmem_cxx<T> * data, pszmem_cxx<T> * anchor, pszmem_cxx<E> * ectrl,  \
+       void* _outlier, double eb, double rel_eb, uint32_t radius,            \
+       struct INTERPOLATION_PARAMS& intp_param, float* time, void* stream,   \
+       pszmem_cxx<T>* profiling_errors);                                     \
+   template int spline_reconstruct<T, E>(                                    \
+       pszmem_cxx<T> * anchor, pszmem_cxx<E> * ectrl, pszmem_cxx<T> * xdata, T* outlier_tmp, \
+       double eb, uint32_t radius, struct INTERPOLATION_PARAMS intp_param,   \
+       float* time, void* stream);
+ 
+ INIT(f4, u1)
+ INIT(f4, u2)
+ INIT(f4, u4)
+ INIT(f4, f4)
+ 
+ INIT(f8, u1)
+ INIT(f8, u2)
+ INIT(f8, u4)
+ INIT(f8, f4)
+ 
+ #undef INIT
+ #undef SETUP
+ 

--- a/src/kernel/spline3.cu
+++ b/src/kernel/spline3.cu
@@ -158,7 +158,7 @@ int spline_construct(
     else{
       int S_STRIDE;
       if(l3.z == 1) S_STRIDE = 14 * AnchorBlockSizeX;
-      else S_STRIDE = 6 * BLOCK16;
+      else S_STRIDE = 8 * BLOCK16;
 
       cusz::reset_errors<<<dim3(1, 1, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream >>>(profiling_errors->dptr());
 

--- a/src/kernel/spline3.cu
+++ b/src/kernel/spline3.cu
@@ -157,16 +157,16 @@ int spline_construct(
     }
     else{
       int S_STRIDE;
-      if(l3.z == 1)S_STRIDE = 6 * AnchorBlockSizeX;
+      if(l3.z == 1) S_STRIDE = 14 * AnchorBlockSizeX;
       else S_STRIDE = 6 * BLOCK16;
 
       cusz::reset_errors<<<dim3(1, 1, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream >>>(profiling_errors->dptr());
 
       auto calc_start_size = [&](auto dim, auto & s_start, auto &s_size, auto BLOCKSIZE) {
           auto mid = dim / 2;
-          auto k = (mid - BLOCKSIZE / 2) / (6 * BLOCKSIZE);  
-          auto t = (dim - BLOCKSIZE / 2 - 1 - mid) / (6 * BLOCKSIZE);
-          s_start = mid - k * (6 * BLOCKSIZE);
+          auto k = (mid - BLOCKSIZE / 2) / S_STRIDE;  
+          auto t = (dim - BLOCKSIZE / 2 - 1 - mid) / S_STRIDE;
+          s_start = mid - k * S_STRIDE;
           s_size = k + t + 1;
       };
 

--- a/src/kernel/spline3.cu
+++ b/src/kernel/spline3.cu
@@ -13,17 +13,30 @@
 
 #include "busyheader.hh"
 #include "cusz/type.h"
-#include "detail/spline3.inl"
+#include "detail/spline3_md.inl"
 #include "kernel/spline.hh"
 #include "mem/compact.hh"
 
 #include <cuda_runtime.h>
-//#include "mem/memseg_cxx.hh"
-//#include "mem/memseg.h"
-//#include "mem/layout.h"
-//#include "mem/layout_cxx.hh"
 
-constexpr int DEFAULT_BLOCK_SIZE = 384;
+#define BLOCK_DIM_SIZE 384
+#define LEVEL 6
+#define SPLINE_DIM_2 2
+#define SPLINE_DIM_3 3
+#define AnchorBlockSizeX 64
+#define AnchorBlockSizeY 64
+#define AnchorBlockSizeZ 1
+#define numAnchorBlockX 1  
+#define numAnchorBlockY 1  
+#define numAnchorBlockZ 1 
+#define BLOCK16 16
+#define PROFILE_BLOCK_SIZE_X 4
+#define PROFILE_BLOCK_SIZE_Y 4
+#define PROFILE_BLOCK_SIZE_Z 4
+#define PROFILE_NUM_BLOCK_X 4
+#define PROFILE_NUM_BLOCK_Y 4
+#define PROFILE_NUM_BLOCK_Z 4
+constexpr int DEFAULT_BLOCK_SIZE = BLOCK_DIM_SIZE;
 
 #define SETUP                                                   \
   auto div3 = [](dim3 len, dim3 sublen) {                       \
@@ -45,28 +58,23 @@ int spline_construct(
     pszmem_cxx<T>* data, pszmem_cxx<T>* anchor, pszmem_cxx<E>* ectrl,
     void* _outlier, double eb, double rel_eb, uint32_t radius, INTERPOLATION_PARAMS &intp_param, float* time, void* stream, pszmem_cxx<T>* profiling_errors)
 {
-  constexpr auto BLOCK = 8;
   auto div = [](auto _l, auto _subl) { return (_l - 1) / _subl + 1; };
 
   auto ebx2 = eb * 2;
   auto eb_r = 1 / eb;
 
   auto l3 = data->template len3<dim3>();
-  auto grid_dim =
-      dim3(div(l3.x, BLOCK * 4), div(l3.y, BLOCK), div(l3.z, BLOCK));
 
-
-  auto auto_tuning_grid_dim =
-      dim3(1, 1, 1);
+  auto auto_tuning_grid_dim = dim3(1, 1, 1);
 
 
 
   using Compact = typename CompactDram<PROPER_GPU_BACKEND, T>::Compact;
   auto ot = (Compact*)_outlier;
 
-  CREATE_GPUEVENT_PAIR;
-  START_GPUEVENT_RECORDING(stream);
-
+  //CREATE_GPUEVENT_PAIR;
+  //START_GPUEVENT_RECORDING(stream);
+  float att_time=0;
  if(intp_param.auto_tuning>0){
    //std::cout<<"att "<<(int)intp_param.auto_tuning<<std::endl;
    double a1=2.0;
@@ -94,69 +102,401 @@ int spline_construct(
    else
     intp_param.alpha=a5;
     if(intp_param.auto_tuning==1){
+
+      CREATE_GPUEVENT_PAIR;
+       START_GPUEVENT_RECORDING(stream);
    
-      cusz::c_spline3d_profiling_16x16x16data<T*, DEFAULT_BLOCK_SIZE>  //
+      cusz::c_spline_profiling_data<T*, SPLINE_DIM_3, PROFILE_BLOCK_SIZE_X, PROFILE_BLOCK_SIZE_Y, PROFILE_BLOCK_SIZE_Z,
+      PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, DEFAULT_BLOCK_SIZE>  //
         <<<auto_tuning_grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>(
             data->dptr(), data->template len3<dim3>(),
             data->template st3<dim3>(),  //
             profiling_errors->dptr());
+        STOP_GPUEVENT_RECORDING(stream);
+        CHECK_GPU(GpuStreamSync(stream));
+        TIME_ELAPSED_GPUEVENT(&att_time);
+        DESTROY_GPUEVENT_PAIR;
       //profiling_errors->control({D2H});
       CHECK_GPU(cudaMemcpy(profiling_errors->m->h, profiling_errors->m->d, profiling_errors->m->bytes, cudaMemcpyDeviceToHost));
       auto errors=profiling_errors->hptr();
       
       //printf("host %.4f %.4f\n",errors[0],errors[1]);
       bool do_reverse=(errors[1]>3*errors[0]);
-      intp_param.reverse[0]=intp_param.reverse[1]=intp_param.reverse[2]=do_reverse;
+      intp_param.reverse[0]=intp_param.reverse[1]=intp_param.reverse[2]=intp_param.reverse[3]=do_reverse;
     }
-    else{
-      cusz::c_spline3d_profiling_data_2<T*, DEFAULT_BLOCK_SIZE>  //
+    else if (intp_param.auto_tuning==2){
+       CREATE_GPUEVENT_PAIR;
+       START_GPUEVENT_RECORDING(stream);
+      cusz::c_spline_profiling_data_2<T*, SPLINE_DIM_3, PROFILE_NUM_BLOCK_X, PROFILE_NUM_BLOCK_Y, PROFILE_NUM_BLOCK_Z, DEFAULT_BLOCK_SIZE>  //
         <<<auto_tuning_grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>(
             data->dptr(), data->template len3<dim3>(),
-            data->template st3<dim3>(),  //
+            data->template st3<dim3>(),
             profiling_errors->dptr());
+      STOP_GPUEVENT_RECORDING(stream);
+      CHECK_GPU(GpuStreamSync(stream));
+      TIME_ELAPSED_GPUEVENT(&att_time);
+      DESTROY_GPUEVENT_PAIR;
       //profiling_errors->control({D2H});
       CHECK_GPU(cudaMemcpy(profiling_errors->m->h, profiling_errors->m->d, profiling_errors->m->bytes, cudaMemcpyDeviceToHost));
       auto errors=profiling_errors->hptr();
 
-      intp_param.interpolators[0]=(errors[0]>errors[1]);
-      intp_param.interpolators[1]=(errors[2]>errors[3]);
-      intp_param.interpolators[2]=(errors[4]>errors[5]);
+      //intp_param.interpolators[0]=(errors[0]>errors[1]);
+      //intp_param.interpolators[1]=(errors[2]>errors[3]);
+      //intp_param.interpolators[2]=(errors[4]>errors[5]);
       
-      bool do_reverse=(errors[4+intp_param.interpolators[2]]>3*errors[intp_param.interpolators[0]]);
+     
+      bool do_nat = errors[0] + errors[2] + errors[4] > errors[1] + errors[3] + errors[5];
+      intp_param.use_natural[0] = intp_param.use_natural[1] = intp_param.use_natural[2] = intp_param.use_natural[3] = do_nat;
+      //intp_param.interpolators[0]=(errors[0]>errors[1]);
+      //intp_param.interpolators[1]=(errors[2]>errors[3]);
+      //intp_param.interpolators[2]=(errors[4]>errors[5]);
+      //to revise: cubic spline selection for both axis-wise and global
        // bool do_reverse=(errors[1]>2*errors[0]);
-       intp_param.reverse[0]=intp_param.reverse[1]=intp_param.reverse[2]=do_reverse;
+        bool do_reverse=(errors[4+do_nat]>3*errors[do_nat]);
+       intp_param.reverse[0]=intp_param.reverse[1]=intp_param.reverse[2]=intp_param.reverse[3]=do_reverse;
     }
-   
-   
-    
-    
-  
+    else{
+      int S_STRIDE;
+      if(l3.z == 1)S_STRIDE = 6 * AnchorBlockSizeX;
+      else S_STRIDE = 6 * BLOCK16;
+
+      cusz::reset_errors<<<dim3(1, 1, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream >>>(profiling_errors->dptr());
+
+      auto calc_start_size = [&](auto dim, auto & s_start, auto &s_size, auto BLOCKSIZE) {
+          auto mid = dim / 2;
+          auto k = (mid - BLOCKSIZE / 2) / (6 * BLOCKSIZE);  
+          auto t = (dim - BLOCKSIZE / 2 - 1 - mid) / (6 * BLOCKSIZE);
+          s_start = mid - k * (6 * BLOCKSIZE);
+          s_size = k + t + 1;
+      };
+
+      int s_start_x, s_start_y, s_start_z, s_size_x, s_size_y, s_size_z;
+
+      if(l3.z == 1){
+        calc_start_size(l3.x, s_start_x, s_size_x, AnchorBlockSizeX);
+        calc_start_size(l3.y, s_start_y, s_size_y, AnchorBlockSizeY);
+        calc_start_size(l3.z, s_start_z, s_size_z, AnchorBlockSizeZ);
+      }
+      else{
+        calc_start_size(l3.x, s_start_x, s_size_x, BLOCK16);
+        calc_start_size(l3.y, s_start_y, s_size_y, BLOCK16);
+        calc_start_size(l3.z, s_start_z, s_size_z, BLOCK16);
+      }
+      float temp_time = 0;
+      CREATE_GPUEVENT_PAIR;
+      START_GPUEVENT_RECORDING(stream);
+      
+      auto block_num = s_size_x * s_size_y * s_size_z;
+      
+      auto errors = profiling_errors->hptr();
+
+
+      double best_ave_pre_error[LEVEL];
+      auto calcnum  = [&](auto N){
+        return N * (7 * N * N + 9 * N + 3);
+      };
+      T best_error;
+      int best_idx;
+
+      // if CONSTEXPR (SPLINE_DIM == 3){
+      if (l3.z > 1){
+        cusz::pa_spline_infprecis_data<T*, float, 4, SPLINE_DIM_3, BLOCK16, BLOCK16, BLOCK16, 1, 1, 1, DEFAULT_BLOCK_SIZE><<<dim3(s_size_x * s_size_y * s_size_z, 9, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>> (data->dptr(), data->template len3<dim3>(), data->template st3<dim3>(), dim3(s_start_x, s_start_y, s_start_z), dim3(s_size_x, s_size_y, s_size_z), dim3(S_STRIDE, S_STRIDE, S_STRIDE), eb_r, ebx2, intp_param, profiling_errors->dptr(), true);
+        
+        STOP_GPUEVENT_RECORDING(stream);
+        CHECK_GPU(GpuStreamSync(stream));
+        TIME_ELAPSED_GPUEVENT(&temp_time);
+        DESTROY_GPUEVENT_PAIR;
+        att_time += temp_time;
+        CHECK_GPU(cudaMemcpy(profiling_errors->m->h, profiling_errors->m->d, profiling_errors->m->bytes, cudaMemcpyDeviceToHost));
+        
+        if(errors[0] > errors[1]){
+          best_error = errors[1];
+          intp_param.reverse[3] = true;
+        }
+        else{
+          best_error = errors[0];
+          intp_param.reverse[3] = false;
+        }
+        
+        printf("use_md[3] errors[2]=%f, best_error=%f\n", errors[2], best_error);
+        intp_param.use_md[3] = errors[2] < best_error; 
+        best_error = fmin(errors[2],best_error);
+        best_ave_pre_error[3] = best_error / (calcnum(1) * block_num);
+
+
+        if(errors[3] > errors[4]){
+          best_error = errors[4];
+          intp_param.reverse[2] = true;
+        }
+        else{
+          best_error = errors[3];
+          intp_param.reverse[2] = false;
+        }
+        printf("use_md[2] errors[5]=%f, best_error=%f\n", errors[5], best_error);
+        intp_param.use_md[2] = errors[5] < best_error; 
+        best_error = fmin(errors[5],best_error);
+        best_ave_pre_error[2] = best_error / (calcnum(2) * block_num);
+
+        best_error = errors[6];
+        best_idx = 6; 
+        for(auto i = 6; i < 12; i++){
+          if(errors[i] < best_error){
+            best_error = errors[i];
+            best_idx = i;
+          }
+        }
+        intp_param.use_natural[1] = best_idx >  8;
+        printf("use_md[1] errors[8]=%f, best_error=%f\n", errors[8], best_error);
+        printf("use_md[1] errors[11]=%f, best_error=%f\n", errors[11], best_error);
+        intp_param.use_md[1] = (best_idx ==  8 or best_idx ==  11) ;
+        intp_param.reverse[1] = best_idx%3;
+
+        best_ave_pre_error[1]= best_error/(calcnum(4)*block_num);
+
+        best_error = errors[12];
+        best_idx = 12; 
+
+        for(auto i = 12;i<18;i++){
+          if(errors[i]<best_error){
+            best_error=errors[i];
+            best_idx = i;
+          }
+        }
+        intp_param.use_natural[0] = best_idx >  14;
+        printf("use_md[1] errors[14]=%f, best_error=%f\n", errors[14], best_error);
+        printf("use_md[1] errors[17]=%f, best_error=%f\n", errors[17], best_error);
+        intp_param.use_md[0] = (best_idx ==  14 or best_idx ==  17);
+        intp_param.reverse[0] = best_idx%3;
+
+        best_ave_pre_error[0]= best_error/(calcnum(8)*block_num);
+        
+        printf("BESTERROR: %.4e %.4e %.4e %.4e\n",best_ave_pre_error[3],best_ave_pre_error[2],best_ave_pre_error[1],best_ave_pre_error[0]);
+      }
+
+    // if CONSTEXPR (SPLINE_DIM == 2){
+    if (l3.z == 1){
+      printf("s_size.x = %d, .y = %d, .z = %d\n", s_size_x, s_size_y, s_size_z);
+      printf("l3.x = %d, .y = %d, .z = %d\n", l3.x, l3.y, l3.z);
+      cusz::pa_spline_infprecis_data<T*, float, LEVEL, SPLINE_DIM_2, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, DEFAULT_BLOCK_SIZE><<<dim3(s_size_x * s_size_y * s_size_z, 6 * LEVEL, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>> (data->dptr(), data->template len3<dim3>(), data->template st3<dim3>(), dim3(s_start_x, s_start_y, s_start_z), dim3(s_size_x, s_size_y, s_size_z), dim3(S_STRIDE, S_STRIDE, S_STRIDE), eb_r, ebx2, intp_param, profiling_errors->dptr(), true);
+        
+      STOP_GPUEVENT_RECORDING(stream);
+      CHECK_GPU(GpuStreamSync(stream));
+      TIME_ELAPSED_GPUEVENT(&temp_time);
+      DESTROY_GPUEVENT_PAIR;
+      att_time += temp_time;
+      CHECK_GPU(cudaMemcpy(profiling_errors->m->h, profiling_errors->m->d, profiling_errors->m->bytes, cudaMemcpyDeviceToHost));
+      
+      
+      for(int level = 0; level < LEVEL; ++level){
+        printf("level=%d: ", level);
+        best_error = errors[level * 6];
+        best_idx = level * 6; 
+        int level_id = LEVEL - 1 - level;
+
+        for(auto i = level * 6; i < level * 6 + 6; i++){
+          printf(" errors[%d]=%.10f", i, errors[i]);
+          if(errors[i] < best_error){
+            best_error = errors[i];
+            best_idx = i;
+          }
+        }
+        intp_param.use_natural[level_id] = (best_idx % 6) > 2;
+        intp_param.use_md[level_id] = ((best_idx % 6) == 2 or (best_idx % 6) ==  5) ;
+        intp_param.reverse[level_id] = best_idx % 3;
+        best_ave_pre_error[level_id]= best_error / (calcnum(1 << level) * block_num);
+        printf(" BESTERROR=%f\n", best_ave_pre_error[level_id]);
+      }
+      printf("\n");
+    }
+      // intp_param.use_md[0] = 1;
+      // intp_param.use_md[1] = 1;
+      // intp_param.use_md[2] = 0;
+      // intp_param.use_md[3] = 1;
+      
+      // intp_param.use_natural[0] = 0;
+      // intp_param.use_natural[1] = 0;
+      // intp_param.use_natural[2] = 1;
+      // intp_param.use_natural[3] = 0;
+
+      // intp_param.reverse[0] = 0;
+      // intp_param.reverse[1] = 1;
+      // intp_param.reverse[2] = 0;
+      // intp_param.reverse[3] = 1;
+      // intp_param.use_md[3] = 1;
+      // intp_param.use_md[2] = 1;
+      // intp_param.use_md[1] = 0;
+      // intp_param.use_md[0] = 1;
+      
+      // intp_param.use_natural[3] = 0;
+      // intp_param.use_natural[2] = 0;
+      // intp_param.use_natural[1] = 1;
+      // intp_param.use_natural[0] = 0;
+
+      // intp_param.reverse[3] = 0;
+      // intp_param.reverse[2] = 1;
+      // intp_param.reverse[1] = 0;
+      // intp_param.reverse[0] = 1;
+      // intp_param.use_md[4] = 1;
+      // intp_param.use_md[5] = 1;
+      // intp_param.use_md[0] = 0;
+      // intp_param.use_md[1] = 0;
+      // intp_param.use_md[2] = 0;
+      // intp_param.use_md[3] = 0;
+      // intp_param.use_md[4] = 0;
+      // intp_param.use_md[5] = 0;
+      if(intp_param.auto_tuning==4){
+         cusz::reset_errors<<<dim3(1, 1, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1),0, (GpuStreamT)stream >>>(profiling_errors->dptr());
+
+        float temp_time = 0;
+        CREATE_GPUEVENT_PAIR;
+         START_GPUEVENT_RECORDING(stream);
+
+        if (l3.z != 1)
+        cusz::pa_spline_infprecis_data<T*, float, 4, SPLINE_DIM_3, BLOCK16, BLOCK16, BLOCK16, 1, 1, 1, DEFAULT_BLOCK_SIZE><<<dim3(s_size_x * s_size_y * s_size_z, 11, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1),0, (GpuStreamT)stream>>>(
+          data->dptr(),
+          data->template len3<dim3>(),
+          data->template st3<dim3>(),
+          dim3(s_start_x,s_start_y,s_start_z),
+          dim3(s_size_x,s_size_y,s_size_z),
+          dim3(S_STRIDE,S_STRIDE,S_STRIDE),
+          eb_r,
+          ebx2,
+          intp_param,
+          profiling_errors->dptr(),
+          false);
+        else cusz::pa_spline_infprecis_data<T*, float, LEVEL, SPLINE_DIM_2, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ, numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, DEFAULT_BLOCK_SIZE><<<dim3(s_size_x * s_size_y * s_size_z, 11, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1),0, (GpuStreamT)stream>>>(
+          data->dptr(),
+          data->template len3<dim3>(),
+          data->template st3<dim3>(),
+          dim3(s_start_x,s_start_y,s_start_z),
+          dim3(s_size_x,s_size_y,s_size_z),
+          dim3(S_STRIDE,S_STRIDE,S_STRIDE),
+          eb_r,
+          ebx2,
+          intp_param,
+          profiling_errors->dptr(),
+          false);
+        
+        STOP_GPUEVENT_RECORDING(stream);
+        CHECK_GPU(GpuStreamSync(stream));
+        TIME_ELAPSED_GPUEVENT(&temp_time);
+        DESTROY_GPUEVENT_PAIR;
+        att_time += temp_time;
+
+        auto errors = profiling_errors->hptr();
+        // for(int i = 0; i < 11; i++){
+        //   printf("%d %.4e\n", i, errors[i]);
+        // }
+
+        best_error = errors[0];
+        auto best_idx = 0; 
+        
+        for(auto i = 1;i < 11;i++){
+          if(errors[i] < best_error){
+            best_error = errors[i];
+            best_idx = i;
+          }
+        }
+
+        if(best_idx == 0){
+            intp_param.alpha = 1.0;
+            intp_param.beta = 2.0;
+        }
+        else if (best_idx == 1){
+            intp_param.alpha = 1.25;
+            intp_param.beta = 2.0;
+        }
+        else{
+            intp_param.alpha = 1.5+0.25*((best_idx-2)/3);
+            intp_param.beta = 2.0+((best_idx-2)%3);
+        }
+
+      }
+      else if(intp_param.auto_tuning >= 5){
+        best_idx = intp_param.auto_tuning - 5;
+        if(best_idx == 0){
+            intp_param.alpha = 1.0;
+            intp_param.beta = 2.0;
+        }
+        else if (best_idx == 1){
+            intp_param.alpha = 1.25;
+            intp_param.beta = 2.0;
+        }
+        else{
+            intp_param.alpha = 1.5 + 0.25 * ((best_idx - 2) / 3);
+            intp_param.beta = 2.0 + ((best_idx - 2) % 3);
+        }
+
+      }
+
+
+    }
+    if(l3.z != 1){
+      printf("\nNAT:");
+      for(int i = 0; i < 4; ++i) printf(" %d", intp_param.use_natural[4 - i - 1]);
+      printf("\nMD:");
+      for(int i = 0; i < 4; ++i) printf(" %d", intp_param.use_md[4 - i - 1]);
+      printf("\nREVERSE:");
+      for(int i = 0; i < 4; ++i) printf(" %d", intp_param.reverse[4 - i - 1]);
+    }
+    else{
+      printf("\nNAT:");
+      for(int i = 0; i < LEVEL; ++i) printf(" %d", intp_param.use_natural[LEVEL - i - 1]);
+      printf("\nMD:");
+      for(int i = 0; i < LEVEL; ++i) printf(" %d", intp_param.use_md[LEVEL - i - 1]);
+      printf("\nREVERSE:");
+      for(int i = 0; i < LEVEL; ++i) printf(" %d", intp_param.reverse[LEVEL - i - 1]);
+    }
+      printf("\nA B: %.2f %.2f\n",intp_param.alpha,intp_param.beta);
   }
+  CREATE_GPUEVENT_PAIR;
+  START_GPUEVENT_RECORDING(stream);
 
-
-  cusz::c_spline3d_infprecis_32x8x8data<T*, E*, float, DEFAULT_BLOCK_SIZE>  //
-      <<<grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>(
-          data->dptr(), data->template len3<dim3>(),
-          data->template st3<dim3>(),  //
-          ectrl->dptr(), ectrl->template len3<dim3>(),
-          ectrl->template st3<dim3>(),  //
-          anchor->dptr(), anchor->template st3<dim3>(), ot->val(), ot->idx(),
-          ot->num(), eb_r, ebx2, radius, intp_param);//,profiling_errors->dptr());
-
+  if (l3.z == 1){
+    auto grid_dim =
+      dim3(div(l3.x, AnchorBlockSizeX * numAnchorBlockX),
+          div(l3.y, AnchorBlockSizeY * numAnchorBlockY),
+          div(l3.z, AnchorBlockSizeZ * numAnchorBlockZ));
+      cusz::c_spline_infprecis_data<T*, E*, float, LEVEL, SPLINE_DIM_2, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+    numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, DEFAULT_BLOCK_SIZE>  //
+        <<<grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>(
+            data->dptr(), data->template len3<dim3>(),
+            data->template st3<dim3>(),  //
+            ectrl->dptr(), ectrl->template len3<dim3>(),
+            ectrl->template st3<dim3>(),  //
+            anchor->dptr(), anchor->template st3<dim3>(), ot->val(), ot->idx(),
+            ot->num(), eb_r, ebx2, radius, intp_param);//,profiling_errors->dptr());
+  }
+  else {
+    auto grid_dim = dim3(div(l3.x, BLOCK16),
+          div(l3.y, BLOCK16),
+          div(l3.z, BLOCK16));
+    cusz::c_spline_infprecis_data<T*, E*, float, 4, SPLINE_DIM_3, BLOCK16, BLOCK16, BLOCK16,
+    1, 1, 1, DEFAULT_BLOCK_SIZE>  //
+        <<<grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>(
+            data->dptr(), data->template len3<dim3>(),
+            data->template st3<dim3>(),  //
+            ectrl->dptr(), ectrl->template len3<dim3>(),
+            ectrl->template st3<dim3>(),  //
+            anchor->dptr(), anchor->template st3<dim3>(), ot->val(), ot->idx(),
+            ot->num(), eb_r, ebx2, radius, intp_param);//,profiling_errors->dptr());
+  }
   STOP_GPUEVENT_RECORDING(stream);
   CHECK_GPU(GpuStreamSync(stream));
   TIME_ELAPSED_GPUEVENT(time);
   DESTROY_GPUEVENT_PAIR;
+
+  *time+=att_time;
 
   return 0;
 }
 
 template <typename T, typename E, typename FP>
 int spline_reconstruct(
-    pszmem_cxx<T>* anchor, pszmem_cxx<E>* ectrl, pszmem_cxx<T>* xdata,
+    pszmem_cxx<T>* anchor, pszmem_cxx<E>* ectrl, pszmem_cxx<T>* xdata, T* outlier_tmp,
     double eb, uint32_t radius, INTERPOLATION_PARAMS intp_param, float* time, void* stream)
 {
-  constexpr auto BLOCK = 8;
+
 
   auto div = [](auto _l, auto _subl) { return (_l - 1) / _subl + 1; };
 
@@ -164,13 +504,15 @@ int spline_reconstruct(
   auto eb_r = 1 / eb;
 
   auto l3 = xdata->template len3<dim3>();
-  auto grid_dim =
-      dim3(div(l3.x, BLOCK * 4), div(l3.y, BLOCK), div(l3.z, BLOCK));
 
   CREATE_GPUEVENT_PAIR;
   START_GPUEVENT_RECORDING(stream);
+  if (l3.z == 1){
+    auto grid_dim =
+    dim3(div(l3.x, AnchorBlockSizeX * numAnchorBlockX ), div(l3.y, AnchorBlockSizeY * numAnchorBlockY ), div(l3.z, AnchorBlockSizeZ * numAnchorBlockZ ));
 
-  cusz::x_spline3d_infprecis_32x8x8data<E*, T*, float, DEFAULT_BLOCK_SIZE>   //
+    cusz::x_spline_infprecis_data<E*, T*, float, LEVEL, SPLINE_DIM_2, AnchorBlockSizeX, AnchorBlockSizeY, AnchorBlockSizeZ,
+  numAnchorBlockX, numAnchorBlockY, numAnchorBlockZ, DEFAULT_BLOCK_SIZE>   //
       <<<grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>  //
       (ectrl->dptr(), ectrl->template len3<dim3>(),
        ectrl->template st3<dim3>(),  //
@@ -178,8 +520,25 @@ int spline_reconstruct(
        anchor->template st3<dim3>(),  //
        xdata->dptr(), xdata->template len3<dim3>(),
        xdata->template st3<dim3>(),  //
+       outlier_tmp,
        eb_r, ebx2, radius, intp_param);
+  }
+  else {
+    auto grid_dim =
+    dim3(div(l3.x, BLOCK16 ), div(l3.y, BLOCK16 ), div(l3.z, BLOCK16 ));
 
+    cusz::x_spline_infprecis_data<E*, T*, float, 4, SPLINE_DIM_3, BLOCK16, BLOCK16, BLOCK16,
+  1, 1, 1, DEFAULT_BLOCK_SIZE>   //
+      <<<grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>  //
+      (ectrl->dptr(), ectrl->template len3<dim3>(),
+       ectrl->template st3<dim3>(),  //
+       anchor->dptr(), anchor->template len3<dim3>(),
+       anchor->template st3<dim3>(),  //
+       xdata->dptr(), xdata->template len3<dim3>(),
+       xdata->template st3<dim3>(),  //
+       outlier_tmp,
+       eb_r, ebx2, radius, intp_param);
+  }
   STOP_GPUEVENT_RECORDING(stream);
   CHECK_GPU(GpuStreamSync(stream));
   TIME_ELAPSED_GPUEVENT(time);
@@ -193,18 +552,13 @@ int spline_reconstruct(
       pszmem_cxx<T> * data, pszmem_cxx<T> * anchor, pszmem_cxx<E> * ectrl,    \
       void* _outlier, double eb, double rel_eb, uint32_t radius, struct INTERPOLATION_PARAMS &intp_param, float* time, void* stream, pszmem_cxx<T> * profiling_errors); \
   template int spline_reconstruct<T, E>(                                      \
-      pszmem_cxx<T> * anchor, pszmem_cxx<E> * ectrl, pszmem_cxx<T> * xdata,   \
+      pszmem_cxx<T> * anchor, pszmem_cxx<E> * ectrl, pszmem_cxx<T> * xdata, T* outlier_tmp,  \
       double eb, uint32_t radius, struct INTERPOLATION_PARAMS intp_param, float* time, void* stream);
 
 INIT(f4, u1)
 INIT(f4, u2)
 INIT(f4, u4)
 INIT(f4, f4)
-
-INIT(f8, u1)
-INIT(f8, u2)
-INIT(f8, u4)
-INIT(f8, f4)
 
 #undef INIT
 #undef SETUP

--- a/src/kernel/spline3.cu
+++ b/src/kernel/spline3.cu
@@ -219,7 +219,7 @@ int spline_construct(
         }
         
         printf("use_md[3] errors[2]=%f, best_error=%f\n", errors[2], best_error);
-        intp_param.use_md[3] = false;//errors[2] < best_error; 
+        intp_param.use_md[3] = errors[2] < best_error; 
         best_error = fmin(errors[2],best_error);
         best_ave_pre_error[3] = best_error / (calcnum(1) * block_num);
 
@@ -233,7 +233,7 @@ int spline_construct(
           intp_param.reverse[2] = false;
         }
         printf("use_md[2] errors[5]=%f, best_error=%f\n", errors[5], best_error);
-        intp_param.use_md[2] = true; //errors[5] < best_error; 
+        intp_param.use_md[2] = errors[5] < best_error; 
         best_error = fmin(errors[5],best_error);
         best_ave_pre_error[2] = best_error / (calcnum(2) * block_num);
 

--- a/src/kernel/spline3.cu
+++ b/src/kernel/spline3.cu
@@ -157,7 +157,7 @@ int spline_construct(
     }
     else{
       int S_STRIDE;
-      if(l3.z == 1) S_STRIDE = 14 * AnchorBlockSizeX;
+      if(l3.z == 1) S_STRIDE = 20 * AnchorBlockSizeX;
       else S_STRIDE = 8 * BLOCK16;
 
       cusz::reset_errors<<<dim3(1, 1, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream >>>(profiling_errors->dptr());

--- a/src/kernel/spline3.cu
+++ b/src/kernel/spline3.cu
@@ -219,7 +219,7 @@ int spline_construct(
         }
         
         printf("use_md[3] errors[2]=%f, best_error=%f\n", errors[2], best_error);
-        intp_param.use_md[3] = errors[2] < best_error; 
+        intp_param.use_md[3] = false;//errors[2] < best_error; 
         best_error = fmin(errors[2],best_error);
         best_ave_pre_error[3] = best_error / (calcnum(1) * block_num);
 
@@ -233,7 +233,7 @@ int spline_construct(
           intp_param.reverse[2] = false;
         }
         printf("use_md[2] errors[5]=%f, best_error=%f\n", errors[5], best_error);
-        intp_param.use_md[2] = errors[5] < best_error; 
+        intp_param.use_md[2] = false; //errors[5] < best_error; 
         best_error = fmin(errors[5],best_error);
         best_ave_pre_error[2] = best_error / (calcnum(2) * block_num);
 

--- a/src/kernel/spline3.cu
+++ b/src/kernel/spline3.cu
@@ -233,7 +233,7 @@ int spline_construct(
           intp_param.reverse[2] = false;
         }
         printf("use_md[2] errors[5]=%f, best_error=%f\n", errors[5], best_error);
-        intp_param.use_md[2] = false; //errors[5] < best_error; 
+        intp_param.use_md[2] = true; //errors[5] < best_error; 
         best_error = fmin(errors[5],best_error);
         best_ave_pre_error[2] = best_error / (calcnum(2) * block_num);
 

--- a/src/kernel/spline3_old.cu
+++ b/src/kernel/spline3_old.cu
@@ -1,0 +1,421 @@
+/**
+ * @file spline3.cu
+ * @author Jinyang Liu, Shixun Wu, Jiannan Tian
+ * @brief A high-level Spline3D wrapper. Allocations are explicitly out of
+ * called functions.
+ * @version 0.3
+ * @date 2021-06-15
+ *
+ * (copyright to be updated)
+ * (C) 2021 by Washington State University, Argonne National Laboratory
+ *
+ */
+
+ #include "busyheader.hh"
+ #include "cusz/type.h"
+ #include "detail/spline3.inl"
+ #include "kernel/spline.hh"
+ #include "mem/compact.hh"
+ 
+ #include <cuda_runtime.h>
+ //#include "mem/memseg_cxx.hh"
+ //#include "mem/memseg.h"
+ //#include "mem/layout.h"
+ //#include "mem/layout_cxx.hh"
+ #define BLOCK_DIM_SIZE 384
+ constexpr int DEFAULT_BLOCK_SIZE = BLOCK_DIM_SIZE;
+ 
+ #define SETUP                                                   \
+   auto div3 = [](dim3 len, dim3 sublen) {                       \
+     return dim3(                                                \
+         (len.x - 1) / sublen.x + 1, (len.y - 1) / sublen.y + 1, \
+         (len.z - 1) / sublen.z + 1);                            \
+   };                                                            \
+   auto ndim = [&]() {                                           \
+     if (len3.z == 1 and len3.y == 1)                            \
+       return 1;                                                 \
+     else if (len3.z == 1 and len3.y != 1)                       \
+       return 2;                                                 \
+     else                                                        \
+       return 3;                                                 \
+   };
+ 
+ template <typename T, typename E, typename FP>
+ int spline_construct(
+     pszmem_cxx<T>* data, pszmem_cxx<T>* anchor, pszmem_cxx<E>* ectrl,
+     void* _outlier, double eb, double rel_eb, uint32_t radius, INTERPOLATION_PARAMS &intp_param, float* time, void* stream, pszmem_cxx<T>* profiling_errors)
+ {
+   constexpr auto BLOCK = 16;
+   auto div = [](auto _l, auto _subl) { return (_l - 1) / _subl + 1; };
+ 
+   auto ebx2 = eb * 2;
+   auto eb_r = 1 / eb;
+ 
+   auto l3 = data->template len3<dim3>();
+   auto grid_dim =
+       dim3(div(l3.x, BLOCK ), div(l3.y, BLOCK ), div(l3.z, BLOCK ));
+ 
+ 
+   auto auto_tuning_grid_dim =
+       dim3(1, 1, 1);
+ 
+ 
+ 
+   using Compact = typename CompactDram<PROPER_GPU_BACKEND, T>::Compact;
+   auto ot = (Compact*)_outlier;
+ 
+   //CREATE_GPUEVENT_PAIR;
+   //START_GPUEVENT_RECORDING(stream);
+   float att_time=0;
+  if(intp_param.auto_tuning>0){
+    //std::cout<<"att "<<(int)intp_param.auto_tuning<<std::endl;
+    double a1=2.0;
+    double a2=1.75;
+    double a3=1.5;
+    double a4=1.25;
+    double a5=1;
+    double e1=1e-1;
+    double e2=1e-2;
+    double e3=1e-3;
+    double e4=1e-4;
+    double e5=1e-5;
+ 
+    intp_param.beta=4.0;
+    if(rel_eb>=e1)
+     intp_param.alpha=a1;
+    else if(rel_eb>=e2)
+     intp_param.alpha=a2+(a1-a2)*(rel_eb-e2)/(e1-e2);
+    else if(rel_eb>=e3)
+     intp_param.alpha=a3+(a2-a3)*(rel_eb-e3)/(e2-e3);
+    else if(rel_eb>=e4)
+     intp_param.alpha=a4+(a3-a4)*(rel_eb-e4)/(e3-e4);
+    else if(rel_eb>=e5)
+     intp_param.alpha=a5+(a4-a5)*(rel_eb-e5)/(e4-e5);
+    else
+     intp_param.alpha=a5;
+     if(intp_param.auto_tuning==1){
+ 
+       CREATE_GPUEVENT_PAIR;
+        START_GPUEVENT_RECORDING(stream);
+    
+       cusz::c_spline3d_profiling_16x16x16data<T*, DEFAULT_BLOCK_SIZE>  //
+         <<<auto_tuning_grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>(
+             data->dptr(), data->template len3<dim3>(),
+             data->template st3<dim3>(),  //
+             profiling_errors->dptr());
+         STOP_GPUEVENT_RECORDING(stream);
+         CHECK_GPU(GpuStreamSync(stream));
+         TIME_ELAPSED_GPUEVENT(&att_time);
+         DESTROY_GPUEVENT_PAIR;
+       //profiling_errors->control({D2H});
+       CHECK_GPU(cudaMemcpy(profiling_errors->m->h, profiling_errors->m->d, profiling_errors->m->bytes, cudaMemcpyDeviceToHost));
+       auto errors=profiling_errors->hptr();
+       
+       //printf("host %.4f %.4f\n",errors[0],errors[1]);
+       bool do_reverse=(errors[1]>3*errors[0]);
+       intp_param.reverse[0]=intp_param.reverse[1]=intp_param.reverse[2]=intp_param.reverse[3]=do_reverse;
+     }
+     else if (intp_param.auto_tuning==2){
+        CREATE_GPUEVENT_PAIR;
+        START_GPUEVENT_RECORDING(stream);
+       cusz::c_spline3d_profiling_data_2<T*, DEFAULT_BLOCK_SIZE>  //
+         <<<auto_tuning_grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>(
+             data->dptr(), data->template len3<dim3>(),
+             data->template st3<dim3>(),
+               //
+             profiling_errors->dptr());
+       STOP_GPUEVENT_RECORDING(stream);
+       CHECK_GPU(GpuStreamSync(stream));
+       TIME_ELAPSED_GPUEVENT(&att_time);
+       DESTROY_GPUEVENT_PAIR;
+       //profiling_errors->control({D2H});
+       CHECK_GPU(cudaMemcpy(profiling_errors->m->h, profiling_errors->m->d, profiling_errors->m->bytes, cudaMemcpyDeviceToHost));
+       auto errors=profiling_errors->hptr();
+ 
+       //intp_param.interpolators[0]=(errors[0]>errors[1]);
+       //intp_param.interpolators[1]=(errors[2]>errors[3]);
+       //intp_param.interpolators[2]=(errors[4]>errors[5]);
+       
+      
+       bool do_nat = errors[0] + errors[2] + errors[4] > errors[1] + errors[3] + errors[5];
+       intp_param.use_natural[0]=intp_param.use_natural[1]=intp_param.use_natural[2]=intp_param.use_natural[3]=do_nat;
+       //intp_param.interpolators[0]=(errors[0]>errors[1]);
+       //intp_param.interpolators[1]=(errors[2]>errors[3]);
+       //intp_param.interpolators[2]=(errors[4]>errors[5]);
+       //to revise: cubic spline selection for both axis-wise and global
+        // bool do_reverse=(errors[1]>2*errors[0]);
+         bool do_reverse=(errors[4+do_nat]>3*errors[do_nat]);
+        intp_param.reverse[0]=intp_param.reverse[1]=intp_param.reverse[2]=intp_param.reverse[3]=do_reverse;
+     }
+     else{
+       const auto S_STRIDE = 6 * BLOCK;//96
+       cusz::reset_errors<<<dim3(1, 1, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1),0, (GpuStreamT)stream >>>(profiling_errors->dptr());
+ 
+       auto calc_start_size = [&](auto dim,auto & s_start,auto &s_size) {
+           auto mid = dim / 2;
+     
+           auto k = (mid - 8) / S_STRIDE;  
+           auto t = (dim - 8 - 1 - mid) / S_STRIDE;  
+ 
+           s_start = mid - k * S_STRIDE;
+           s_size = k+t+1;
+       };
+ 
+       int s_start_x,s_start_y,s_start_z,s_size_x,s_size_y,s_size_z;
+ 
+       calc_start_size(l3.x,s_start_x,s_size_x);
+       calc_start_size(l3.y,s_start_y,s_size_y);
+       calc_start_size(l3.z,s_start_z,s_size_z);
+ 
+       //printf("%d %d %d %d %d %d\n",s_start_x,s_start_y,s_start_z,s_size_x,s_size_y,s_size_z);
+       float temp_time = 0;
+       CREATE_GPUEVENT_PAIR;
+        START_GPUEVENT_RECORDING(stream);
+       auto block_num = s_size_x*s_size_y*s_size_z;
+ 
+       cusz::pa_spline3d_infprecis_16x16x16data<T*, float, DEFAULT_BLOCK_SIZE> //
+       <<<dim3(s_size_x*s_size_y*s_size_z, 9, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1),0, (GpuStreamT)stream  >>>
+       (data->dptr(), data->template len3<dim3>(),data->template st3<dim3>(),dim3(s_start_x,s_start_y,s_start_z),dim3(s_size_x,s_size_y,s_size_z),dim3(S_STRIDE,S_STRIDE,S_STRIDE),eb_r,ebx2,intp_param,profiling_errors->dptr(),true);
+        STOP_GPUEVENT_RECORDING(stream);
+       CHECK_GPU(GpuStreamSync(stream));
+       TIME_ELAPSED_GPUEVENT(&temp_time);
+       DESTROY_GPUEVENT_PAIR;
+       att_time+=temp_time;
+       CHECK_GPU(cudaMemcpy(profiling_errors->m->h, profiling_errors->m->d, profiling_errors->m->bytes, cudaMemcpyDeviceToHost));
+       auto errors=profiling_errors->hptr();
+ 
+       //for(int i=0;i<18;i++){
+       //printf("%d %.4e\n",i,errors[i]);
+      // }
+ 
+ 
+       double best_ave_pre_error[4];
+       auto calcnum  = [&](auto N){
+         return N*(7*N*N+9*N+3);
+       };
+ 
+ 
+       T best_error;
+       if(errors[0]>errors[1]){
+         best_error = errors[1];
+         intp_param.reverse[3] = true;
+       }
+       else{
+         best_error = errors[0];
+         intp_param.reverse[3] = false;
+       }
+        
+ 
+       intp_param.use_md[3] = errors[2] < best_error; 
+       best_error = fmin(errors[2],best_error);
+       best_ave_pre_error[3]= best_error/(calcnum(1)*block_num);
+ 
+ 
+       if(errors[3]>errors[4]){
+         best_error = errors[4];
+         intp_param.reverse[2] = true;
+       }
+       else{
+         best_error = errors[3];
+         intp_param.reverse[2] = false;
+       }
+ 
+       intp_param.use_md[2] = errors[5] < best_error; 
+       best_error = fmin(errors[5],best_error);
+       best_ave_pre_error[2]= best_error/(calcnum(2)*block_num);
+ 
+       best_error = errors[6];
+       auto best_idx = 6; 
+       for(auto i = 6;i<12;i++){
+         if(errors[i]<best_error){
+           best_error=errors[i];
+           best_idx = i;
+         }
+       }
+       intp_param.use_natural[1] = best_idx >  8;
+       intp_param.use_md[1] = (best_idx ==  8 or best_idx ==  11) ;
+       intp_param.reverse[1] = best_idx%3;
+ 
+       best_ave_pre_error[1]= best_error/(calcnum(4)*block_num);
+ 
+       best_error = errors[12];
+       best_idx = 12; 
+ 
+       for(auto i = 12;i<18;i++){
+         if(errors[i]<best_error){
+           best_error=errors[i];
+           best_idx = i;
+         }
+       }
+       intp_param.use_natural[0] = best_idx >  14;
+       intp_param.use_md[0] = (best_idx ==  14 or best_idx ==  17);
+       intp_param.reverse[0] = best_idx%3;
+ 
+       best_ave_pre_error[0]= best_error/(calcnum(8)*block_num);
+       
+       printf("BESTERROR: %.4e %.4e %.4e %.4e\n",best_ave_pre_error[3],best_ave_pre_error[2],best_ave_pre_error[1],best_ave_pre_error[0]);
+       // intp_param.use_md[0] = 1;
+       // intp_param.use_md[1] = 1;
+       // intp_param.use_md[2] = 1;
+       // intp_param.use_md[3] = 1;
+       if(intp_param.auto_tuning==4){
+          cusz::reset_errors<<<dim3(1, 1, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1),0, (GpuStreamT)stream >>>(profiling_errors->dptr());
+ 
+         float temp_time = 0;
+         CREATE_GPUEVENT_PAIR;
+          START_GPUEVENT_RECORDING(stream);
+ 
+         cusz::pa_spline3d_infprecis_16x16x16data<T*, float, DEFAULT_BLOCK_SIZE> //
+         <<<dim3(s_size_x*s_size_y*s_size_z, 11, 1), dim3(DEFAULT_BLOCK_SIZE, 1, 1),0, (GpuStreamT)stream  >>>
+         (data->dptr(), data->template len3<dim3>(),data->template st3<dim3>(),dim3(s_start_x,s_start_y,s_start_z),dim3(s_size_x,s_size_y,s_size_z),dim3(S_STRIDE,S_STRIDE,S_STRIDE),eb_r,ebx2,intp_param,profiling_errors->dptr(),false);
+          STOP_GPUEVENT_RECORDING(stream);
+         CHECK_GPU(GpuStreamSync(stream));
+         TIME_ELAPSED_GPUEVENT(&temp_time);
+         DESTROY_GPUEVENT_PAIR;
+         att_time+=temp_time;
+ 
+         auto errors=profiling_errors->hptr();
+         for(int i=0;i<11;i++){
+           printf("%d %.4e\n",i,errors[i]);
+         }
+ 
+         best_error = errors[0];
+         auto best_idx = 0; 
+         
+         for(auto i = 1;i<11;i++){
+           if(errors[i]<best_error){
+             best_error=errors[i];
+             best_idx = i;
+           }
+         }
+ 
+         if(best_idx==0){
+             intp_param.alpha = 1.0;
+             intp_param.beta = 2.0;
+         }
+         else if (best_idx==1){
+             intp_param.alpha = 1.25;
+             intp_param.beta = 2.0;
+         }
+         else{
+             intp_param.alpha = 1.5+0.25*((best_idx-2)/3);
+             intp_param.beta = 2.0+((best_idx-2)%3);
+         }
+ 
+       }
+       else if(intp_param.auto_tuning >=5){
+         best_idx = intp_param.auto_tuning-5;
+         if(best_idx==0){
+             intp_param.alpha = 1.0;
+             intp_param.beta = 2.0;
+         }
+         else if (best_idx==1){
+             intp_param.alpha = 1.25;
+             intp_param.beta = 2.0;
+         }
+         else{
+             intp_param.alpha = 1.5+0.25*((best_idx-2)/3);
+             intp_param.beta = 2.0+((best_idx-2)%3);
+         }
+ 
+       }
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+     }
+     //for(int i=0;i<4;i++)
+     //intp_param.reverse[i]=false;
+      printf("NAT: %d %d %d %d\n",intp_param.use_natural[3],intp_param.use_natural[2],intp_param.use_natural[1],intp_param.use_natural[0]);
+       printf("MD: %d %d %d %d\n",intp_param.use_md[3],intp_param.use_md[2],intp_param.use_md[1],intp_param.use_md[0]);
+       printf("REVERSE: %d %d %d %d\n",intp_param.reverse[3],intp_param.reverse[2],intp_param.reverse[1],intp_param.reverse[0]);
+       printf("A B: %.2f %.2f\n",intp_param.alpha,intp_param.beta);
+     
+   
+   }
+   CREATE_GPUEVENT_PAIR;
+   START_GPUEVENT_RECORDING(stream);
+ 
+   cusz::c_spline3d_infprecis_16x16x16data<T*, E*, float, DEFAULT_BLOCK_SIZE>  //
+       <<<grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>(
+           data->dptr(), data->template len3<dim3>(),
+           data->template st3<dim3>(),  //
+           ectrl->dptr(), ectrl->template len3<dim3>(),
+           ectrl->template st3<dim3>(),  //
+           anchor->dptr(), anchor->template st3<dim3>(), ot->val(), ot->idx(),
+           ot->num(), eb_r, ebx2, radius, intp_param);//,profiling_errors->dptr());
+ 
+   STOP_GPUEVENT_RECORDING(stream);
+   CHECK_GPU(GpuStreamSync(stream));
+   TIME_ELAPSED_GPUEVENT(time);
+   DESTROY_GPUEVENT_PAIR;
+ 
+   *time+=att_time;
+ 
+   return 0;
+ }
+ 
+ template <typename T, typename E, typename FP>
+ int spline_reconstruct(
+     pszmem_cxx<T>* anchor, pszmem_cxx<E>* ectrl, pszmem_cxx<T>* xdata, T* outlier_tmp,
+     double eb, uint32_t radius, INTERPOLATION_PARAMS intp_param, float* time, void* stream)
+ {
+   constexpr auto BLOCK = 16;
+ 
+   auto div = [](auto _l, auto _subl) { return (_l - 1) / _subl + 1; };
+ 
+   auto ebx2 = eb * 2;
+   auto eb_r = 1 / eb;
+ 
+   auto l3 = xdata->template len3<dim3>();
+   auto grid_dim =
+       dim3(div(l3.x, BLOCK ), div(l3.y, BLOCK ), div(l3.z, BLOCK ));
+ 
+   CREATE_GPUEVENT_PAIR;
+   START_GPUEVENT_RECORDING(stream);
+ 
+   cusz::x_spline3d_infprecis_16x16x16data<E*, T*, float, DEFAULT_BLOCK_SIZE>   //
+       <<<grid_dim, dim3(DEFAULT_BLOCK_SIZE, 1, 1), 0, (GpuStreamT)stream>>>  //
+       (ectrl->dptr(), ectrl->template len3<dim3>(),
+        ectrl->template st3<dim3>(),  //
+        anchor->dptr(), anchor->template len3<dim3>(),
+        anchor->template st3<dim3>(),  //
+        xdata->dptr(), xdata->template len3<dim3>(),
+        xdata->template st3<dim3>(),  //
+        outlier_tmp,
+        eb_r, ebx2, radius, intp_param);
+ 
+   STOP_GPUEVENT_RECORDING(stream);
+   CHECK_GPU(GpuStreamSync(stream));
+   TIME_ELAPSED_GPUEVENT(time);
+   DESTROY_GPUEVENT_PAIR;
+ 
+   return 0;
+ }
+ 
+ #define INIT(T, E)                                                            \
+   template int spline_construct<T, E>(                                        \
+       pszmem_cxx<T> * data, pszmem_cxx<T> * anchor, pszmem_cxx<E> * ectrl,    \
+       void* _outlier, double eb, double rel_eb, uint32_t radius, struct INTERPOLATION_PARAMS &intp_param, float* time, void* stream, pszmem_cxx<T> * profiling_errors); \
+   template int spline_reconstruct<T, E>(                                      \
+       pszmem_cxx<T> * anchor, pszmem_cxx<E> * ectrl, pszmem_cxx<T> * xdata, T* outlier_tmp,  \
+       double eb, uint32_t radius, struct INTERPOLATION_PARAMS intp_param, float* time, void* stream);
+ 
+ INIT(f4, u1)
+ INIT(f4, u2)
+ INIT(f4, u4)
+ INIT(f4, f4)
+ 
+ //INIT(f8, u1)
+ //INIT(f8, u2)
+ //INIT(f8, u4)
+ //INIT(f8, f4)
+ 
+ #undef INIT
+ #undef SETUP
+ 

--- a/src/lc/comp-bitr.cu
+++ b/src/lc/comp-bitr.cu
@@ -1,0 +1,322 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef NDEBUG
+#define NDEBUG
+#endif
+
+using byte = unsigned char;
+static const int CS = 1024 * 16;  // chunk size (in bytes) [must be multiple of 8]
+static const int TPB = 512;  // threads per block [must be power of 2 and at least 128]
+#if defined(__AMDGCN_WAVEFRONT_SIZE) && (__AMDGCN_WAVEFRONT_SIZE == 64)
+#define WS 64
+#else
+#define WS 32
+#endif
+
+#include <string>
+#include <cmath>
+#include <cassert>
+#include <stdexcept>
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include "lc/sum_reduction.h"
+#include "lc/max_scan.h"
+#include "lc/prefix_sum.h"
+#include "lc/components/d_BIT_4.h"
+#include "lc/components/d_RRE_2.h"
+#include "lc/components/d_RZE_1.h"
+#include "lc/lc.h"
+
+// copy (len) bytes from shared memory (source) to global memory (destination)
+// source must we word aligned
+static inline __device__ void s2g(void* const __restrict__ destination, const void* const __restrict__ source, const int len)
+{
+  const int tid = threadIdx.x;
+  const byte* const __restrict__ input = (byte*)source;
+  byte* const __restrict__ output = (byte*)destination;
+  if (len < 128) {
+    if (tid < len) output[tid] = input[tid];
+  } else {
+    const int nonaligned = (int)(size_t)output;
+    const int wordaligned = (nonaligned + 3) & ~3;
+    const int linealigned = (nonaligned + 127) & ~127;
+    const int bcnt = wordaligned - nonaligned;
+    const int wcnt = (linealigned - wordaligned) / 4;
+    const int* const __restrict__ in_w = (int*)input;
+    if (bcnt == 0) {
+      int* const __restrict__ out_w = (int*)output;
+      if (tid < wcnt) out_w[tid] = in_w[tid];
+      for (int i = tid + wcnt; i < len / 4; i += TPB) {
+        out_w[i] = in_w[i];
+      }
+      if (tid < (len & 3)) {
+        const int i = len - 1 - tid;
+        output[i] = input[i];
+      }
+    } else {
+      const int shift = bcnt * 8;
+      const int rlen = len - bcnt;
+      int* const __restrict__ out_w = (int*)&output[bcnt];
+      if (tid < bcnt) output[tid] = input[tid];
+      if (tid < wcnt) out_w[tid] = __funnelshift_r(in_w[tid], in_w[tid + 1], shift);
+      for (int i = tid + wcnt; i < rlen / 4; i += TPB) {
+        out_w[i] = __funnelshift_r(in_w[i], in_w[i + 1], shift);
+      }
+      if (tid < (rlen & 3)) {
+        const int i = len - 1 - tid;
+        output[i] = input[i];
+      }
+    }
+  }
+}
+
+
+static __device__ int g_chunk_counter;
+
+
+static __global__ void d_reset()
+{
+  g_chunk_counter = 0;
+}
+
+
+static inline __device__ void propagate_carry(const int value, const int chunkID, volatile int* const __restrict__ fullcarry, int* const __restrict__ s_fullc)
+{
+  if (threadIdx.x == TPB - 1) {  // last thread
+    fullcarry[chunkID] = (chunkID == 0) ? value : -value;
+  }
+
+  if (chunkID != 0) {
+    if (threadIdx.x + WS >= TPB) {  // last warp
+      const int lane = threadIdx.x % WS;
+      const int cidm1ml = chunkID - 1 - lane;
+      int val = -1;
+      __syncwarp();  // not optional
+      do {
+        if (cidm1ml >= 0) {
+          val = fullcarry[cidm1ml];
+        }
+      } while ((__any_sync(~0, val == 0)) || (__all_sync(~0, val <= 0)));
+#if defined(WS) && (WS == 64)
+      const long long mask = __ballot_sync(~0, val > 0);
+      const int pos = __ffsll(mask) - 1;
+#else
+      const int mask = __ballot_sync(~0, val > 0);
+      const int pos = __ffs(mask) - 1;
+#endif
+      int partc = (lane < pos) ? -val : 0;
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+      partc = __reduce_add_sync(~0, partc);
+#else
+      partc += __shfl_xor_sync(~0, partc, 1);
+      partc += __shfl_xor_sync(~0, partc, 2);
+      partc += __shfl_xor_sync(~0, partc, 4);
+      partc += __shfl_xor_sync(~0, partc, 8);
+      partc += __shfl_xor_sync(~0, partc, 16);
+#endif
+      if (lane == pos) {
+        const int fullc = partc + val;
+        fullcarry[chunkID] = fullc + value;
+        *s_fullc = fullc;
+      }
+    }
+  }
+}
+
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 800)
+static __global__ __launch_bounds__(TPB, 3)
+#else
+static __global__ __launch_bounds__(TPB, 2)
+#endif
+void d_encode_bitr(const byte* const __restrict__ input, const int insize, byte* const __restrict__ output, int* const __restrict__ outsize, int* const __restrict__ fullcarry)
+{
+  // allocate shared memory buffer
+  __shared__ long long chunk [3 * (CS / sizeof(long long))];
+
+  // split into 3 shared memory buffers
+  byte* in = (byte*)&chunk[0 * (CS / sizeof(long long))];
+  byte* out = (byte*)&chunk[1 * (CS / sizeof(long long))];
+  byte* const temp = (byte*)&chunk[2 * (CS / sizeof(long long))];
+
+  // initialize
+  const int tid = threadIdx.x;
+  const int last = 3 * (CS / sizeof(long long)) - 2 - WS;
+  const int chunks = (insize + CS - 1) / CS;  // round up
+  int* const head_out = (int*)output;
+  unsigned short* const size_out = (unsigned short*)&head_out[1];
+  byte* const data_out = (byte*)&size_out[chunks];
+
+  // loop over chunks
+  do {
+    // assign work dynamically
+    if (tid == 0) chunk[last] = atomicAdd(&g_chunk_counter, 1);
+    __syncthreads();  // chunk[last] produced, chunk consumed
+
+    // terminate if done
+    const int chunkID = chunk[last];
+    const int base = chunkID * CS;
+    if (base >= insize) break;
+
+    // load chunk
+    const int osize = min(CS, insize - base);
+    long long* const input_l = (long long*)&input[base];
+    long long* const out_l = (long long*)out;
+    for (int i = tid; i < osize / 8; i += TPB) {
+      out_l[i] = input_l[i];
+    }
+    const int extra = osize % 8;
+    if (tid < extra) out[osize - extra + tid] = input[base + osize - extra + tid];
+
+    // encode chunk
+    __syncthreads();  // chunk produced, chunk[last] consumed
+    int csize = osize;
+    bool good = true;
+    if (good) {
+      byte* tmp = in; in = out; out = tmp;
+      good = d_BIT_4(csize, in, out, temp);
+     __syncthreads();
+    }
+    if (good) {
+      byte* tmp = in; in = out; out = tmp;
+      good = d_RRE_2(csize, in, out, temp);
+     __syncthreads();
+    }
+    if (good) {
+      byte* tmp = in; in = out; out = tmp;
+      good = d_RZE_1(csize, in, out, temp);
+     __syncthreads();
+    }
+
+    // handle carry
+    if (!good || (csize >= osize)) csize = osize;
+    propagate_carry(csize, chunkID, fullcarry, (int*)temp);
+
+    // reload chunk if incompressible
+    if (tid == 0) size_out[chunkID] = csize;
+    if (csize == osize) {
+      // store original data
+      long long* const out_l = (long long*)out;
+      for (int i = tid; i < osize / 8; i += TPB) {
+        out_l[i] = input_l[i];
+      }
+      const int extra = osize % 8;
+      if (tid < extra) out[osize - extra + tid] = input[base + osize - extra + tid];
+    }
+    __syncthreads();  // "out" done, temp produced
+
+    // store chunk
+    const int offs = (chunkID == 0) ? 0 : *((int*)temp);
+    s2g(&data_out[offs], out, csize);
+
+    // finalize if last chunk
+    if ((tid == 0) && (base + CS >= insize)) {
+      // output header
+      head_out[0] = insize;
+      // compute compressed size
+      *outsize = &data_out[fullcarry[chunkID]] - output;
+    }
+  } while (true);
+}
+
+
+struct GPUTimer
+{
+  cudaEvent_t beg, end;
+  GPUTimer() {cudaEventCreate(&beg); cudaEventCreate(&end);}
+  ~GPUTimer() {cudaEventDestroy(beg); cudaEventDestroy(end);}
+  void start() {cudaEventRecord(beg, 0);}
+  double stop() {cudaEventRecord(end, 0); cudaEventSynchronize(end); float ms; cudaEventElapsedTime(&ms, beg, end); return ms;}
+};
+
+
+static void CheckCuda(const int line)
+{
+  cudaError_t e;
+  cudaDeviceSynchronize();
+  if (cudaSuccess != (e = cudaGetLastError())) {
+    fprintf(stderr, "CUDA error %d on line %d: %s\n\n", e, line, cudaGetErrorString(e));
+    throw std::runtime_error("LC error");
+  }
+}
+
+
+void BITR_COMPRESS(uint8_t* input, size_t insize, uint8_t** output, size_t* outsize, float* time, void* stream)
+{
+  // get GPU info
+  cudaSetDevice(0);
+  cudaDeviceProp deviceProp;
+  cudaGetDeviceProperties(&deviceProp, 0);
+  if ((deviceProp.major == 9999) && (deviceProp.minor == 9999)) {fprintf(stderr, "ERROR: no CUDA capable device detected\n\n"); throw std::runtime_error("LC error");}
+  const int SMs = deviceProp.multiProcessorCount;
+  const int mTpSM = deviceProp.maxThreadsPerMultiProcessor;
+  const int blocks = SMs * (mTpSM / TPB);
+  const int chunks = (insize + CS - 1) / CS;  // round up
+  CheckCuda(__LINE__);
+  const int maxsize = 3 * sizeof(int) + chunks * sizeof(short) + chunks * CS;
+
+  byte* d_encoded;
+  cudaMalloc((void **)&d_encoded, maxsize);
+  int* d_encsize;
+  cudaMalloc((void **)&d_encsize, sizeof(int));
+  CheckCuda(__LINE__);
+
+
+  int* d_fullcarry;
+  cudaMalloc((void **)&d_fullcarry, chunks * sizeof(int));
+  d_reset<<<1, 1>>>();
+  cudaMemset(d_fullcarry, 0, chunks * sizeof(int));
+  GPUTimer dtimer;
+  dtimer.start();
+  d_encode_bitr<<<blocks, TPB>>>(input, (int)insize, d_encoded, d_encsize, d_fullcarry);
+  *time = (float)dtimer.stop();
+  cudaFree(d_fullcarry);
+  CheckCuda(__LINE__);
+
+
+  // get encoded GPU result
+  int dencsize = 0;
+  cudaMemcpy(&dencsize, d_encsize, sizeof(int), cudaMemcpyDeviceToHost);
+  
+  *outsize = (size_t)(dencsize);
+  *output = d_encoded;
+
+  CheckCuda(__LINE__);
+}

--- a/src/lc/comp-rtr.cu
+++ b/src/lc/comp-rtr.cu
@@ -1,0 +1,322 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef NDEBUG
+#define NDEBUG
+#endif
+
+using byte = unsigned char;
+static const int CS = 1024 * 16;  // chunk size (in bytes) [must be multiple of 8]
+static const int TPB = 512;  // threads per block [must be power of 2 and at least 128]
+#if defined(__AMDGCN_WAVEFRONT_SIZE) && (__AMDGCN_WAVEFRONT_SIZE == 64)
+#define WS 64
+#else
+#define WS 32
+#endif
+
+#include <string>
+#include <cmath>
+#include <cassert>
+#include <stdexcept>
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include "lc/sum_reduction.h"
+#include "lc/max_scan.h"
+#include "lc/prefix_sum.h"
+#include "lc/components/d_RRE_4.h"
+#include "lc/components/d_TCMS_8.h"
+#include "lc/components/d_RZE_1.h"
+#include "lc/lc.h"
+
+// copy (len) bytes from shared memory (source) to global memory (destination)
+// source must we word aligned
+static inline __device__ void s2g(void* const __restrict__ destination, const void* const __restrict__ source, const int len)
+{
+  const int tid = threadIdx.x;
+  const byte* const __restrict__ input = (byte*)source;
+  byte* const __restrict__ output = (byte*)destination;
+  if (len < 128) {
+    if (tid < len) output[tid] = input[tid];
+  } else {
+    const int nonaligned = (int)(size_t)output;
+    const int wordaligned = (nonaligned + 3) & ~3;
+    const int linealigned = (nonaligned + 127) & ~127;
+    const int bcnt = wordaligned - nonaligned;
+    const int wcnt = (linealigned - wordaligned) / 4;
+    const int* const __restrict__ in_w = (int*)input;
+    if (bcnt == 0) {
+      int* const __restrict__ out_w = (int*)output;
+      if (tid < wcnt) out_w[tid] = in_w[tid];
+      for (int i = tid + wcnt; i < len / 4; i += TPB) {
+        out_w[i] = in_w[i];
+      }
+      if (tid < (len & 3)) {
+        const int i = len - 1 - tid;
+        output[i] = input[i];
+      }
+    } else {
+      const int shift = bcnt * 8;
+      const int rlen = len - bcnt;
+      int* const __restrict__ out_w = (int*)&output[bcnt];
+      if (tid < bcnt) output[tid] = input[tid];
+      if (tid < wcnt) out_w[tid] = __funnelshift_r(in_w[tid], in_w[tid + 1], shift);
+      for (int i = tid + wcnt; i < rlen / 4; i += TPB) {
+        out_w[i] = __funnelshift_r(in_w[i], in_w[i + 1], shift);
+      }
+      if (tid < (rlen & 3)) {
+        const int i = len - 1 - tid;
+        output[i] = input[i];
+      }
+    }
+  }
+}
+
+
+static __device__ int g_chunk_counter;
+
+
+static __global__ void d_reset()
+{
+  g_chunk_counter = 0;
+}
+
+
+static inline __device__ void propagate_carry(const int value, const int chunkID, volatile int* const __restrict__ fullcarry, int* const __restrict__ s_fullc)
+{
+  if (threadIdx.x == TPB - 1) {  // last thread
+    fullcarry[chunkID] = (chunkID == 0) ? value : -value;
+  }
+
+  if (chunkID != 0) {
+    if (threadIdx.x + WS >= TPB) {  // last warp
+      const int lane = threadIdx.x % WS;
+      const int cidm1ml = chunkID - 1 - lane;
+      int val = -1;
+      __syncwarp();  // not optional
+      do {
+        if (cidm1ml >= 0) {
+          val = fullcarry[cidm1ml];
+        }
+      } while ((__any_sync(~0, val == 0)) || (__all_sync(~0, val <= 0)));
+#if defined(WS) && (WS == 64)
+      const long long mask = __ballot_sync(~0, val > 0);
+      const int pos = __ffsll(mask) - 1;
+#else
+      const int mask = __ballot_sync(~0, val > 0);
+      const int pos = __ffs(mask) - 1;
+#endif
+      int partc = (lane < pos) ? -val : 0;
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+      partc = __reduce_add_sync(~0, partc);
+#else
+      partc += __shfl_xor_sync(~0, partc, 1);
+      partc += __shfl_xor_sync(~0, partc, 2);
+      partc += __shfl_xor_sync(~0, partc, 4);
+      partc += __shfl_xor_sync(~0, partc, 8);
+      partc += __shfl_xor_sync(~0, partc, 16);
+#endif
+      if (lane == pos) {
+        const int fullc = partc + val;
+        fullcarry[chunkID] = fullc + value;
+        *s_fullc = fullc;
+      }
+    }
+  }
+}
+
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 800)
+static __global__ __launch_bounds__(TPB, 3)
+#else
+static __global__ __launch_bounds__(TPB, 2)
+#endif
+void d_encode_rtr(const byte* const __restrict__ input, const int insize, byte* const __restrict__ output, int* const __restrict__ outsize, int* const __restrict__ fullcarry)
+{
+  // allocate shared memory buffer
+  __shared__ long long chunk [3 * (CS / sizeof(long long))];
+
+  // split into 3 shared memory buffers
+  byte* in = (byte*)&chunk[0 * (CS / sizeof(long long))];
+  byte* out = (byte*)&chunk[1 * (CS / sizeof(long long))];
+  byte* const temp = (byte*)&chunk[2 * (CS / sizeof(long long))];
+
+  // initialize
+  const int tid = threadIdx.x;
+  const int last = 3 * (CS / sizeof(long long)) - 2 - WS;
+  const int chunks = (insize + CS - 1) / CS;  // round up
+  int* const head_out = (int*)output;
+  unsigned short* const size_out = (unsigned short*)&head_out[1];
+  byte* const data_out = (byte*)&size_out[chunks];
+
+  // loop over chunks
+  do {
+    // assign work dynamically
+    if (tid == 0) chunk[last] = atomicAdd(&g_chunk_counter, 1);
+    __syncthreads();  // chunk[last] produced, chunk consumed
+
+    // terminate if done
+    const int chunkID = chunk[last];
+    const int base = chunkID * CS;
+    if (base >= insize) break;
+
+    // load chunk
+    const int osize = min(CS, insize - base);
+    long long* const input_l = (long long*)&input[base];
+    long long* const out_l = (long long*)out;
+    for (int i = tid; i < osize / 8; i += TPB) {
+      out_l[i] = input_l[i];
+    }
+    const int extra = osize % 8;
+    if (tid < extra) out[osize - extra + tid] = input[base + osize - extra + tid];
+
+    // encode chunk
+    __syncthreads();  // chunk produced, chunk[last] consumed
+    int csize = osize;
+    bool good = true;
+    if (good) {
+      byte* tmp = in; in = out; out = tmp;
+      good = d_RRE_4(csize, in, out, temp);
+     __syncthreads();
+    }
+    if (good) {
+      byte* tmp = in; in = out; out = tmp;
+      good = d_TCMS_8(csize, in, out, temp);
+     __syncthreads();
+    }
+    if (good) {
+      byte* tmp = in; in = out; out = tmp;
+      good = d_RZE_1(csize, in, out, temp);
+     __syncthreads();
+    }
+
+    // handle carry
+    if (!good || (csize >= osize)) csize = osize;
+    propagate_carry(csize, chunkID, fullcarry, (int*)temp);
+
+    // reload chunk if incompressible
+    if (tid == 0) size_out[chunkID] = csize;
+    if (csize == osize) {
+      // store original data
+      long long* const out_l = (long long*)out;
+      for (int i = tid; i < osize / 8; i += TPB) {
+        out_l[i] = input_l[i];
+      }
+      const int extra = osize % 8;
+      if (tid < extra) out[osize - extra + tid] = input[base + osize - extra + tid];
+    }
+    __syncthreads();  // "out" done, temp produced
+
+    // store chunk
+    const int offs = (chunkID == 0) ? 0 : *((int*)temp);
+    s2g(&data_out[offs], out, csize);
+
+    // finalize if last chunk
+    if ((tid == 0) && (base + CS >= insize)) {
+      // output header
+      head_out[0] = insize;
+      // compute compressed size
+      *outsize = &data_out[fullcarry[chunkID]] - output;
+    }
+  } while (true);
+}
+
+
+struct GPUTimer
+{
+  cudaEvent_t beg, end;
+  GPUTimer() {cudaEventCreate(&beg); cudaEventCreate(&end);}
+  ~GPUTimer() {cudaEventDestroy(beg); cudaEventDestroy(end);}
+  void start() {cudaEventRecord(beg, 0);}
+  double stop() {cudaEventRecord(end, 0); cudaEventSynchronize(end); float ms; cudaEventElapsedTime(&ms, beg, end); return ms;}
+};
+
+
+static void CheckCuda(const int line)
+{
+  cudaError_t e;
+  cudaDeviceSynchronize();
+  if (cudaSuccess != (e = cudaGetLastError())) {
+    fprintf(stderr, "CUDA error %d on line %d: %s\n\n", e, line, cudaGetErrorString(e));
+    throw std::runtime_error("LC error");
+  }
+}
+
+
+void RTR_COMPRESS(uint8_t* input, size_t insize, uint8_t** output, size_t* outsize, float* time, void* stream)
+{
+  // get GPU info
+  cudaSetDevice(0);
+  cudaDeviceProp deviceProp;
+  cudaGetDeviceProperties(&deviceProp, 0);
+  if ((deviceProp.major == 9999) && (deviceProp.minor == 9999)) {fprintf(stderr, "ERROR: no CUDA capable device detected\n\n"); throw std::runtime_error("LC error");}
+  const int SMs = deviceProp.multiProcessorCount;
+  const int mTpSM = deviceProp.maxThreadsPerMultiProcessor;
+  const int blocks = SMs * (mTpSM / TPB);
+  const int chunks = (insize + CS - 1) / CS;  // round up
+  CheckCuda(__LINE__);
+  const int maxsize = 3 * sizeof(int) + chunks * sizeof(short) + chunks * CS;
+
+  byte* d_encoded;
+  cudaMalloc((void **)&d_encoded, maxsize);
+  int* d_encsize;
+  cudaMalloc((void **)&d_encsize, sizeof(int));
+  CheckCuda(__LINE__);
+
+  
+  int* d_fullcarry;
+  cudaMalloc((void **)&d_fullcarry, chunks * sizeof(int));
+  d_reset<<<1, 1>>>();
+  cudaMemset(d_fullcarry, 0, chunks * sizeof(int));
+  GPUTimer dtimer;
+  dtimer.start();
+  d_encode_rtr<<<blocks, TPB>>>(input, (int)insize, d_encoded, d_encsize, d_fullcarry);
+  *time = (float)dtimer.stop();
+  cudaFree(d_fullcarry);
+  CheckCuda(__LINE__);
+ 
+
+  // get encoded GPU result
+  int dencsize = 0;
+  cudaMemcpy(&dencsize, d_encsize, sizeof(int), cudaMemcpyDeviceToHost);
+
+  *outsize = (size_t)(dencsize);
+  *output = d_encoded;
+
+  CheckCuda(__LINE__);
+}

--- a/src/lc/comp-tcms.cu
+++ b/src/lc/comp-tcms.cu
@@ -1,0 +1,326 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+
+#ifndef NDEBUG
+#define NDEBUG
+#endif
+
+using byte = unsigned char;
+static const int CS = 1024 * 16;  // chunk size (in bytes) [must be multiple of 8]
+static const int TPB = 512;  // threads per block [must be power of 2 and at least 128]
+#if defined(__AMDGCN_WAVEFRONT_SIZE) && (__AMDGCN_WAVEFRONT_SIZE == 64)
+#define WS 64
+#else
+#define WS 32
+#endif
+
+#include <string>
+#include <cmath>
+#include <cassert>
+#include <stdexcept>
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include "lc/sum_reduction.h"
+#include "lc/max_scan.h"
+#include "lc/prefix_sum.h"
+#include "lc/components/d_TCMS_1.h"
+#include "lc/components/d_BIT_1.h"
+#include "lc/components/d_RRE_1.h"
+#include "lc/lc.h"
+
+// copy (len) bytes from shared memory (source) to global memory (destination)
+// source must we word aligned
+static inline __device__ void s2g(void* const __restrict__ destination, const void* const __restrict__ source, const int len)
+{
+  const int tid = threadIdx.x;
+  const byte* const __restrict__ input = (byte*)source;
+  byte* const __restrict__ output = (byte*)destination;
+  if (len < 128) {
+    if (tid < len) output[tid] = input[tid];
+  } else {
+    const int nonaligned = (int)(size_t)output;
+    const int wordaligned = (nonaligned + 3) & ~3;
+    const int linealigned = (nonaligned + 127) & ~127;
+    const int bcnt = wordaligned - nonaligned;
+    const int wcnt = (linealigned - wordaligned) / 4;
+    const int* const __restrict__ in_w = (int*)input;
+    if (bcnt == 0) {
+      int* const __restrict__ out_w = (int*)output;
+      if (tid < wcnt) out_w[tid] = in_w[tid];
+      for (int i = tid + wcnt; i < len / 4; i += TPB) {
+        out_w[i] = in_w[i];
+      }
+      if (tid < (len & 3)) {
+        const int i = len - 1 - tid;
+        output[i] = input[i];
+      }
+    } else {
+      const int shift = bcnt * 8;
+      const int rlen = len - bcnt;
+      int* const __restrict__ out_w = (int*)&output[bcnt];
+      if (tid < bcnt) output[tid] = input[tid];
+      if (tid < wcnt) out_w[tid] = __funnelshift_r(in_w[tid], in_w[tid + 1], shift);
+      for (int i = tid + wcnt; i < rlen / 4; i += TPB) {
+        out_w[i] = __funnelshift_r(in_w[i], in_w[i + 1], shift);
+      }
+      if (tid < (rlen & 3)) {
+        const int i = len - 1 - tid;
+        output[i] = input[i];
+      }
+    }
+  }
+}
+
+
+static __device__ int g_chunk_counter;
+
+
+static __global__ void d_reset()
+{
+  g_chunk_counter = 0;
+}
+
+
+static inline __device__ void propagate_carry(const int value, const int chunkID, volatile int* const __restrict__ fullcarry, int* const __restrict__ s_fullc)
+{
+  if (threadIdx.x == TPB - 1) {  // last thread
+    fullcarry[chunkID] = (chunkID == 0) ? value : -value;
+  }
+
+  if (chunkID != 0) {
+    if (threadIdx.x + WS >= TPB) {  // last warp
+      const int lane = threadIdx.x % WS;
+      const int cidm1ml = chunkID - 1 - lane;
+      int val = -1;
+      __syncwarp();  // not optional
+      do {
+        if (cidm1ml >= 0) {
+          val = fullcarry[cidm1ml];
+        }
+      } while ((__any_sync(~0, val == 0)) || (__all_sync(~0, val <= 0)));
+#if defined(WS) && (WS == 64)
+      const long long mask = __ballot_sync(~0, val > 0);
+      const int pos = __ffsll(mask) - 1;
+#else
+      const int mask = __ballot_sync(~0, val > 0);
+      const int pos = __ffs(mask) - 1;
+#endif
+      int partc = (lane < pos) ? -val : 0;
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+      partc = __reduce_add_sync(~0, partc);
+#else
+      partc += __shfl_xor_sync(~0, partc, 1);
+      partc += __shfl_xor_sync(~0, partc, 2);
+      partc += __shfl_xor_sync(~0, partc, 4);
+      partc += __shfl_xor_sync(~0, partc, 8);
+      partc += __shfl_xor_sync(~0, partc, 16);
+#endif
+      if (lane == pos) {
+        const int fullc = partc + val;
+        fullcarry[chunkID] = fullc + value;
+        *s_fullc = fullc;
+      }
+    }
+  }
+}
+
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 800)
+static __global__ __launch_bounds__(TPB, 3)
+#else
+static __global__ __launch_bounds__(TPB, 2)
+#endif
+void d_encode_tcms(const byte* const __restrict__ input, const int insize, byte* const __restrict__ output, int* const __restrict__ outsize, int* const __restrict__ fullcarry)
+{
+  // allocate shared memory buffer
+  __shared__ long long chunk [3 * (CS / sizeof(long long))];
+
+  // split into 3 shared memory buffers
+  byte* in = (byte*)&chunk[0 * (CS / sizeof(long long))];
+  byte* out = (byte*)&chunk[1 * (CS / sizeof(long long))];
+  byte* const temp = (byte*)&chunk[2 * (CS / sizeof(long long))];
+
+  // initialize
+  const int tid = threadIdx.x;
+  const int last = 3 * (CS / sizeof(long long)) - 2 - WS;
+  const int chunks = (insize + CS - 1) / CS;  // round up
+  int* const head_out = (int*)output;
+  unsigned short* const size_out = (unsigned short*)&head_out[1];
+  byte* const data_out = (byte*)&size_out[chunks];
+
+  // loop over chunks
+  do {
+    // assign work dynamically
+    if (tid == 0) chunk[last] = atomicAdd(&g_chunk_counter, 1);
+    __syncthreads();  // chunk[last] produced, chunk consumed
+
+    // terminate if done
+    const int chunkID = chunk[last];
+    const int base = chunkID * CS;
+    if (base >= insize) break;
+
+    // load chunk
+    const int osize = min(CS, insize - base);
+    long long* const input_l = (long long*)&input[base];
+    long long* const out_l = (long long*)out;
+    for (int i = tid; i < osize / 8; i += TPB) {
+      out_l[i] = input_l[i];
+    }
+    const int extra = osize % 8;
+    if (tid < extra) out[osize - extra + tid] = input[base + osize - extra + tid];
+
+    // encode chunk
+    __syncthreads();  // chunk produced, chunk[last] consumed
+    int csize = osize;
+    bool good = true;
+    if (good) {
+      byte* tmp = in; in = out; out = tmp;
+      good = d_TCMS_1(csize, in, out, temp);
+     __syncthreads();
+    }
+    if (good) {
+      byte* tmp = in; in = out; out = tmp;
+      good = d_BIT_1(csize, in, out, temp);
+     __syncthreads();
+    }
+    if (good) {
+      byte* tmp = in; in = out; out = tmp;
+      good = d_RRE_1(csize, in, out, temp);
+     __syncthreads();
+    }
+
+    // handle carry
+    if (!good || (csize >= osize)) csize = osize;
+    propagate_carry(csize, chunkID, fullcarry, (int*)temp);
+
+    // reload chunk if incompressible
+    if (tid == 0) size_out[chunkID] = csize;
+    if (csize == osize) {
+      // store original data
+      long long* const out_l = (long long*)out;
+      for (int i = tid; i < osize / 8; i += TPB) {
+        out_l[i] = input_l[i];
+      }
+      const int extra = osize % 8;
+      if (tid < extra) out[osize - extra + tid] = input[base + osize - extra + tid];
+    }
+    __syncthreads();  // "out" done, temp produced
+
+    // store chunk
+    const int offs = (chunkID == 0) ? 0 : *((int*)temp);
+    s2g(&data_out[offs], out, csize);
+
+    // finalize if last chunk
+    if ((tid == 0) && (base + CS >= insize)) {
+      // output header
+      head_out[0] = insize;
+      // compute compressed size
+      *outsize = &data_out[fullcarry[chunkID]] - output;
+    }
+  } while (true);
+}
+
+
+struct GPUTimer
+{
+  cudaEvent_t beg, end;
+  GPUTimer() {cudaEventCreate(&beg); cudaEventCreate(&end);}
+  ~GPUTimer() {cudaEventDestroy(beg); cudaEventDestroy(end);}
+  void start() {cudaEventRecord(beg, 0);}
+  double stop() {cudaEventRecord(end, 0); cudaEventSynchronize(end); float ms; cudaEventElapsedTime(&ms, beg, end); return ms;}
+};
+
+
+static void CheckCuda(const int line)
+{
+  cudaError_t e;
+  cudaDeviceSynchronize();
+  if (cudaSuccess != (e = cudaGetLastError())) {
+    fprintf(stderr, "CUDA error %d on line %d: %s\n\n", e, line, cudaGetErrorString(e));
+    throw std::runtime_error("LC error");
+  }
+}
+
+
+void TCMS_COMPRESS(uint8_t* input, size_t insize, uint8_t** output, size_t* outsize, float* time, void* stream)
+{
+  // get GPU info
+  cudaSetDevice(0);
+  cudaDeviceProp deviceProp;
+  cudaGetDeviceProperties(&deviceProp, 0);
+  if ((deviceProp.major == 9999) && (deviceProp.minor == 9999)) {fprintf(stderr, "ERROR: no CUDA capable device detected\n\n"); throw std::runtime_error("LC error");}
+  const int SMs = deviceProp.multiProcessorCount;
+  const int mTpSM = deviceProp.maxThreadsPerMultiProcessor;
+  const int blocks = SMs * (mTpSM / TPB);
+  const int chunks = (insize + CS - 1) / CS;  // round up
+  CheckCuda(__LINE__);
+  const int maxsize = 3 * sizeof(int) + chunks * sizeof(short) + chunks * CS + 7;
+
+  byte* d_encoded;
+  cudaMalloc((void **)&d_encoded, maxsize);
+  int* d_encsize;
+  cudaMalloc((void **)&d_encsize, sizeof(int));
+  CheckCuda(__LINE__);
+
+
+  int* d_fullcarry;
+  cudaMalloc((void **)&d_fullcarry, chunks * sizeof(int));
+  d_reset<<<1, 1>>>();
+  cudaMemset(d_fullcarry, 0, chunks * sizeof(int));
+  GPUTimer dtimer;
+  dtimer.start();
+  d_encode_tcms<<<blocks, TPB>>>(input, (int)insize, d_encoded, d_encsize, d_fullcarry);
+  *time = (float)dtimer.stop();
+  cudaFree(d_fullcarry);
+  CheckCuda(__LINE__);
+
+
+  // get encoded GPU result
+  int dencsize = 0;
+  cudaMemcpy(&dencsize, d_encsize, sizeof(int), cudaMemcpyDeviceToHost);
+    
+  // Calculate padding needed for 8-byte alignment
+  size_t padding = (8 - (dencsize % 8)) % 8;
+
+  // Round up size to 8-byte alignment
+  *outsize = (size_t)(dencsize + padding);
+  *output = d_encoded;
+  
+  CheckCuda(__LINE__);
+}

--- a/src/lc/decomp-bitr.cu
+++ b/src/lc/decomp-bitr.cu
@@ -1,0 +1,275 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+#ifndef NDEBUG
+#define NDEBUG
+#endif
+
+using byte = unsigned char;
+static const int CS = 1024 * 16;  // chunk size (in bytes) [must be multiple of 8]
+static const int TPB = 512;  // threads per block [must be power of 2 and at least 128]
+#if defined(__AMDGCN_WAVEFRONT_SIZE) && (__AMDGCN_WAVEFRONT_SIZE == 64)
+#define WS 64
+#else
+#define WS 32
+#endif
+
+#include <cmath>
+#include <string>
+#include <cassert>
+#include <stdexcept>
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include "lc/sum_reduction.h"
+#include "lc/max_scan.h"
+#include "lc/prefix_sum.h"
+#include "lc/components/d_BIT_4.h"
+#include "lc/components/d_RRE_2.h"
+#include "lc/components/d_RZE_1.h"
+#include "lc/lc.h"
+
+
+// copy (len) bytes from global memory (source) to shared memory (destination) using separate shared memory buffer (temp)
+// destination and temp must we word aligned, accesses up to CS + 3 bytes in temp
+static inline __device__ void g2s(void* const __restrict__ destination, const void* const __restrict__ source, const int len, void* const __restrict__ temp)
+{
+  const int tid = threadIdx.x;
+  const byte* const __restrict__ input = (byte*)source;
+  if (len < 128) {
+    byte* const __restrict__ output = (byte*)destination;
+    if (tid < len) output[tid] = input[tid];
+  } else {
+    const int nonaligned = (int)(size_t)input;
+    const int wordaligned = (nonaligned + 3) & ~3;
+    const int linealigned = (nonaligned + 127) & ~127;
+    const int bcnt = wordaligned - nonaligned;
+    const int wcnt = (linealigned - wordaligned) / 4;
+    int* const __restrict__ out_w = (int*)destination;
+    if (bcnt == 0) {
+      const int* const __restrict__ in_w = (int*)input;
+      byte* const __restrict__ out = (byte*)destination;
+      if (tid < wcnt) out_w[tid] = in_w[tid];
+      for (int i = tid + wcnt; i < len / 4; i += TPB) {
+        out_w[i] = in_w[i];
+      }
+      if (tid < (len & 3)) {
+        const int i = len - 1 - tid;
+        out[i] = input[i];
+      }
+    } else {
+      const int offs = 4 - bcnt;  //(4 - bcnt) & 3;
+      const int shift = offs * 8;
+      const int rlen = len - bcnt;
+      const int* const __restrict__ in_w = (int*)&input[bcnt];
+      byte* const __restrict__ buffer = (byte*)temp;
+      byte* const __restrict__ buf = (byte*)&buffer[offs];
+      int* __restrict__ buf_w = (int*)&buffer[4];  //(int*)&buffer[(bcnt + 3) & 4];
+      if (tid < bcnt) buf[tid] = input[tid];
+      if (tid < wcnt) buf_w[tid] = in_w[tid];
+      for (int i = tid + wcnt; i < rlen / 4; i += TPB) {
+        buf_w[i] = in_w[i];
+      }
+      if (tid < (rlen & 3)) {
+        const int i = len - 1 - tid;
+        buf[i] = input[i];
+      }
+      __syncthreads();
+      buf_w = (int*)buffer;
+      for (int i = tid; i < (len + 3) / 4; i += TPB) {
+        out_w[i] = __funnelshift_r(buf_w[i], buf_w[i + 1], shift);
+      }
+    }
+  }
+}
+
+
+static __device__ int g_chunk_counter;
+
+
+static __global__ void d_reset()
+{
+  g_chunk_counter = 0;
+}
+
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 800)
+static __global__ __launch_bounds__(TPB, 3)
+#else
+static __global__ __launch_bounds__(TPB, 2)
+#endif
+void d_decode_bitr(const byte* const __restrict__ input, byte* const __restrict__ output, int* const __restrict__ g_outsize)
+{
+  // allocate shared memory buffer
+  __shared__ long long chunk [3 * (CS / sizeof(long long))];
+  const int last = 3 * (CS / sizeof(long long)) - 2 - WS;
+
+  // input header
+  int* const head_in = (int*)input;
+  const int outsize = head_in[0];
+
+  // initialize
+  const int chunks = (outsize + CS - 1) / CS;  // round up
+  unsigned short* const size_in = (unsigned short*)&head_in[1];
+  byte* const data_in = (byte*)&size_in[chunks];
+
+  // loop over chunks
+  const int tid = threadIdx.x;
+  int prevChunkID = 0;
+  int prevOffset = 0;
+  do {
+    // assign work dynamically
+    if (tid == 0) chunk[last] = atomicAdd(&g_chunk_counter, 1);
+    __syncthreads();  // chunk[last] produced, chunk consumed
+
+    // terminate if done
+    const int chunkID = chunk[last];
+    const int base = chunkID * CS;
+    if (base >= outsize) break;
+
+    // compute sum of all prior csizes (start where left off in previous iteration)
+    int sum = 0;
+    for (int i = prevChunkID + tid; i < chunkID; i += TPB) {
+      sum += (int)size_in[i];
+    }
+    int csize = (int)size_in[chunkID];
+    const int offs = prevOffset + block_sum_reduction(sum, (int*)&chunk[last + 1]);
+    prevChunkID = chunkID;
+    prevOffset = offs;
+
+    // create the 3 shared memory buffers
+    byte* in = (byte*)&chunk[0 * (CS / sizeof(long long))];
+    byte* out = (byte*)&chunk[1 * (CS / sizeof(long long))];
+    byte* temp = (byte*)&chunk[2 * (CS / sizeof(long long))];
+
+    // load chunk
+    g2s(in, &data_in[offs], csize, out);
+    byte* tmp = in; in = out; out = tmp;
+    __syncthreads();  // chunk produced, chunk[last] consumed
+
+    // decode
+    const int osize = min(CS, outsize - base);
+    if (csize < osize) {
+      byte* tmp;
+     tmp = in; in = out; out = tmp;
+      d_iRZE_1(csize, in, out,temp);
+      __syncthreads();
+     tmp = in; in = out; out = tmp;
+      d_iRRE_2(csize, in, out,temp);
+      __syncthreads();
+     tmp = in; in = out; out = tmp;
+      d_iBIT_4(csize, in, out,temp);
+      __syncthreads();
+     }
+
+    if (csize != osize) {printf("ERROR: csize %d doesn't match osize %d in chunk %d\n\n", csize, osize, chunkID); __trap();}
+    long long* const output_l = (long long*)&output[base];
+    long long* const out_l = (long long*)out;
+    for (int i = tid; i < osize / 8; i += TPB) {
+      output_l[i] = out_l[i];
+    }
+    const int extra = osize % 8;
+    if (tid < extra) output[base + osize - extra + tid] = out[osize - extra + tid];
+  } while (true);
+
+  if ((blockIdx.x == 0) && (tid == 0)) {
+    *g_outsize = outsize;
+  }
+}
+
+
+struct GPUTimer
+{
+  cudaEvent_t beg, end;
+  GPUTimer() {cudaEventCreate(&beg); cudaEventCreate(&end);}
+  ~GPUTimer() {cudaEventDestroy(beg); cudaEventDestroy(end);}
+  void start() {cudaEventRecord(beg, 0);}
+  double stop() {cudaEventRecord(end, 0); cudaEventSynchronize(end); float ms; cudaEventElapsedTime(&ms, beg, end); return ms;}
+};
+
+
+static void CheckCuda(const int line)
+{
+  cudaError_t e;
+  cudaDeviceSynchronize();
+  if (cudaSuccess != (e = cudaGetLastError())) {
+    fprintf(stderr, "CUDA error %d on line %d: %s\n\n", e, line, cudaGetErrorString(e));
+    throw std::runtime_error("LC error");
+  }
+}
+
+
+void BITR_DECOMPRESS(uint8_t* input, void** output, float* time)
+{ 
+  int pre_size;
+  cudaMemcpy(&pre_size, input, sizeof(int), cudaMemcpyDeviceToHost);
+
+  // get GPU info
+  cudaSetDevice(0);
+  cudaDeviceProp deviceProp;
+  cudaGetDeviceProperties(&deviceProp, 0);
+  if ((deviceProp.major == 9999) && (deviceProp.minor == 9999)) {fprintf(stderr, "ERROR: no CUDA capable device detected\n\n"); throw std::runtime_error("LC error");}
+  const int SMs = deviceProp.multiProcessorCount;
+  const int mTpSM = deviceProp.maxThreadsPerMultiProcessor;
+  const int blocks = SMs * (mTpSM / TPB);
+  CheckCuda(__LINE__);
+
+  // allocate GPU memory
+  byte* d_decoded;
+  cudaMalloc((void **)&d_decoded, pre_size);
+  int* d_decsize;
+  cudaMalloc((void **)&d_decsize, sizeof(int));
+  CheckCuda(__LINE__);
+
+  // warm up
+  byte* d_decoded_dummy;
+  cudaMalloc((void **)&d_decoded_dummy, pre_size);
+  int* d_decsize_dummy;
+  cudaMalloc((void **)&d_decsize_dummy, sizeof(int));
+  d_decode_bitr<<<blocks, TPB>>>(input, d_decoded_dummy, d_decsize_dummy);
+  cudaFree(d_decoded_dummy);
+  cudaFree(d_decsize_dummy);
+
+  // time GPU decoding
+  GPUTimer dtimer;
+  dtimer.start();
+  d_reset<<<1, 1>>>();
+  d_decode_bitr<<<blocks, TPB>>>(input, d_decoded, d_decsize);
+  *time = (float)dtimer.stop();
+  CheckCuda(__LINE__);
+  *output = d_decoded;
+}

--- a/src/lc/decomp-rtr.cu
+++ b/src/lc/decomp-rtr.cu
@@ -1,0 +1,275 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+#ifndef NDEBUG
+#define NDEBUG
+#endif
+
+using byte = unsigned char;
+static const int CS = 1024 * 16;  // chunk size (in bytes) [must be multiple of 8]
+static const int TPB = 512;  // threads per block [must be power of 2 and at least 128]
+#if defined(__AMDGCN_WAVEFRONT_SIZE) && (__AMDGCN_WAVEFRONT_SIZE == 64)
+#define WS 64
+#else
+#define WS 32
+#endif
+
+#include <cmath>
+#include <string>
+#include <cassert>
+#include <stdexcept>
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include "lc/sum_reduction.h"
+#include "lc/max_scan.h"
+#include "lc/prefix_sum.h"
+#include "lc/components/d_RRE_4.h"
+#include "lc/components/d_TCMS_8.h"
+#include "lc/components/d_RZE_1.h"
+#include "lc/lc.h"
+
+
+// copy (len) bytes from global memory (source) to shared memory (destination) using separate shared memory buffer (temp)
+// destination and temp must we word aligned, accesses up to CS + 3 bytes in temp
+static inline __device__ void g2s(void* const __restrict__ destination, const void* const __restrict__ source, const int len, void* const __restrict__ temp)
+{
+  const int tid = threadIdx.x;
+  const byte* const __restrict__ input = (byte*)source;
+  if (len < 128) {
+    byte* const __restrict__ output = (byte*)destination;
+    if (tid < len) output[tid] = input[tid];
+  } else {
+    const int nonaligned = (int)(size_t)input;
+    const int wordaligned = (nonaligned + 3) & ~3;
+    const int linealigned = (nonaligned + 127) & ~127;
+    const int bcnt = wordaligned - nonaligned;
+    const int wcnt = (linealigned - wordaligned) / 4;
+    int* const __restrict__ out_w = (int*)destination;
+    if (bcnt == 0) {
+      const int* const __restrict__ in_w = (int*)input;
+      byte* const __restrict__ out = (byte*)destination;
+      if (tid < wcnt) out_w[tid] = in_w[tid];
+      for (int i = tid + wcnt; i < len / 4; i += TPB) {
+        out_w[i] = in_w[i];
+      }
+      if (tid < (len & 3)) {
+        const int i = len - 1 - tid;
+        out[i] = input[i];
+      }
+    } else {
+      const int offs = 4 - bcnt;  //(4 - bcnt) & 3;
+      const int shift = offs * 8;
+      const int rlen = len - bcnt;
+      const int* const __restrict__ in_w = (int*)&input[bcnt];
+      byte* const __restrict__ buffer = (byte*)temp;
+      byte* const __restrict__ buf = (byte*)&buffer[offs];
+      int* __restrict__ buf_w = (int*)&buffer[4];  //(int*)&buffer[(bcnt + 3) & 4];
+      if (tid < bcnt) buf[tid] = input[tid];
+      if (tid < wcnt) buf_w[tid] = in_w[tid];
+      for (int i = tid + wcnt; i < rlen / 4; i += TPB) {
+        buf_w[i] = in_w[i];
+      }
+      if (tid < (rlen & 3)) {
+        const int i = len - 1 - tid;
+        buf[i] = input[i];
+      }
+      __syncthreads();
+      buf_w = (int*)buffer;
+      for (int i = tid; i < (len + 3) / 4; i += TPB) {
+        out_w[i] = __funnelshift_r(buf_w[i], buf_w[i + 1], shift);
+      }
+    }
+  }
+}
+
+
+static __device__ int g_chunk_counter;
+
+
+static __global__ void d_reset()
+{
+  g_chunk_counter = 0;
+}
+
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 800)
+static __global__ __launch_bounds__(TPB, 3)
+#else
+static __global__ __launch_bounds__(TPB, 2)
+#endif
+void d_decode_rtr(const byte* const __restrict__ input, byte* const __restrict__ output, int* const __restrict__ g_outsize)
+{
+  // allocate shared memory buffer
+  __shared__ long long chunk [3 * (CS / sizeof(long long))];
+  const int last = 3 * (CS / sizeof(long long)) - 2 - WS;
+
+  // input header
+  int* const head_in = (int*)input;
+  const int outsize = head_in[0];
+
+  // initialize
+  const int chunks = (outsize + CS - 1) / CS;  // round up
+  unsigned short* const size_in = (unsigned short*)&head_in[1];
+  byte* const data_in = (byte*)&size_in[chunks];
+
+  // loop over chunks
+  const int tid = threadIdx.x;
+  int prevChunkID = 0;
+  int prevOffset = 0;
+  do {
+    // assign work dynamically
+    if (tid == 0) chunk[last] = atomicAdd(&g_chunk_counter, 1);
+    __syncthreads();  // chunk[last] produced, chunk consumed
+
+    // terminate if done
+    const int chunkID = chunk[last];
+    const int base = chunkID * CS;
+    if (base >= outsize) break;
+
+    // compute sum of all prior csizes (start where left off in previous iteration)
+    int sum = 0;
+    for (int i = prevChunkID + tid; i < chunkID; i += TPB) {
+      sum += (int)size_in[i];
+    }
+    int csize = (int)size_in[chunkID];
+    const int offs = prevOffset + block_sum_reduction(sum, (int*)&chunk[last + 1]);
+    prevChunkID = chunkID;
+    prevOffset = offs;
+
+    // create the 3 shared memory buffers
+    byte* in = (byte*)&chunk[0 * (CS / sizeof(long long))];
+    byte* out = (byte*)&chunk[1 * (CS / sizeof(long long))];
+    byte* temp = (byte*)&chunk[2 * (CS / sizeof(long long))];
+
+    // load chunk
+    g2s(in, &data_in[offs], csize, out);
+    byte* tmp = in; in = out; out = tmp;
+    __syncthreads();  // chunk produced, chunk[last] consumed
+
+    // decode
+    const int osize = min(CS, outsize - base);
+    if (csize < osize) {
+      byte* tmp;
+     tmp = in; in = out; out = tmp;
+      d_iRZE_1(csize, in, out,temp);
+      __syncthreads();
+     tmp = in; in = out; out = tmp;
+      d_iTCMS_8(csize, in, out,temp);
+      __syncthreads();
+     tmp = in; in = out; out = tmp;
+      d_iRRE_4(csize, in, out,temp);
+      __syncthreads();
+     }
+
+    if (csize != osize) {printf("ERROR: csize %d doesn't match osize %d in chunk %d\n\n", csize, osize, chunkID); __trap();}
+    long long* const output_l = (long long*)&output[base];
+    long long* const out_l = (long long*)out;
+    for (int i = tid; i < osize / 8; i += TPB) {
+      output_l[i] = out_l[i];
+    }
+    const int extra = osize % 8;
+    if (tid < extra) output[base + osize - extra + tid] = out[osize - extra + tid];
+  } while (true);
+
+  if ((blockIdx.x == 0) && (tid == 0)) {
+    *g_outsize = outsize;
+  }
+}
+
+
+struct GPUTimer
+{
+  cudaEvent_t beg, end;
+  GPUTimer() {cudaEventCreate(&beg); cudaEventCreate(&end);}
+  ~GPUTimer() {cudaEventDestroy(beg); cudaEventDestroy(end);}
+  void start() {cudaEventRecord(beg, 0);}
+  double stop() {cudaEventRecord(end, 0); cudaEventSynchronize(end); float ms; cudaEventElapsedTime(&ms, beg, end); return ms;}
+};
+
+
+static void CheckCuda(const int line)
+{
+  cudaError_t e;
+  cudaDeviceSynchronize();
+  if (cudaSuccess != (e = cudaGetLastError())) {
+    fprintf(stderr, "CUDA error %d on line %d: %s\n\n", e, line, cudaGetErrorString(e));
+    throw std::runtime_error("LC error");
+  }
+}
+
+
+void RTR_DECOMPRESS(uint8_t* input, void** output, float* time)
+{
+  int pre_size;
+  cudaMemcpy(&pre_size, input, sizeof(int), cudaMemcpyDeviceToHost);
+
+  // get GPU info
+  cudaSetDevice(0);
+  cudaDeviceProp deviceProp;
+  cudaGetDeviceProperties(&deviceProp, 0);
+  if ((deviceProp.major == 9999) && (deviceProp.minor == 9999)) {fprintf(stderr, "ERROR: no CUDA capable device detected\n\n"); throw std::runtime_error("LC error");}
+  const int SMs = deviceProp.multiProcessorCount;
+  const int mTpSM = deviceProp.maxThreadsPerMultiProcessor;
+  const int blocks = SMs * (mTpSM / TPB);
+  CheckCuda(__LINE__);
+
+  // allocate GPU memory
+  byte* d_decoded;
+  cudaMalloc((void **)&d_decoded, pre_size);
+  int* d_decsize;
+  cudaMalloc((void **)&d_decsize, sizeof(int));
+  CheckCuda(__LINE__);
+
+  // warm up
+  byte* d_decoded_dummy;
+  cudaMalloc((void **)&d_decoded_dummy, pre_size);
+  int* d_decsize_dummy;
+  cudaMalloc((void **)&d_decsize_dummy, sizeof(int));
+  d_decode_rtr<<<blocks, TPB>>>(input, d_decoded_dummy, d_decsize_dummy);
+  cudaFree(d_decoded_dummy);
+  cudaFree(d_decsize_dummy);
+
+  // time GPU decoding
+  GPUTimer dtimer;
+  dtimer.start();
+  d_reset<<<1, 1>>>();
+  d_decode_rtr<<<blocks, TPB>>>(input, d_decoded, d_decsize);
+  *time = (float)dtimer.stop();
+  CheckCuda(__LINE__);
+  *output = d_decoded;
+}

--- a/src/lc/decomp-tcms.cu
+++ b/src/lc/decomp-tcms.cu
@@ -1,0 +1,275 @@
+/*
+This file is part of the LC framework for synthesizing high-speed parallel lossless and error-bounded lossy data compression and decompression algorithms for CPUs and GPUs.
+
+BSD 3-Clause License
+
+Copyright (c) 2021-2024, Noushin Azami, Alex Fallin, Brandon Burtchell, Andrew Rodriguez, Benila Jerald, Yiqian Liu, and Martin Burtscher
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+URL: The latest version of this code is available at https://github.com/burtscher/LC-framework.
+
+Sponsor: This code is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Research (ASCR), under contract DE-SC0022223.
+*/
+
+#ifndef NDEBUG
+#define NDEBUG
+#endif
+
+using byte = unsigned char;
+static const int CS = 1024 * 16;  // chunk size (in bytes) [must be multiple of 8]
+static const int TPB = 512;  // threads per block [must be power of 2 and at least 128]
+#if defined(__AMDGCN_WAVEFRONT_SIZE) && (__AMDGCN_WAVEFRONT_SIZE == 64)
+#define WS 64
+#else
+#define WS 32
+#endif
+
+#include <cmath>
+#include <string>
+#include <cassert>
+#include <stdexcept>
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include "lc/sum_reduction.h"
+#include "lc/max_scan.h"
+#include "lc/prefix_sum.h"
+#include "lc/components/d_TCMS_1.h"
+#include "lc/components/d_BIT_1.h"
+#include "lc/components/d_RRE_1.h"
+#include "lc/lc.h"
+
+
+// copy (len) bytes from global memory (source) to shared memory (destination) using separate shared memory buffer (temp)
+// destination and temp must we word aligned, accesses up to CS + 3 bytes in temp
+static inline __device__ void g2s(void* const __restrict__ destination, const void* const __restrict__ source, const int len, void* const __restrict__ temp)
+{
+  const int tid = threadIdx.x;
+  const byte* const __restrict__ input = (byte*)source;
+  if (len < 128) {
+    byte* const __restrict__ output = (byte*)destination;
+    if (tid < len) output[tid] = input[tid];
+  } else {
+    const int nonaligned = (int)(size_t)input;
+    const int wordaligned = (nonaligned + 3) & ~3;
+    const int linealigned = (nonaligned + 127) & ~127;
+    const int bcnt = wordaligned - nonaligned;
+    const int wcnt = (linealigned - wordaligned) / 4;
+    int* const __restrict__ out_w = (int*)destination;
+    if (bcnt == 0) {
+      const int* const __restrict__ in_w = (int*)input;
+      byte* const __restrict__ out = (byte*)destination;
+      if (tid < wcnt) out_w[tid] = in_w[tid];
+      for (int i = tid + wcnt; i < len / 4; i += TPB) {
+        out_w[i] = in_w[i];
+      }
+      if (tid < (len & 3)) {
+        const int i = len - 1 - tid;
+        out[i] = input[i];
+      }
+    } else {
+      const int offs = 4 - bcnt;  //(4 - bcnt) & 3;
+      const int shift = offs * 8;
+      const int rlen = len - bcnt;
+      const int* const __restrict__ in_w = (int*)&input[bcnt];
+      byte* const __restrict__ buffer = (byte*)temp;
+      byte* const __restrict__ buf = (byte*)&buffer[offs];
+      int* __restrict__ buf_w = (int*)&buffer[4];  //(int*)&buffer[(bcnt + 3) & 4];
+      if (tid < bcnt) buf[tid] = input[tid];
+      if (tid < wcnt) buf_w[tid] = in_w[tid];
+      for (int i = tid + wcnt; i < rlen / 4; i += TPB) {
+        buf_w[i] = in_w[i];
+      }
+      if (tid < (rlen & 3)) {
+        const int i = len - 1 - tid;
+        buf[i] = input[i];
+      }
+      __syncthreads();
+      buf_w = (int*)buffer;
+      for (int i = tid; i < (len + 3) / 4; i += TPB) {
+        out_w[i] = __funnelshift_r(buf_w[i], buf_w[i + 1], shift);
+      }
+    }
+  }
+}
+
+
+static __device__ int g_chunk_counter;
+
+
+static __global__ void d_reset()
+{
+  g_chunk_counter = 0;
+}
+
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 800)
+static __global__ __launch_bounds__(TPB, 3)
+#else
+static __global__ __launch_bounds__(TPB, 2)
+#endif
+void d_decode_tcms(const byte* const __restrict__ input, byte* const __restrict__ output, int* const __restrict__ g_outsize)
+{
+  // allocate shared memory buffer
+  __shared__ long long chunk [3 * (CS / sizeof(long long))];
+  const int last = 3 * (CS / sizeof(long long)) - 2 - WS;
+
+  // input header
+  int* const head_in = (int*)input;
+  const int outsize = head_in[0];
+
+  // initialize
+  const int chunks = (outsize + CS - 1) / CS;  // round up
+  unsigned short* const size_in = (unsigned short*)&head_in[1];
+  byte* const data_in = (byte*)&size_in[chunks];
+
+  // loop over chunks
+  const int tid = threadIdx.x;
+  int prevChunkID = 0;
+  int prevOffset = 0;
+  do {
+    // assign work dynamically
+    if (tid == 0) chunk[last] = atomicAdd(&g_chunk_counter, 1);
+    __syncthreads();  // chunk[last] produced, chunk consumed
+
+    // terminate if done
+    const int chunkID = chunk[last];
+    const int base = chunkID * CS;
+    if (base >= outsize) break;
+
+    // compute sum of all prior csizes (start where left off in previous iteration)
+    int sum = 0;
+    for (int i = prevChunkID + tid; i < chunkID; i += TPB) {
+      sum += (int)size_in[i];
+    }
+    int csize = (int)size_in[chunkID];
+    const int offs = prevOffset + block_sum_reduction(sum, (int*)&chunk[last + 1]);
+    prevChunkID = chunkID;
+    prevOffset = offs;
+
+    // create the 3 shared memory buffers
+    byte* in = (byte*)&chunk[0 * (CS / sizeof(long long))];
+    byte* out = (byte*)&chunk[1 * (CS / sizeof(long long))];
+    byte* temp = (byte*)&chunk[2 * (CS / sizeof(long long))];
+
+    // load chunk
+    g2s(in, &data_in[offs], csize, out);
+    byte* tmp = in; in = out; out = tmp;
+    __syncthreads();  // chunk produced, chunk[last] consumed
+
+    // decode
+    const int osize = min(CS, outsize - base);
+    if (csize < osize) {
+      byte* tmp;
+     tmp = in; in = out; out = tmp;
+      d_iRRE_1(csize, in, out,temp);
+      __syncthreads();
+     tmp = in; in = out; out = tmp;
+      d_iBIT_1(csize, in, out,temp);
+      __syncthreads();
+     tmp = in; in = out; out = tmp;
+      d_iTCMS_1(csize, in, out,temp);
+      __syncthreads();
+     }
+
+    if (csize != osize) {printf("ERROR: csize %d doesn't match osize %d in chunk %d\n\n", csize, osize, chunkID); __trap();}
+    long long* const output_l = (long long*)&output[base];
+    long long* const out_l = (long long*)out;
+    for (int i = tid; i < osize / 8; i += TPB) {
+      output_l[i] = out_l[i];
+    }
+    const int extra = osize % 8;
+    if (tid < extra) output[base + osize - extra + tid] = out[osize - extra + tid];
+  } while (true);
+
+  if ((blockIdx.x == 0) && (tid == 0)) {
+    *g_outsize = outsize;
+  }
+}
+
+
+struct GPUTimer
+{
+  cudaEvent_t beg, end;
+  GPUTimer() {cudaEventCreate(&beg); cudaEventCreate(&end);}
+  ~GPUTimer() {cudaEventDestroy(beg); cudaEventDestroy(end);}
+  void start() {cudaEventRecord(beg, 0);}
+  double stop() {cudaEventRecord(end, 0); cudaEventSynchronize(end); float ms; cudaEventElapsedTime(&ms, beg, end); return ms;}
+};
+
+
+static void CheckCuda(const int line)
+{
+  cudaError_t e;
+  cudaDeviceSynchronize();
+  if (cudaSuccess != (e = cudaGetLastError())) {
+    fprintf(stderr, "CUDA error %d on line %d: %s\n\n", e, line, cudaGetErrorString(e));
+    throw std::runtime_error("LC error");
+  }
+}
+
+
+void TCMS_DECOMPRESS(uint8_t* input, void** output, float* time)
+{ 
+  int pre_size;
+  cudaMemcpy(&pre_size, input, sizeof(int), cudaMemcpyDeviceToHost);
+  
+  // get GPU info
+  cudaSetDevice(0);
+  cudaDeviceProp deviceProp;
+  cudaGetDeviceProperties(&deviceProp, 0);
+  if ((deviceProp.major == 9999) && (deviceProp.minor == 9999)) {fprintf(stderr, "ERROR: no CUDA capable device detected\n\n"); throw std::runtime_error("LC error");}
+  const int SMs = deviceProp.multiProcessorCount;
+  const int mTpSM = deviceProp.maxThreadsPerMultiProcessor;
+  const int blocks = SMs * (mTpSM / TPB);
+  CheckCuda(__LINE__);
+
+  // allocate GPU memory
+  byte* d_decoded;
+  cudaMalloc((void **)&d_decoded, pre_size);
+  int* d_decsize;
+  cudaMalloc((void **)&d_decsize, sizeof(int));
+  CheckCuda(__LINE__);
+
+  // warm up
+  byte* d_decoded_dummy;
+  cudaMalloc((void **)&d_decoded_dummy, pre_size);
+  int* d_decsize_dummy;
+  cudaMalloc((void **)&d_decsize_dummy, sizeof(int));
+  d_decode_tcms<<<blocks, TPB>>>(input, d_decoded_dummy, d_decsize_dummy);
+  cudaFree(d_decoded_dummy);
+  cudaFree(d_decsize_dummy);
+
+  // time GPU decoding
+  GPUTimer dtimer;
+  dtimer.start();
+  d_reset<<<1, 1>>>();
+  d_decode_tcms<<<blocks, TPB>>>(input, d_decoded, d_decsize);
+  *time = (float)dtimer.stop();
+  CheckCuda(__LINE__);
+  *output = d_decoded;
+}

--- a/src/pipeline/testframe.cc
+++ b/src/pipeline/testframe.cc
@@ -36,8 +36,8 @@ TESTFRAME::full_decompress(
 
   cor->decompress_scatter(header, in, d_space, stream);
   cor->decompress_decode(header, in, stream);
-  cor->decompress_predict(header, in, nullptr, d_xdata, stream);
-  cor->decompress_collect_kerneltime();
+  // cor->decompress_predict(header, in, nullptr, d_xdata, d_xdata, stream);
+  cor->decompress_collect_kerneltime(header);
 }
 
 TESTFRAME::pred_comp_decomp(
@@ -57,7 +57,7 @@ TESTFRAME::pred_comp_decomp(
   header->x = ctx->x, header->y = ctx->y, header->z = ctx->z;
   header->eb = ctx->eb, header->radius = ctx->radius;
 
-  cor->decompress_predict(header, nullptr, d_anchor, d_xdata, stream);
+  // cor->decompress_predict(header, nullptr, d_anchor, d_xdata, stream);
 }
 
 TESTFRAME::pred_hist_comp(
@@ -82,10 +82,10 @@ TESTFRAME::pred_hist_comp(
   auto ht_cpu = new pszmem_cxx<u4>(booklen, 1, 1, "ht_cpu");
   ht_cpu->control({MallocHost});
 
-  psz::histsp<PROPER_GPU_BACKEND, u4>(
-      ectrl_gpu, len, ht_gpu->dptr(), booklen, &time_hist, stream);
-  psz::histsp<SEQ, u4>(
-      ectrl_cpu, len, ht_cpu->hptr(), booklen, &time_hist, stream);
+  // psz::histsp<PROPER_GPU_BACKEND, u4>(
+  //     ectrl_gpu, len, ht_gpu->dptr(), booklen, &time_hist, stream);
+  // psz::histsp<SEQ, u4>(
+  //     ectrl_cpu, len, ht_cpu->hptr(), booklen, &time_hist, stream);
 
   ht_gpu->control({D2H});
   auto eq = std::equal(ht_gpu->hbegin(), ht_gpu->hend(), ht_cpu->hbegin());


### PR DESCRIPTION
1. CESM -s cr, -a 2 will set use_md[1]-[6] to false to test cuszi_24
2. Fix all compile warnings.
![image](https://github.com/user-attachments/assets/aa845866-1706-4fec-8d00-b871a7a42fbb)
