### PR TITLE
remove arch_sm

### DIFF
--- a/cmake/cusz.cmake
+++ b/cmake/cusz.cmake
@@ -134,8 +134,6 @@ target_compile_options(lc
   PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:
       -O3
-      -arch=sm_89
-      -arch=sm_80
       -fmad=false>
     $<$<COMPILE_LANGUAGE:CXX>:
       -O3


### PR DESCRIPTION
Suggested by Jinwen

Remove -arch_sm in cmake/cusz.cmake to avoid warning.